### PR TITLE
Enable bibtex references in the documentation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     - repo: https://github.com/econchick/interrogate
       rev: 1.5.0
       hooks:
-          - id: interrogate
-            # needed to make excludes in pyproject.toml work
-            # see here https://github.com/econchick/interrogate/issues/60#issuecomment-735436566
-            pass_filenames: false
+        - id: interrogate
+          # needed to make excludes in pyproject.toml work
+          # see here https://github.com/econchick/interrogate/issues/60#issuecomment-735436566
+          pass_filenames: false

--- a/docs/source/_static/interrogate_badge.svg
+++ b/docs/source/_static/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 53.0%</title>
+    <title>interrogate: 51.6%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">53.0%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">53.0%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">51.6%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">51.6%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,30 +46,35 @@ release = __version__
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
 extensions = [
-    "myst_parser",
-    "nbsphinx",
+    "myst_nb",
+    "sphinxcontrib.bibtex",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx_autodoc_typehints",
 ]
 
-source_suffix = [".rst", ".md"]
+nb_execution_mode = "off"
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".ipynb": "myst-nb",
+    ".myst": "myst-nb",
+}
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 master_doc = "index"
+
+# bibtex config
+bibtex_bibfiles = ["references.bib"]
+bibtex_default_style = "unsrt"
+bibtex_reference_style = "author_year"
 
 # -- intersphinx config -------------------------------------------------------
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pymc": ("https://www.pymc.io/projects/docs/en/stable/", None),
 }
-
-# -- nbsphinx config ----------------------------------------------------------
-# Opt out of executing the notebooks remotely. This will save time in the remote build
-# process on readthedocs. The notebooks in /docs/notebooks will be parsed/converted,
-# but not re-executed.
-nbsphinx_execute = "never"
 
 # MyST options for working with markdown files.
 # Info about extensions here https://myst-parser.readthedocs.io/en/latest/syntax/optional.html?highlight=math#admonition-directives # noqa: E501

--- a/docs/source/glossary.md
+++ b/docs/source/glossary.md
@@ -1,10 +1,8 @@
 # Glossary
 
-<div class="admonition note" name="html-admonition">
-<p class="title">Note:</p>
-Some of the definitions have been copied from (or inspired by) various resources, including Reichardt (2019).
-</div>
-
+:::{note}
+Some of the definitions have been copied from (or inspired by) various resources, including {cite:t}`reichardt2019quasi`.
+:::
 
 **ANCOVA:** Analysis of covariance is a simple linear model, typically with one continuous predictor (the covariate) and a catgeorical variable (which may correspond to treatment or control group). In the context of this package, ANCOVA could be useful in pre-post treatment designs, either with or without random assignment. This is similar to the approach of difference in differences, but only applicable with a single pre and post treatment measure.
 
@@ -63,4 +61,6 @@ Data from pretest-posttest NEGD could be analysed using change score analysis or
 **Treatment effect:** The difference in outcomes between what happened after a treatment is implemented and what would have happened (see Counterfactual) if the treatment had not been implemented, assuming everything else had been the same.
 
 ## References
-* Reichardt, C. S. (2019). Quasi-experimentation: A guide to design and analysis. Guilford Publications.
+:::{bibliography}
+:filter: docname in docnames
+:::

