### PR TITLE
Fix lint CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run lint
-        run: |
-          make init
-          make check_lint
+        uses: pre-commit/action@v3.0.0
 
   test:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
           - id: check-yaml
           - id: check-added-large-files
     - repo: https://github.com/pycqa/isort
-      rev: 5.11.4
+      rev: 5.12.0
       hooks:
           - id: isort
             args: [--profile, black]


### PR DESCRIPTION
#166 and #163 ran into lint failures. I think that this was caused by using `make init` and `make lint`, which have unpinned versions of lint scripts. One way to avoid this and to have an encapsulated CI step is to rely on `pre-commit` itself to run the lint step.