### PR TITLE
version bump to #0.0.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ packages = ['causalpy', 'causalpy.data']
 
 [project]
 name = "CausalPy"
-version = "0.0.10"
+version = "0.0.11"
 description = "Causal inference for quasi-experiments in Python"
 readme = "README.md"
 license = {file = "LICENSE"}


### PR DESCRIPTION
There was a mistake in the previous version bump today for 0.0.10. The tag did not match up with what was in `pyproject.toml`. So hopefully this fixes things.