--- a/docs/source/notebooks/ancova_pymc.ipynb
+++ b/docs/source/notebooks/ancova_pymc.ipynb
@@ -7,13 +7,9 @@
    "source": [
     "# ANCOVA for pre/post treatment nonequivalent group designs\n",
     "\n",
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
-    "\n",
+    ":::{note}\n",
     "This is a preliminary example based on synthetic data. It will hopefully soon be updated with data from a real study.\n",
-    "\n",
-    "</div>\n",
+    ":::\n",
     "\n",
     "In cases where there is just one pre and one post treatment measurement, it we can analyse data from NEGD experiments using an ANCOVA type approach. The basic model is:\n",
     "\n",
@@ -56,6 +52,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -219,13 +216,9 @@
    "source": [
     "## Run the analysis\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/did_pymc.ipynb
+++ b/docs/source/notebooks/did_pymc.ipynb
@@ -7,13 +7,9 @@
    "source": [
     "# Difference in Differences with `pymc` models\n",
     "\n",
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
-    "\n",
+    ":::{note}\n",
     "This example is in-progress! Further elaboration and explanation will follow soon.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {
@@ -40,6 +36,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/notebooks/did_pymc.ipynb
+++ b/docs/source/notebooks/did_pymc.ipynb
@@ -147,13 +147,9 @@
    "source": [
     "## Run the analysis\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/did_pymc_banks.ipynb
+++ b/docs/source/notebooks/did_pymc_banks.ipynb
@@ -7,13 +7,9 @@
    "source": [
     "# Banking dataset with a `pymc` model\n",
     "\n",
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
-    "\n",
+    ":::{note}\n",
     "This example is in-progress! Further elaboration and explanation will follow soon.\n",
-    "\n",
-    "</div>\n",
+    ":::\n",
     "\n",
     "This notebook analyses historic data on banking closures from [Richardson & Troost (2009)](http://masteringmetrics.com/wp-content/uploads/2015/02/Richardson_Troost_2009_JPE.pdf) and used as a case study for a difference in differences analysis in the [Mastering Metrics](http://www.masteringmetrics.com) book. Here, we replicate this analysis, but using Bayesian inference."
    ]
@@ -395,13 +391,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/did_pymc_banks.ipynb
+++ b/docs/source/notebooks/did_pymc_banks.ipynb
@@ -11,7 +11,7 @@
     "This example is in-progress! Further elaboration and explanation will follow soon.\n",
     ":::\n",
     "\n",
-    "This notebook analyses historic data on banking closures from [Richardson & Troost (2009)](http://masteringmetrics.com/wp-content/uploads/2015/02/Richardson_Troost_2009_JPE.pdf) and used as a case study for a difference in differences analysis in the [Mastering Metrics](http://www.masteringmetrics.com) book. Here, we replicate this analysis, but using Bayesian inference."
+    "This notebook analyses historic data on banking closures from {cite:t}`richardson2009monetary` and used as a case study for a difference in differences analysis in the excellent book [Mastering Metrics](http://www.masteringmetrics.com) {cite:p}`angrist2014mastering`. Here, we replicate this analysis, but using Bayesian inference."
    ]
   },
   {
@@ -45,7 +45,7 @@
    "source": [
     "## Load data\n",
     "\n",
-    "The raw dataset has a `date` columns which is just some uninterpretable number. All we need for our analysis is the `year` column. We also have columns `bib6`, `bio6`, `bib8`, `bio8`. We know that the `6` and `8` represent the 6th and 8th Federal Reserve districts, respectively. I assume `bib` means \"banks in business\", so I'll discard the `bib*` columns. The data is at daily resolution, but we will convert this to yearly resolution. And from what I can tell from Figure 5.2 of the [Mastering Metrics](http://www.masteringmetrics.com) book, they seem to present the _median_ number of banks open per year. Let's load the data up and do those steps."
+    "The raw dataset has a `date` columns which is just some uninterpretable number. All we need for our analysis is the `year` column. We also have columns `bib6`, `bio6`, `bib8`, `bio8`. We know that the `6` and `8` represent the 6th and 8th Federal Reserve districts, respectively. I assume `bib` means \"banks in business\", so I'll discard the `bib*` columns. The data is at daily resolution, but we will convert this to yearly resolution. And from what I can tell from Figure 5.2 of the {cite:t}`angrist2014mastering`, they seem to present the _median_ number of banks open per year. Let's load the data up and do those steps."
    ]
   },
   {
@@ -166,7 +166,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's visualise what we have. This matches up exactly with Figure 5.2 of the [Mastering Metrics](http://www.masteringmetrics.com) book."
+    "Let's visualise what we have. This matches up exactly with Figure 5.2 of the {cite:t}`angrist2014mastering`."
    ]
   },
   {
@@ -628,11 +628,15 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## References\n",
+    ":::{bibliography}\n",
+    ":filter: docname in docnames\n",
+    ":::"
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/notebooks/geolift1.ipynb
+++ b/docs/source/notebooks/geolift1.ipynb
@@ -268,13 +268,9 @@
     "\n",
     "We can use `CausalPy`'s API to run this procedure, but using Bayesian inference methods as follows:\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/its_covid.ipynb
+++ b/docs/source/notebooks/its_covid.ipynb
@@ -181,13 +181,9 @@
     "\n",
     "In this example we are going to standardize the data. So we have to be careful in how we interpret the inferred regression coefficients, and the posterior predictions will be in this standardized space.\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/its_pymc.ipynb
+++ b/docs/source/notebooks/its_pymc.ipynb
@@ -308,13 +308,9 @@
    "source": [
     "As well as the model coefficients, we might be interested in the avarage causal impact and average cumulative causal impact.\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note\n",
-    "\n",
+    ":::{note}\n",
     "Better output for the summary statistics are in progress!\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {
@@ -401,13 +397,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
-    "\n",
+    ":::{warning}\n",
     "Care must be taken with the mean impact statistic. It only makes sense to use this statistic if it looks like the intervention had a lasting (and roughly constant) effect on the outcome variable. If the effect is transient, then clearly there will be a lot of post-intervention period where the impact of the intervention has 'worn off'. If so, then it will be hard to interpret the mean impacts real meaning.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/its_pymc.ipynb
+++ b/docs/source/notebooks/its_pymc.ipynb
@@ -162,13 +162,9 @@
    "source": [
     "Run the analysis\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/rd_pymc.ipynb
+++ b/docs/source/notebooks/rd_pymc.ipynb
@@ -1,6 +1,7 @@
 {
     "cells": [
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -42,13 +43,9 @@
             "cell_type": "markdown",
             "metadata": {},
             "source": [
-                "<div class=\"alert alert-info\">\n",
-                "\n",
-                "Note:\n",
-                "\n",
+                ":::{note}\n",
                 "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-                "\n",
-                "</div>"
+                ":::"
             ]
         },
         {

--- a/docs/source/notebooks/rd_pymc_drinking.ipynb
+++ b/docs/source/notebooks/rd_pymc_drinking.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# Drinking age - Bayesian analysis\n",
     "\n",
-    "This example uses the regression discontinuity design to make claims about the causal effects of the minimum legal drinking age (21 in the USA) upon all cause mortality rates. The dataset is from a study by [Carpenter & Dobkin, (2009)](https://www.aeaweb.org/articles?id=10.1257/app.1.1.164)."
+    "This example uses the regression discontinuity design to make claims about the causal effects of the minimum legal drinking age (21 in the USA) upon all cause mortality rates. The dataset is from a study by {cite:t}`carpenter2009effect`."
    ]
   },
   {
@@ -563,11 +563,15 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## References\n",
+    ":::{bibliography}\n",
+    ":filter: docname in docnames\n",
+    ":::"
+   ]
   }
  ],
  "metadata": {

--- a/docs/source/notebooks/rd_pymc_drinking.ipynb
+++ b/docs/source/notebooks/rd_pymc_drinking.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -28,6 +29,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -48,6 +50,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -79,13 +82,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {
@@ -193,6 +192,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -228,6 +228,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -264,6 +265,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -273,6 +275,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -382,6 +385,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -409,6 +413,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -416,6 +421,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/notebooks/rd_skl_drinking.ipynb
+++ b/docs/source/notebooks/rd_skl_drinking.ipynb
@@ -1,14 +1,13 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Drinking age with a scikit-learn model\n",
     "\n",
-    "Run the 'drinking example' from the RDD chapter of [Causal Inference for the Brave and True](https://matheusfacure.github.io/python-causality-handbook/16-Regression-Discontinuity-Design.html).\n",
-    "\n",
-    "Use sci-kit learn models"
+    "This example uses the regression discontinuity design to make claims about the causal effects of the minimum legal drinking age (21 in the USA) upon all cause mortality rates. The dataset is from a study by {cite:t}`carpenter2009effect`."
    ]
   },
   {
@@ -52,6 +51,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -103,6 +103,17 @@
    ],
    "source": [
     "result.summary()"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## References\n",
+    ":::{bibliography}\n",
+    ":filter: docname in docnames\n",
+    ":::"
    ]
   }
  ],

