### PR TITLE
Add Codespell pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,14 @@ repos:
         # needed to make excludes in pyproject.toml work
         # see here https://github.com/econchick/interrogate/issues/60#issuecomment-735436566
         pass_filenames: false
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.5
+    hooks:
+      - id: codespell
+        args: [
+            # Write changes in place
+            "-w",
+          ]
+        additional_dependencies:
+          # Support pyproject.toml configuration
+          - tomli

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,14 @@ repos:
     hooks:
       - id: codespell
         args: [
+            "-S",
+            "*.csv",
+            "-S",
+            "*.ipynb",
+            "-S",
+            "pyproject.toml",
+            "--ignore-words-list",
+            "\"nD,CACE\"",
             # Write changes in place
             "-w",
           ]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ This is appropriate when you have multiple units, one of which is treated. You b
 > The data (treated and untreated units), pre-treatment model fit, and counterfactual (i.e. the synthetic control) are plotted (top). The causal impact is shown as a blue shaded region. The Bayesian analysis shows shaded Bayesian credible regions of the model fit and counterfactual. Also shown is the causal impact (middle) and cumulative causal impact (bottom).
 
 ### Geographical lift (Geolift)
-We can also use synthetic control methods to analyse data from geographical lift studies. For example, we can try to evaluate the causal impact of an intervention (e.g. a marketing campaign) run in one geographical area by using control geographical areas which are similar to the intervention area but which did not recieve the specific marketing intervention.
+We can also use synthetic control methods to analyse data from geographical lift studies. For example, we can try to evaluate the causal impact of an intervention (e.g. a marketing campaign) run in one geographical area by using control geographical areas which are similar to the intervention area but which did not receive the specific marketing intervention.
 
 ### ANCOVA
 

--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -291,7 +291,7 @@ def generate_ancova_data(
     N=200, pre_treatment_means=np.array([10, 12]), treatment_effect=2, sigma=1
 ):
     """
-    Generate ANCOVA eample data
+    Generate ANCOVA example data
 
     Example
     --------
@@ -440,7 +440,7 @@ def generate_seasonality(n=12, amplitude=1, length_scale=0.5):
 
 
 def periodic_kernel(x1, x2, period=1, length_scale=1, amplitude=1):
-    """Generate a periodic kernal for gaussian process"""
+    """Generate a periodic kernel for gaussian process"""
     return amplitude**2 * np.exp(
         -2 * np.sin(np.pi * np.abs(x1 - x2) / period) ** 2 / length_scale**2
     )

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -44,7 +44,7 @@ class InstrumentalVariable(BaseExperiment):
     :param model: A PyMC model
     :param priors: An optional dictionary of priors for the
                    mus and sigmas of both regressions. If priors are not
-                   specified we will substitue MLE estimates for the beta
+                   specified we will substitute MLE estimates for the beta
                    coefficients. Greater control can be achieved
                    by specifying the priors directly e.g. priors = {
                                     "mus": [0, 0],

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -195,7 +195,7 @@ class InversePropensityWeighting(BaseExperiment):
         m1 = sk_lin_reg().fit(X[t == 1].astype(float), self.y[t == 1])
         m0_pred = m0.predict(X)
         m1_pred = m1.predict(X)
-        ## Compromise between outcome and treatement assignment model
+        ## Compromise between outcome and treatment assignment model
         weighted_outcome0 = (1 - t) * (self.y - m0_pred) / (1 - X["ps"]) + m0_pred
         weighted_outcome1 = t * (self.y - m1_pred) / X["ps"] + m1_pred
         return weighted_outcome0, weighted_outcome1, None, None

--- a/causalpy/experiments/prepostfit.py
+++ b/causalpy/experiments/prepostfit.py
@@ -311,7 +311,7 @@ class InterruptedTimeSeries(PrePostFit):
     :param data:
         A pandas dataframe
     :param treatment_time:
-        The time when treatment occured, should be in reference to the data index
+        The time when treatment occurred, should be in reference to the data index
     :param formula:
         A statistical model formula
     :param model:
@@ -352,7 +352,7 @@ class SyntheticControl(PrePostFit):
     :param data:
         A pandas dataframe
     :param treatment_time:
-        The time when treatment occured, should be in reference to the data index
+        The time when treatment occurred, should be in reference to the data index
     :param formula:
         A statistical model formula
     :param model:

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -73,7 +73,7 @@ def plot_xY(
         ax=ax,
         **plot_hdi_kwargs,
     )
-    # Return handle to patch. We get a list of the childen of the axis. Filter for just
+    # Return handle to patch. We get a list of the children of the axis. Filter for just
     # the PolyCollection objects. Take the last one.
     h_patch = list(
         filter(lambda x: isinstance(x, PolyCollection), ax_hdi.get_children())

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -27,7 +27,7 @@ from causalpy.utils import round_num
 
 
 class PyMCModel(pm.Model):
-    """A wraper class for PyMC models. This provides a scikit-learn like interface with
+    """A wrapper class for PyMC models. This provides a scikit-learn like interface with
     methods like `fit`, `predict`, and `score`. It also provides other methods which are
     useful for causal inference.
 

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -142,7 +142,7 @@ seeds = [1234, 42, 123456789]
 @pytest.mark.parametrize("seed", seeds)
 def test_result_reproducibility(seed):
     """Test that we can reproduce the results from the model. We could in theory test
