### PR TITLE
Only run CI on pushes or PRs to the main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: ci
 
-on: [push]
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
 
 jobs:
   lint:


### PR DESCRIPTION
This PR makes CI run only on pushes or PRs that target the main branch.

The original behavior was to run the CI action upon the `push` event in any branch. When attempting a PR from a fork, that means that the CI actions would be run on the fork repo instead of the upstream repo. As a consequence, PRs from forks wouldn't show any CI action workflows, and would seem clean and ready for merging (e.g. #167 that has its action workflow [here](https://github.com/lucianopaz/CausalPy/actions/runs/4182434551))