--- a/docs/source/notebooks/sc_pymc.ipynb
+++ b/docs/source/notebooks/sc_pymc.ipynb
@@ -284,13 +284,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
+    ":::{Warning}\n",
     "\n",
     "Care must be taken with the mean impact statistic. It only makes sense to use this statistic if it looks like the intervention had a lasting (and roughly constant) effect on the outcome variable. If the effect is transient, then clearly there will be a lot of post-intervention period where the impact of the intervention has 'worn off'. If so, then it will be hard to interpret the mean impacts real meaning.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {

--- a/docs/source/notebooks/sc_pymc.ipynb
+++ b/docs/source/notebooks/sc_pymc.ipynb
@@ -1,6 +1,7 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -31,6 +32,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -54,13 +56,9 @@
    "source": [
     "## Run the analysis\n",
     "\n",
-    "<div class=\"alert alert-info\">\n",
-    "\n",
-    "Note:\n",
-    "\n",
+    ":::{note}\n",
     "The `random_seed` keyword argument for the PyMC sampler is not neccessary. We use it here so that the results are reproducible.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {
@@ -195,6 +193,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -281,6 +280,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -294,6 +294,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/notebooks/sc_pymc_brexit.ipynb
+++ b/docs/source/notebooks/sc_pymc_brexit.ipynb
@@ -1,27 +1,25 @@
 {
  "cells": [
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# The effects of Brexit\n",
     "\n",
-    "The aim of this notebook is to estimate the causal impact of Brexit upon the UK's GDP. This will be done using the synthetic control approch. As such, it is similar to the policy brief [\"What can we know about the cost of Brexit so far?\"](https://www.cer.eu/publications/archive/policy-brief/2022/cost-brexit-so-far) by John Springford from the Center for European Reform. That approach did not use Bayesian estimation methods however.\n",
+    "The aim of this notebook is to estimate the causal impact of Brexit upon the UK's GDP. This will be done using the synthetic control approch. As such, it is similar to the policy brief \"What can we know about the cost of Brexit so far?\" {cite:p}`brexit2022policybrief` from the Center for European Reform. That approach did not use Bayesian estimation methods however.\n",
     "\n",
     "I did not use the GDP data from the above report however as it had been scaled in some way that was hard for me to understand how it related to the absolute GDP figures. Instead, GDP data was obtained courtesy of Prof. Dooruj Rambaccussing. Raw data is in units of billions of USD."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<div class=\"alert alert-warning\">\n",
-    "\n",
-    "Warning\n",
-    "\n",
+    ":::{warning}\n",
     "This is an experimental and in-progress notebook! While the results are reasonable, there is still come perfecting to be done on the inference side of things. There are high correlations between countries, and the prior for the Dirichlet distribution for country weightings could do with some attention. That said, the results here represent a 'reasonable' first approach at this dataset.\n",
-    "\n",
-    "</div>"
+    ":::"
    ]
   },
   {
@@ -53,6 +51,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -93,6 +92,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -181,6 +181,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -315,6 +316,7 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -709,10 +711,20 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "attachments": {},
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
+   "source": [
+    "## References\n",
+    ":::{bibliography}\n",
+    ":filter: docname in docnames\n",
+    ":::"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
    "source": []
   }
  ],
@@ -732,7 +744,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.11.4"
   },
   "orig_nbformat": 4,
   "vscode": {

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -1,0 +1,13 @@
+@online{brexit2022policybrief,
+year={2022},
+title={What can we know about the cost of Brexit so far?},
+url={https://www.cer.eu/publications/archive/policy-brief/2022/cost-brexit-so-far},
+author={Springford, John}
+}
+
+@book{reichardt2019quasi,
+  title={Quasi-experimentation: A guide to design and analysis},
+  author={Reichardt, Charles S},
+  year={2019},
+  publisher={Guilford Publications}
+}

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -11,3 +11,32 @@ author={Springford, John}
   year={2019},
   publisher={Guilford Publications}
 }
+
+@article{richardson2009monetary,
+  title={Monetary intervention mitigated banking panics during the great depression: quasi-experimental evidence from a federal reserve district border, 1929--1933},
+  author={Richardson, Gary and Troost, William},
+  journal={Journal of Political Economy},
+  volume={117},
+  number={6},
+  pages={1031--1073},
+  year={2009},
+  publisher={The University of Chicago Press}
+}
+
+@book{angrist2014mastering,
+  title={Mastering 'Metrics: The path from cause to effect},
+  author={Angrist, Joshua D and Pischke, J{\"o}rn-Steffen},
+  year={2014},
+  publisher={Princeton University Press}
+}
+
+@article{carpenter2009effect,
+  title={The effect of alcohol consumption on mortality: regression discontinuity evidence from the minimum drinking age},
+  author={Carpenter, Christopher and Dobkin, Carlos},
+  journal={American Economic Journal: Applied Economics},
+  volume={1},
+  number={1},
+  pages={164--182},
+  year={2009},
+  publisher={American Economic Association}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,8 +56,7 @@ dev = [
     ]
 docs = ["ipykernel",
     "linkify-it-py",
-    "myst_parser",
-    "nbsphinx",
+    "myst-nb",
     "pathlib",
     "sphinx",
     "sphinx-autodoc-typehints",
@@ -65,6 +64,7 @@ docs = ["ipykernel",
     "sphinx-design",
     "sphinx-rtd-theme",
     "statsmodels",
+    "sphinxcontrib-bibtex",
     ]
 lint = ["black",
     "flake8",


### PR DESCRIPTION
* This PR enables you to use bibtex references in the documentation.
* Extension changes: This is done through `sphinxcontrib.bibtex`, but we also now use `myst_nb` (see https://myst-nb.readthedocs.io/en/latest/index.html) and no explicitly use `nbsphinx` or `myst_parser`. 
* That change to use `myst_nb` also allowed us to use simpler admonitions, so this was changed in all the relevant example notebooks.
* Default behaviour is to collect all references (site wide) into a single reference section. But because the site is / will be heavy with example notebooks then it makes sense to keep references at the end of each notebook. This is the same style as the `pymc-examples` repo.
* This will close #214.