### PR TITLE
HOTFIX: attempt to get syntax highlighting in remote readthedocs build working again

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,6 +73,9 @@ myst_enable_extensions = [
     "html_admonition",
 ]
 
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = "sphinx"
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 


### PR DESCRIPTION
Syntax highlighting in just the ipynb files stopped working, and just in the remote readthedocs build. Unclear why this happened.