### PR TITLE
Drop support for Python 3.8 and 3.9, add 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Build the sdist and the wheel
         run: |
           pip install build
@@ -62,7 +62,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.11
       - name: Test pip install from test.pypi
         run: |
           # Give time to test.pypi to update its index. If we don't wait,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
 
    Always use a feature branch. It's good practice to never routinely work on the `main` branch of any repository.
 
-1. Create a new environment using Python >=3.8, for example 3.11
+1. Create a new environment using Python >=3.10, for example 3.11
 
     ```bash
     conda create --name CausalPy python=3.11

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ description = "Causal inference for quasi-experiments in Python"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Ben Vincent", email = "ben.vincent@pymc-labs.com" }]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 
 # This field lists other packages that your project depends on to run.
 # Any package you put here will be installed by pip when your project is
@@ -115,5 +115,5 @@ badge-format = "svg"
 
 [tool.ruff.lint]
 extend-select = [
-  "I",  # isort
+    "I", # isort
 ]


### PR DESCRIPTION
After the arviz release, the test kept failing because arviz 0.18.0 does not support Python 3.9 (https://github.com/arviz-devs/arviz/pull/2315/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7).

This PR drops support for 3.8 and 3.9 and adds support for 3.11.