### PR TITLE
fix docstring example rendering

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,10 +52,9 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.mathjax",
     "sphinx.ext.intersphinx",
-    # "sphinx.ext.napoleon",
+    "sphinx.ext.napoleon",
     "sphinx_autodoc_typehints",
     # extensions provided by other packages
-    "numpydoc",
     "sphinxcontrib.bibtex",
     "matplotlib.sphinxext.plot_directive",  # needed to plot in docstrings
     "myst_nb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,6 @@ docs = [
     "sphinxcontrib-bibtex",
     "sphinx-notfound-page",
     "ipywidgets",
-    "numpydoc",
     "sphinx-design",
 ]
 lint = ["interrogate", "pre-commit", "ruff"]


### PR DESCRIPTION
closes #373


<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--376.org.readthedocs.build/en/376/

<!-- readthedocs-preview causalpy end -->