### PR TITLE
Add page of causal video resources from PyMC community into the docs

### DIFF
--- a/docs/source/knowledgebase/causal_video_resources.md
+++ b/docs/source/knowledgebase/causal_video_resources.md
@@ -1,6 +1,5 @@
 # Causal video resources
 
-## PyMC Videos
 
 <style>
 .video-container {
@@ -22,14 +21,26 @@
 }
 </style>
 
+## What if Causal reasoning meets Bayesian Inference
+
+<div class="video-container">
+    <iframe src="https://www.youtube.com/embed/gV6wzTk3o1U" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>
+
+## Combining Bayes and Graph-based Causal Inference
+
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/0PQ8BQaDP04?si=O4qb44OBDVn8gqHP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-<br>
+
+## Bayesian Causal Modeling
+
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/b47wmTdcICE?si=aXufYM8AiHZAQ9Q0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-<br>
+
+## Thomas Wiecki's Guide To Causal Inference Using PyMC
+
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/QAzAFess1AA?si=zD6PrljOFUyvjm1I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>

--- a/docs/source/knowledgebase/causal_video_resources.md
+++ b/docs/source/knowledgebase/causal_video_resources.md
@@ -21,7 +21,7 @@
 }
 </style>
 
-## What if Causal reasoning meets Bayesian Inference
+## What if? Causal reasoning meets Bayesian Inference
 
 <div class="video-container">
     <iframe src="https://www.youtube.com/embed/gV6wzTk3o1U" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>

--- a/docs/source/knowledgebase/causal_video_resources.md
+++ b/docs/source/knowledgebase/causal_video_resources.md
@@ -1,0 +1,35 @@
+# Causal video resources
+
+## PyMC Videos
+
+<style>
+.video-container {
+    position: relative;
+    padding-bottom: 56.25%; /* 16:9 aspect ratio */
+    height: 0;
+    overflow: hidden;
+    max-width: 100%;
+    background: #000;
+}
+
+.video-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+</style>
+
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/0PQ8BQaDP04?si=O4qb44OBDVn8gqHP" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<br>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/b47wmTdcICE?si=aXufYM8AiHZAQ9Q0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+<br>
+<div class="video-container">
+    <iframe width="560" height="315" src="https://www.youtube.com/embed/QAzAFess1AA?si=zD6PrljOFUyvjm1I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>

--- a/docs/source/knowledgebase/causal_video_resources.md
+++ b/docs/source/knowledgebase/causal_video_resources.md
@@ -39,7 +39,7 @@
     <iframe width="560" height="315" src="https://www.youtube.com/embed/b47wmTdcICE?si=aXufYM8AiHZAQ9Q0" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
 
-## Thomas Wiecki's Guide To Causal Inference Using PyMC
+## Guide To Causal Inference Using PyMC
 
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/QAzAFess1AA?si=zD6PrljOFUyvjm1I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>

--- a/docs/source/knowledgebase/index.md
+++ b/docs/source/knowledgebase/index.md
@@ -6,4 +6,6 @@
 glossary
 design_notation
 quasi_dags.ipynb
+causal_video_resources
+
 :::


### PR DESCRIPTION
# feat: Add causal videos from PyMC / PyMC Labs community [Issue No: 374](https://github.com/pymc-labs/CausalPy/issues/374)

#### closes #374 

## What type of PR:-
- [x] ✨ Enhancement
- [x] 📃 Documentation

## Description

1. Added the `causal_video_resources` page markdown file for the PyMC Labs Videos, used iframe to add the videos.
2. Tested if the UI is responsive or not in both light and dark mode.
3. Updated the `index.md` for the knowledge base to include the page link for the `causal_video_resources`.

## Screenshot & Screen recording

https://github.com/pymc-labs/CausalPy/assets/76129377/7305cb30-6a73-4c7c-a403-8c2e916219d6

![link-check](https://github.com/pymc-labs/CausalPy/assets/76129377/547d496b-40b6-4d89-bbe6-61f2bc8903db)


<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--379.org.readthedocs.build/en/379/

<!-- readthedocs-preview causalpy end -->