### PR TITLE
fix optional type hints

### DIFF
--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -11,11 +11,14 @@ def plot_xY(
     x: Union[pd.DatetimeIndex, np.array],
     Y: xr.DataArray,
     ax: plt.Axes,
-    plot_hdi_kwargs: Optional[Dict[str, Any]] = {},
-    hdi_prob: Optional[float] = 0.94,
-    include_label: Optional[bool] = True,
+    plot_hdi_kwargs: Optional[Dict[str, Any]] = None,
+    hdi_prob: float = 0.94,
+    include_label: bool = True,
 ) -> None:
     """Utility function to plot HDI intervals."""
+
+    if plot_hdi_kwargs is None:
+        plot_hdi_kwargs = {}
 
     az.plot_hdi(
         x,


### PR DESCRIPTION
hey! this PR just correct some type hints: From the [documentation](https://mypy.readthedocs.io/en/stable/kinds_of_types.html#optional-types-and-the-none-type):

> You can use the [Optional](https://docs.python.org/3/library/typing.html#typing.Optional) type modifier to define a type variant that allows None, such as Optional[int] (Optional[X] is the preferred shorthand for Union[X, None])

This means that a parameter with a default value is not an `Optional` type. We will capture these type of errors once we set up `mypy`. 
In addition, we should not use mutable structures as defaults. It is better to set `None` as default, see https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/