### PR TITLE
Remove all remaining traces of `nbqa` from the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ lint:
 check_lint:
 	ruff check .
 	ruff format --diff --check .
-	nbqa black --check .
-	nbqa ruff .
 	interrogate .
 
 doctest:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ docs = [
     "statsmodels",
     "sphinxcontrib-bibtex",
 ]
-lint = ["interrogate", "nbqa", "pre-commit", "ruff"]
+lint = ["interrogate", "pre-commit", "ruff"]
 test = ["pytest", "pytest-cov"]
 
 [metadata]


### PR DESCRIPTION
* In #352 I forgot to nuke all mention of nbqa from the repo
* This PR does that, removing it from `pyproject.toml` and the `Makefile`