### PR TITLE
Add an `epsilon` parameter to `RegressionDiscontinuity` classes

### DIFF
--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 import arviz as az
 import matplotlib.pyplot as plt
@@ -565,7 +565,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold: float,
         model=None,
         running_variable_name: str = "x",
-        epsilon: float = 0.001,
+        epsilon: Optional[float] = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Union
 
 import arviz as az
 import matplotlib.pyplot as plt
@@ -565,7 +565,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold: float,
         model=None,
         running_variable_name: str = "x",
-        epsilon: Optional[float] = 0.001,
+        epsilon: float | None = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -565,7 +565,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold: float,
         model=None,
         running_variable_name: str = "x",
-        epsilon: float | None = 0.001,
+        epsilon: float = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -543,18 +543,19 @@ class RegressionDiscontinuity(ExperimentalDesign):
     """
     A class to analyse regression discontinuity experiments.
 
-    :param data: A pandas dataframe
-    :param formula: A statistical model formula
-    :param treatment_threshold: A scalar threshold value at which the treatment
-                                is applied
-    :param model: A PyMC model
-    :param running_variable_name: The name of the predictor variable that the treatment
-                                  threshold is based upon
-
-    .. note::
-
-        There is no pre/post intervention data distinction for the regression
-        discontinuity design, we fit all the data available.
+    :param data:
+        A pandas dataframe
+    :param formula:
+        A statistical model formula
+    :param treatment_threshold:
+        A scalar threshold value at which the treatment is applied
+    :param model:
+        A PyMC model
+    :param running_variable_name:
+        The name of the predictor variable that the treatment threshold is based upon
+    :param epsilon:
+        A small scalar value which determines how far above and below the treatment
+        threshold to evaluate the causal impact.
     """
 
     def __init__(
@@ -564,6 +565,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold: float,
         model=None,
         running_variable_name: str = "x",
+        epsilon: float = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)
@@ -572,6 +574,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.treatment_threshold = treatment_threshold
+        self.epsilon = epsilon
         self._input_validation()
 
         y, X = dmatrices(formula, self.data)
@@ -609,7 +612,10 @@ class RegressionDiscontinuity(ExperimentalDesign):
         self.x_discon = pd.DataFrame(
             {
                 self.running_variable_name: np.array(
-                    [self.treatment_threshold - 0.001, self.treatment_threshold + 0.001]
+                    [
+                        self.treatment_threshold - self.epsilon,
+                        self.treatment_threshold + self.epsilon,
+                    ]
                 ),
                 "treated": np.array([0, 1]),
             }

--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -372,7 +370,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold,
         model=None,
         running_variable_name="x",
-        epsilon: Optional[float] = 0.001,
+        epsilon: float | None = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -370,7 +372,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold,
         model=None,
         running_variable_name="x",
-        epsilon: float = 0.001,
+        epsilon: Optional[float] = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -370,7 +370,7 @@ class RegressionDiscontinuity(ExperimentalDesign):
         treatment_threshold,
         model=None,
         running_variable_name="x",
-        epsilon: float | None = 0.001,
+        epsilon: float = 0.001,
         **kwargs,
     ):
         super().__init__(model=model, **kwargs)

--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -112,6 +112,7 @@ def test_rd():
         formula="y ~ 1 + bs(x, df=6) + treated",
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
         treatment_threshold=0.5,
+        epsilon=0.001,
     )
     assert isinstance(df, pd.DataFrame)
     assert isinstance(result, cp.pymc_experiments.RegressionDiscontinuity)

--- a/causalpy/tests/test_integration_skl_examples.py
+++ b/causalpy/tests/test_integration_skl_examples.py
@@ -36,6 +36,7 @@ def test_rd_drinking():
         running_variable_name="age",
         model=LinearRegression(),
         treatment_threshold=21,
+        epsilon=0.001,
     )
     assert isinstance(df, pd.DataFrame)
     assert isinstance(result, cp.skl_experiments.RegressionDiscontinuity)
@@ -81,6 +82,7 @@ def test_rd_linear_main_effects():
         formula="y ~ 1 + x + treated",
         model=LinearRegression(),
         treatment_threshold=0.5,
+        epsilon=0.001,
     )
     assert isinstance(data, pd.DataFrame)
     assert isinstance(result, cp.skl_experiments.RegressionDiscontinuity)
@@ -94,6 +96,7 @@ def test_rd_linear_with_interaction():
         formula="y ~ 1 + x + treated + x:treated",
         model=LinearRegression(),
         treatment_threshold=0.5,
+        epsilon=0.001,
     )
     assert isinstance(data, pd.DataFrame)
     assert isinstance(result, cp.skl_experiments.RegressionDiscontinuity)
@@ -108,6 +111,7 @@ def test_rd_linear_with_gaussian_process():
         formula="y ~ 1 + x + treated",
         model=GaussianProcessRegressor(kernel=kernel),
         treatment_threshold=0.5,
+        epsilon=0.001,
     )
     assert isinstance(data, pd.DataFrame)
     assert isinstance(result, cp.skl_experiments.RegressionDiscontinuity)


### PR DESCRIPTION
Epsilon is the (small) distance above and below the threshold that we use to calculate the discontinuity. Previously this was hard-wired to be 0.001, but now we have a kwarg `epsilon` that can be used to override the default (still 0.001).

Added a short description in the docstring.

Added use of the kwarg into the integration tests.

Closes #220.