### PR TITLE
remove `treated` and `untreated` kwargs for DifferenceInDifferences

### DIFF
--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -14,8 +14,6 @@ def test_did():
         formula="y ~ 1 + group*post_treatment",
         time_variable_name="t",
         group_variable_name="group",
-        treated=1,
-        untreated=0,
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
     assert isinstance(df, pd.DataFrame)
@@ -59,8 +57,6 @@ def test_did_banks_simple():
         formula="bib ~ 1 + district * post_treatment",
         time_variable_name="year",
         group_variable_name="district",
-        treated=1,
-        untreated=0,
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
     assert isinstance(df, pd.DataFrame)
@@ -100,8 +96,6 @@ def test_did_banks_multi():
         formula="bib ~ 1 + year + district + post_treatment + district:post_treatment",
         time_variable_name="year",
         group_variable_name="district",
-        treated=1,
-        untreated=0,
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
     assert isinstance(df, pd.DataFrame)

--- a/docs/notebooks/did_pymc.ipynb
+++ b/docs/notebooks/did_pymc.ipynb
@@ -239,8 +239,6 @@
     "    formula=\"y ~ 1 + group*post_treatment\",\n",
     "    time_variable_name=\"t\",\n",
     "    group_variable_name=\"group\",\n",
-    "    treated=1,\n",
-    "    untreated=0,\n",
     "    model=cp.pymc_models.LinearRegression(sample_kwargs={\"random_seed\": seed}),\n",
     ")"
    ]

--- a/docs/notebooks/did_pymc_banks.ipynb
+++ b/docs/notebooks/did_pymc_banks.ipynb
@@ -482,8 +482,6 @@
     "    formula=\"bib ~ 1 + district * post_treatment\",\n",
     "    time_variable_name=\"year\",\n",
     "    group_variable_name=\"district\",\n",
-    "    treated=1,\n",
-    "    untreated=0,\n",
     "    model=cp.pymc_models.LinearRegression(\n",
     "        sample_kwargs={\"target_accept\": 0.95, \"random_seed\": seed}\n",
     "    ),\n",
@@ -647,8 +645,6 @@
     "    formula=\"bib ~ 1 + year + district + post_treatment + district:post_treatment\",\n",
     "    time_variable_name=\"year\",\n",
     "    group_variable_name=\"district\",\n",
-    "    treated=1,\n",
-    "    untreated=0,\n",
     "    model=cp.pymc_models.LinearRegression(sample_kwargs={\"random_seed\": seed}),\n",
     ")"
    ]


### PR DESCRIPTION
The group variable is dummy coded as 0/1, rather than categorical, so we don't need to have these kwargs any more.

Closes #150 