### PR TITLE
add pydata global 2022 video to README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ result.summary()
 
 Plans for the repository can be seen in the [Issues](https://github.com/pymc-labs/CausalPy/issues).
 
+## Videos
+Click on the thumbnail below to watch a video about CausalPy on YouTube.
+[![Youtube video thumbnail image](https://img.youtube.com/vi/gV6wzTk3o1U/maxresdefault.jpg)](https://www.youtube.com/watch?v=gV6wzTk3o1U)
+
 ## Overview of package capabilities
 
 ### Synthetic control

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,6 +54,14 @@ Quickstart
    # Get a results summary
    result.summary()
 
+
+Videos
+------
+
+.. raw:: html
+
+   <iframe width="700" height="394" src="https://www.youtube.com/embed/gV6wzTk3o1U" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+
 Features
 --------
 


### PR DESCRIPTION
Adds PyData Global 2022 talk on CausalPy to the docs + README.
Closes #75.