### PR TITLE
Ignore `causalpy/tests/` when running doctest to save a little time

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run doctests
         run: |
           pip install -e .[test]
-          pytest --doctest-modules causalpy/
+          pytest --doctest-modules --ignore=causalpy/tests/ causalpy/
       - name: Run tests
         run: |
           pip install -e .[test]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ check_lint:
 
 doctest:
 	pip install causalpy[test]
-	pytest --doctest-modules causalpy/
+	pytest --doctest-modules --ignore=causalpy/tests/ causalpy/
 
 test:
 	pip install causalpy[test]


### PR DESCRIPTION
Ignore `causalpy/tests/` when running doctest to save a little time. Resolves issue #278.

This cuts out the tests from being run twice, and doesn't doctest the docstrings in the tests - but none of them have examples so the doctests weren't doing much.

Locally, this went from 4m 50s to 3m 20s, so ~40% reduction in time.