### PR TITLE
Fix #299: Rounding issue for DiD results.

### DIFF
--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -709,7 +709,7 @@ class DifferenceInDifferences(ExperimentalDesign, DiDDataValidator):
         print(f"{self.expt_type:=^80}")
         print(f"Formula: {self.formula}")
         print("\nResults:")
-        print(round_num(self._causal_impact_summary_stat(), round_to))
+        print(self._causal_impact_summary_stat(round_to))
         self.print_coefficients(round_to)
 
 

--- a/docs/source/_static/interrogate_badge.svg
+++ b/docs/source/_static/interrogate_badge.svg
@@ -1,5 +1,5 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 96.6%</title>
+    <title>interrogate: 96.0%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">96.6%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">96.6%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">96.0%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">96.0%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">


### PR DESCRIPTION
Closes #299 .

- Rounding `round_num` was applied to a string. The method itself handles the rounding.
- Tests are already done [here](https://github.com/pymc-labs/CausalPy/blob/main/causalpy/tests/test_pymc_experiments.py#L10).