-    this with all the model and experiment types, but what is being targetted is
+    this with all the model and experiment types, but what is being targeted is
     the PyMCModel.fit method, so we should be safe testing with just one model. Here
     we use the DifferenceInDifferences experiment class."""
     # Load the data

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -98,7 +98,7 @@ This is appropriate when you have multiple units, one of which is treated. You b
 ![Synthetic Control](./_static/synthetic_control_pymc.svg)
 
 ### Geographical Lift / Geolift
-We can also use synthetic control methods to analyse data from geographical lift studies. For example, we can try to evaluate the causal impact of an intervention (e.g. a marketing campaign) run in one geographical area by using control geographical areas which are similar to the intervention area but which did not recieve the specific marketing intervention.
+We can also use synthetic control methods to analyse data from geographical lift studies. For example, we can try to evaluate the causal impact of an intervention (e.g. a marketing campaign) run in one geographical area by using control geographical areas which are similar to the intervention area but which did not receive the specific marketing intervention.
 
 ### ANCOVA
 

--- a/docs/source/knowledgebase/glossary.rst
+++ b/docs/source/knowledgebase/glossary.rst
@@ -9,11 +9,11 @@ Glossary
 
    Average treatment effect
    ATE
-      The average treatement effect across all units.
+      The average treatment effect across all units.
 
    Average treatment effect on the treated
    ATT
-      The average effect of the treatment on the units that recieved it. Also called Treatment on the treated.
+      The average effect of the treatment on the units that received it. Also called Treatment on the treated.
 
    Change score analysis
       A statistical procedure where the outcome variable is the difference between the posttest and protest scores.
@@ -48,7 +48,7 @@ Glossary
 
    Local Average Treatment effect
    LATE
-      Also known asthe complier average causal effect (CACE), is the effect of a treatment for subjects who comply with the experimental treatment assigned to their sample group. It is the quantity we're estimating in IV designs.
+      Also known asthe compiler average causal effect (CACE), is the effect of a treatment for subjects who comply with the experimental treatment assigned to their sample group. It is the quantity we're estimating in IV designs.
 
    Non-equivalent group designs
    NEGD
@@ -76,7 +76,7 @@ Glossary
       Where units are assigned to conditions at random.
 
    Randomized experiment
-      An emprical comparison used to estimate the effects of treatments where units are assigned to treatment conditions randomly.
+      An empirical comparison used to estimate the effects of treatments where units are assigned to treatment conditions randomly.
 
    Regression discontinuity design
    RDD
@@ -96,7 +96,7 @@ Glossary
 
    Treatment on the treated effect
    TOT
-      The average effect of the treatment on the units that recieved it. Also called the average treatment effect on the treated (ATT).
+      The average effect of the treatment on the units that received it. Also called the average treatment effect on the treated (ATT).
 
    Treatment effect
       The difference in outcomes between what happened after a treatment is implemented and what would have happened (see Counterfactual) if the treatment had not been implemented, assuming everything else had been the same.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,3 +122,7 @@ badge-format = "svg"
 extend-select = [
     "I", # isort
 ]
+
+[tool.codespell]
+skip = "*.csv,*.ipynb"
+ignore-words-list = "nD,CACE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,7 +122,3 @@ badge-format = "svg"
 extend-select = [
     "I", # isort
 ]
-
-[tool.codespell]
-skip = "*.csv,*.ipynb"
-ignore-words-list = "nD,CACE"


### PR DESCRIPTION
Closes #401 -- I ignored all the jupyter notebooks as there's a lot of custom variable definition in there that is getting flagged as incorrect words.  I felt like trying to maintain a list of all these words, long term, as a dictionary would be a bit too tricky / annoying. 

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--402.org.readthedocs.build/en/402/

<!-- readthedocs-preview causalpy end -->