### PR TITLE
Remove `<BLANKLINE>` from docstrings

### DIFF
--- a/causalpy/pymc_experiments.py
+++ b/causalpy/pymc_experiments.py
@@ -102,11 +102,6 @@ class ExperimentalDesign:
         ...                 "progressbar": False
         ...             }),
         ...  )
-        <BLANKLINE>
-        <BLANKLINE>
-        <BLANKLINE>
-        <BLANKLINE>
-        <BLANKLINE>
         >>> result.print_coefficients(round_to=1) # doctest: +NUMBER
         Model coefficients:
         Intercept                     1, 94% HDI [1, 1]
@@ -165,11 +160,6 @@ class PrePostFit(ExperimentalDesign, PrePostFitDataValidator):
     ...         }
     ...     ),
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     >>> result.summary(round_to=1) # doctest: +NUMBER
     ==================================Pre-Post Fit==================================
     Formula: actual ~ 0 + a + g
@@ -396,11 +386,6 @@ class InterruptedTimeSeries(PrePostFit):
     ...         }
     ...     )
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     expt_type = "Interrupted Time Series"
@@ -436,11 +421,6 @@ class SyntheticControl(PrePostFit):
     ...         }
     ...     ),
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     expt_type = "Synthetic Control"
@@ -497,11 +477,6 @@ class DifferenceInDifferences(ExperimentalDesign, DiDDataValidator):
     ...         }
     ...     )
     ...  )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     def __init__(
@@ -793,11 +768,6 @@ class RegressionDiscontinuity(ExperimentalDesign, RDDataValidator):
     ...     ),
     ...     treatment_threshold=0.5,
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     def __init__(
@@ -1207,10 +1177,6 @@ class PrePostNEGD(ExperimentalDesign, PrePostNEGDDataValidator):
     ...         }
     ...     )
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
-    <BLANKLINE>
     >>> result.summary(round_to=1) # doctest: +NUMBER
     ==================Pretest/posttest Nonequivalent Group Design===================
     Formula: post ~ 1 + C(group) + pre
@@ -1441,8 +1407,6 @@ class InstrumentalVariable(ExperimentalDesign, IVDataValidator):
     ...         formula=formula,
     ...         model=InstrumentalVariableRegression(sample_kwargs=sample_kwargs),
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     def __init__(
@@ -1568,8 +1532,6 @@ class InversePropensityWeighting(ExperimentalDesign, PropensityDataValidator):
     ...         },
     ...     ),
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
     """
 
     def __init__(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -72,15 +72,11 @@ class ModelBuilder(pm.Model):
     ...             }
     ... )
     >>> model.fit(X, y)
-    <BLANKLINE>
-    <BLANKLINE>
     Inference data...
     >>> X_new = rng.normal(loc=0, scale=1, size=(20,2))
     >>> model.predict(X_new)
-    <BLANKLINE>
     Inference data...
     >>> model.score(X, y)
-    <BLANKLINE>
     r2        0.390344
     r2_std    0.081135
     dtype: float64
@@ -201,8 +197,6 @@ class WeightedSumFitter(ModelBuilder):
     >>> y = np.asarray(sc['actual']).reshape((sc.shape[0], 1))
     >>> wsf = WeightedSumFitter(sample_kwargs={"progressbar": False})
     >>> wsf.fit(X,y)
-    <BLANKLINE>
-    <BLANKLINE>
     Inference data...
     """  # noqa: W605
 
@@ -259,8 +253,6 @@ class LinearRegression(ModelBuilder):
     ...                 'obs_indx': np.arange(rd.shape[0])
     ...                },
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
     Inference data...
     """  # noqa: W605
 
@@ -313,8 +305,6 @@ class InstrumentalVariableRegression(ModelBuilder):
     ...                  "eta": 2,
     ...                  "lkj_sd": 2,
     ...              })
-    <BLANKLINE>
-    <BLANKLINE>
     Inference data...
     """
 
@@ -432,8 +422,6 @@ class PropensityScore(ModelBuilder):
     ...                 'obs_indx': np.arange(df.shape[0])
     ...                },
     ... )
-    <BLANKLINE>
-    <BLANKLINE>
     Inference...
     """  # noqa: W605
 

--- a/causalpy/skl_experiments.py
+++ b/causalpy/skl_experiments.py
@@ -547,7 +547,6 @@ class RegressionDiscontinuity(ExperimentalDesign, RDDataValidator):
     Formula: y ~ 1 + x + treated
     Running variable: x
     Threshold on running variable: 0.5
-    <BLANKLINE>
     Results:
     Discontinuity at threshold = 0.19
     Model coefficients:

--- a/environment.yml
+++ b/environment.yml
@@ -9,7 +9,7 @@ dependencies:
   - numpy<1.26.0
   - pandas
   - patsy
-  - pymc>=5.14.0
+  - pymc>=5.15.1
   - scikit-learn>=1
   - scipy
   - seaborn>=0.11.2


### PR DESCRIPTION
* Removes a bunch of `<BLANKLINE>` instances in the docstrings. They were put there in #330 in order to fix failing tests. And that was happening because the progress bar was misbehaving.
* This was fixed in https://github.com/pymc-devs/pymc/pull/7290 so we no longer need most `<BLANKLINE>` instances.
* This PR removes those, **and increments the required version of PyMC to `5.15.1`** which is the version to include https://github.com/pymc-devs/pymc/pull/7290
* Closes #331 
* This should also fix failing remote tests that we are seeing in other PR's.