### PR TITLE
Issue 155: single source of version, setuptools -> flit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir -p test-sdist
           cd test-sdist
           python -m venv venv-sdist
-          venv-sdist/bin/python -m pip install ../dist/CausalPy*.tar.gz
+          venv-sdist/bin/python -m pip install ../dist/causalpy*.tar.gz
           echo "Checking import and version number (on release)"
           venv-sdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{  github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..
@@ -36,7 +36,7 @@ jobs:
           mkdir -p test-bdist
           cd test-bdist
           python -m venv venv-bdist
-          venv-bdist/bin/python -m pip install ../dist/CausalPy*.whl
+          venv-bdist/bin/python -m pip install ../dist/causalpy*.whl
           echo "Checking import and version number (on release)"
           venv-bdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{  github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,22 @@
 [build-system]
 # Minimum requirements for the build system to execute.
-build-backend = "setuptools.build_meta"
-requires = ["setuptools>=61.0"]
+build-backend = "flit_core.buildapi"
+requires = ["flit_core>=3.4,<4"]
 
-# This is configuration specific to the `setuptools` build backend.
+# This is configuration specific to the `flit` build backend.
 # If you are using a different build backend, you will need to change this.
-[tool.setuptools.packages.find]
-exclude = ["causalpy.test*", "docs*"]
+[tool.flit.sdist]
+exclude = ["causalpy/test*", "docs/*", "dist/*"]
 
-[tool.setuptools.package-data]
-"causalpy.data" = ["*.csv"]
+[tool.flit.external-data]
+directory = "causalpy/data"
+
+[tool.flit.module]
+name="causalpy"
 
 [project]
 name = "CausalPy"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Causal inference for quasi-experiments in Python"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This should resolve issue #155 , but I couldn't get setuptools to do dynamic versioning because of the imports in `__init__.py`. Switching to flit seems to work with minimal changes.

I tested by changing the version locally and using `pip install -e .` in a clean environment. The version was correct. Also using `python -m build` produced targ.gz and whl files with the correct versions in names.

Not sure if other testing would be good or if there's further discussion needed before changing the backend build system.