### PR TITLE
Automate pre commit updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,21 +7,6 @@ on:
     branches: [main]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10", "3.11"]
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Run lint
-        uses: pre-commit/action@v3.0.0
-
   test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
           mkdir -p test-sdist
           cd test-sdist
           python -m venv venv-sdist
-          venv-sdist/bin/python -m pip install ../dist/CausalPy*.tar.gz
+          venv-sdist/bin/python -m pip install ../dist/causalpy*.tar.gz
           echo "Checking import and version number (on release)"
           venv-sdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{  github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,6 +19,7 @@ repos:
     rev: v0.4.2
     hooks:
       - id: ruff
+        args: ["--fix", "--output-format=full"]
       - id: ruff-format
   - repo: https://github.com/nbQA-dev/nbQA
     rev: 1.8.5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,23 +1,27 @@
+ci:
+  autofix_prs: false
+
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
+      - id: debug-statements
       - id: trailing-whitespace
         exclude_types: [svg]
       - id: end-of-file-fixer
         exclude_types: [svg]
       - id: check-yaml
       - id: check-added-large-files
-        args: ['--maxkb=1500']
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.1.4
+        args: ["--maxkb=1500"]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.2
     hooks:
       - id: ruff
       - id: ruff-format
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.7.0
+    rev: 1.8.5
     hooks:
       - id: nbqa-ruff
   - repo: https://github.com/econchick/interrogate

--- a/causalpy/data/__init__.py
+++ b/causalpy/data/__init__.py
@@ -1,4 +1,5 @@
 """Code for loading datasets."""
+
 from .datasets import load_data
 
 __all__ = ["load_data"]

--- a/causalpy/data/datasets.py
+++ b/causalpy/data/datasets.py
@@ -1,6 +1,7 @@
 """
 Functions to load example datasets
 """
+
 import pathlib
 
 import pandas as pd

--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -1,6 +1,7 @@
 """
 Functions that generate data sets used in examples
 """
+
 import numpy as np
 import pandas as pd
 from scipy.stats import dirichlet, gamma, norm, uniform

--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -8,6 +8,7 @@ Experiments for Scikit-Learn models
 - DifferenceInDifferences
 - RegressionDiscontinuity
 """
+
 import warnings
 from typing import Optional
 

--- a/causalpy/skl_models.py
+++ b/causalpy/skl_models.py
@@ -4,6 +4,7 @@ Scikit-Learn Models
 - Weighted Proportion
 
 """
+
 from functools import partial
 
 import numpy as np

--- a/causalpy/tests/conftest.py
+++ b/causalpy/tests/conftest.py
@@ -4,6 +4,7 @@ CausalPy Test Configuration
 Functions:
 * rng: random number generator with session level scope
 """
+
 import numpy as np
 import pytest
 

--- a/causalpy/tests/test_data_loading.py
+++ b/causalpy/tests/test_data_loading.py
@@ -1,6 +1,7 @@
 """
 Tests that example data can be loaded into data frames.
 """
+
 import pandas as pd
 import pytest
 

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -1,6 +1,7 @@
 """
 Utility functions
 """
+
 import numpy as np
 import pandas as pd
 


### PR DESCRIPTION
This PR adds the feature to use https://pre-commit.ci/ to generate automatic version updates of the pre-commit versions. This is already working on pymc-marketing: https://github.com/pymc-labs/pymc-marketing/blob/main/.pre-commit-config.yaml  Note I deleted the GitHub action as it will be a duplicate after this one is merged (https://github.com/pymc-devs/pymc/pull/7285)

@drbenvincent Can you please log into https://pre-commit.ci/ and grant access to this repository after we merge this PR? We then can start getting these automatic PRs as in https://github.com/pymc-labs/pymc-marketing/pull/655

I ran `pre-commit run --all-files` to verify everything was working as expected. The result is that some files were modified just by adding a white space. 