### PR TITLE
Fix #259: Annotation in `did_skl` notebook plot .

### DIFF
--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -475,7 +475,7 @@ class DifferenceInDifferences(ExperimentalDesign, DiDDataValidator):
         )
         ax.annotate(
             "causal\nimpact",
-            xy=(1.05, np.mean([self.y_pred_counterfactual, self.y_pred_treatment[1]])),
+            xy=(1.05, np.mean([self.y_pred_counterfactual[0], self.y_pred_treatment[1]])),
             xycoords="data",
             xytext=(5, 0),
             textcoords="offset points",


### PR DESCRIPTION
Closes #259.

- `self.y_pred_counterfactual` was a list within a list.