### PR TITLE
fix logo path and add favicon option

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,8 @@ myst_enable_extensions = [
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
-html_logo = "logo.png"
+html_logo = "_static/logo.png"
+html_favicon = "_static/logo.png"
 html_theme_options = {
     "logo_only": True,
     "display_version": False,


### PR DESCRIPTION
This resolves issue #237 . 

I'm using the same image for the favicon, which looks ok according to http://www.colinkeany.com/favicon-checker/, but in general I think the logo isn't the best on dark themed browsers, so it may be worth having a specialized favicon version of the logo that looks good at the small size in all themes.

 
<img width="424" alt="Screenshot 2023-09-19 at 1 00 51 PM" src="https://github.com/pymc-labs/CausalPy/assets/7041021/7bd4120e-5c48-4ac9-be39-cf722bce0fc2">
