### PR TITLE
Fix rtd builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -26,7 +26,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   - requirements: requirements.txt
-   - requirements: requirements-docs.txt
    - method: pip
      path: .
+     extra_requirements:
+       - docs


### PR DESCRIPTION
I noticed docs weren't being build from main. This updates the readthedocs config so it takes into account pyproject and extra pip installs with `[]` are used now instead of requirements files. closes #158 