### PR TITLE
Fix docs syntax highlighting issue? Temporary fix by disallowing ipython 8.7.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -73,9 +73,6 @@ myst_enable_extensions = [
     "html_admonition",
 ]
 
-# The name of the Pygments (syntax highlighting) style to use.
-pygments_style = "sphinx"
-
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 arviz>=0.14.0
 graphviz
-ipython
+ipython!=8.7.0
 matplotlib>=3.5.3
 numpy
 pandas


### PR DESCRIPTION
Addresses #103. Let's see if it works!