### PR TITLE
Various improvements to documentation infrastructure

### DIFF
--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -1,0 +1,16 @@
+name: Read the Docs Pull Request Preview
+on:
+  pull_request_target:
+    types:
+      - opened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  documentation-links:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          project-slug: "pymc"

--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: readthedocs/actions/preview@v1
         with:
-          project-slug: "pymc"
+          project-slug: "causalpy"

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ _build
 build/
 dist/
 docs/_build/
+docs/build/
+docs/jupyter_execute/
 *.vscode
 .coverage
 *.jupyterlab-workspace

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,9 +7,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-lts-latest
   tools:
-    python: "3.10"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pip install git+https://github.com/pymc-labs/CausalPy.git
 
 ```python
 import causalpy as cp
-
+import matplotlib.pyplot as plt
 
 # Import and process data
 df = (
@@ -57,6 +57,8 @@ fig, ax = result.plot();
 
 # Get a results summary
 result.summary()
+
+plt.show()
 ```
 
 ## Roadmap

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -74,8 +74,15 @@ bibtex_reference_style = "author_year"
 
 # -- intersphinx config -------------------------------------------------------
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None),
+    "examples": ("https://www.pymc.io/projects/examples/en/latest/", None),
+    "mpl": ("https://matplotlib.org/stable", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "pymc": ("https://www.pymc.io/projects/docs/en/stable/", None),
+    "python": ("https://docs.python.org/3", None),
+    "scikit-learn": ("https://scikit-learn.org/stable/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable/", None),
 }
 
 # MyST options for working with markdown files.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,6 +58,11 @@ extensions = [
 
 nb_execution_mode = "off"
 
+# configure copy button to avoid copying sphinx or console characters
+copybutton_exclude = ".linenos, .gp"
+copybutton_prompt_text = r">>> |\.\.\. |\$ |In \[\d*\]: | {2,5}\.\.\.: | {5,8}: "
+copybutton_prompt_is_regexp = True
+
 source_suffix = {
     ".rst": "restructuredtext",
     ".ipynb": "myst-nb",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,9 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
+    "sphinx.ext.viewcode",
     "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
 ]
 
 nb_execution_mode = "off"

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,11 +12,17 @@ A Python package focussing on causal inference for quasi-experiments. The packag
 Installation
 ------------
 
-To get the latest release:
+To get the latest release you can use pip:
 
 .. code-block:: sh
 
    pip install CausalPy
+
+or conda:
+
+.. code-block:: sh
+
+   conda install causalpy -c conda-forge
 
 Alternatively, if you want the very latest version of the package you can install from GitHub:
 
@@ -31,6 +37,7 @@ Quickstart
 .. code-block:: python
 
    import causalpy as cp
+   import matplotlib.pyplot as plt
 
 
    # Import and process data
@@ -54,6 +61,8 @@ Quickstart
 
    # Get a results summary
    result.summary()
+
+   plt.show()
 
 
 Videos

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ docs = [
     "ipykernel",
     "daft",
     "linkify-it-py",
-    "myst-nb<=1.0.0",
+    "myst-nb!=1.1.0",
     "pathlib",
     "sphinx",
     "sphinx-autodoc-typehints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx_autodoc_defaultargs",
-    "sphinx-design",
+    "sphinx-copybutton",
     "sphinx-rtd-theme",
     "statsmodels",
     "sphinxcontrib-bibtex",


### PR DESCRIPTION
Multiple changes related to documentation infrastructure.
Can add some more depending on preferences.

* Add conda forge install instructions
* add viewcode and copybutton extensions. They add the [source] link to docs and a copybutton to
  copy whole cells. I will double check, but using the copy button should also copy the snippets
  in docstrings like the one in https://causalpy.readthedocs.io/en/latest/api_skl_experiments.html
  without the >>> parts.
* Add the rtd-preview workflow that adds a link to the PR documentation preview as text at the
  bottom of the PR description. From what I see, PR doc preview aren't active yet, this can
  be done from https://readthedocs.org/dashboard/causalpy/edit/, scroll down and check
  the

  > Build pull requests for this project:
  > * [ ] More information in our docs. 

* remove sphinx-design from [docs] external dependencies as it was not used
* updates to rtd config to make it more future proof

Related to #236 (not completely sure about the scope of the issue so not sure if it should be closed already or not yet), closes #86 
