### PR TITLE
Replace makefile commands with ruff 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,16 +5,15 @@ init:
 
 lint:
 	pip install causalpy[lint]
-	isort .
-	black .
+	ruff check --fix .
+	ruff format .
 
 check_lint:
 	pip install causalpy[lint]
-	flake8 .
-	isort --check-only .
-	black --diff --check --fast .
+	ruff check .
+	ruff format --diff --check .
 	nbqa black --check .
-	nbqa isort --check-only .
+	nbqa ruff .
 	interrogate .
 
 doctest:

--- a/causalpy/__init__.py
+++ b/causalpy/__init__.py
@@ -1,9 +1,6 @@
 import arviz as az
 
-from causalpy import pymc_experiments
-from causalpy import pymc_models
-from causalpy import skl_experiments
-from causalpy import skl_models
+from causalpy import pymc_experiments, pymc_models, skl_experiments, skl_models
 from causalpy.version import __version__
 
 from .data import load_data

--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -11,7 +11,7 @@ Experiment routines for PyMC models.
 
 """
 
-import warnings
+import warnings  # noqa: I001
 from typing import Union
 
 import arviz as az
@@ -23,7 +23,7 @@ import xarray as xr
 from patsy import build_design_matrices, dmatrices
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
-from causalpy.custom_exceptions import BadIndexException  # NOQA
+from causalpy.custom_exceptions import BadIndexException
 from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.plot_utils import plot_xY
 from causalpy.utils import _is_variable_dummy_coded

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -1,11 +1,11 @@
 """Input validation tests"""
 
-import numpy as np
+import numpy as np  # noqa: I001
 import pandas as pd
 import pytest
 
 import causalpy as cp
-from causalpy.custom_exceptions import BadIndexException  # NOQA
+from causalpy.custom_exceptions import BadIndexException
 from causalpy.custom_exceptions import DataException, FormulaException
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -112,3 +112,8 @@ color = true
 omit-covered-files = false
 generate-badge = "docs/source/_static/"
 badge-format = "svg"
+
+[tool.ruff.lint]
+extend-select = [
+  "I",  # isort
+]


### PR DESCRIPTION
This PR replaces makefile commands with the ruff linter and formatted. The PR resolves #271 
Changes:  
- Add isort rules to ruff config in the `poetry.toml` file
- Replace existing noqa in the codebase with ruff noqa syntax
- Replace the makefile commands with 

Unfortunately, `nbqa` is only compatible with `ruff check`/`ruff` command  not the `ruff format` so I kept it as is!