### PR TITLE
Calculate goodness of fit (`r2_score`) based on posterior expectation rather than posterior prediction

### DIFF
--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -59,13 +59,13 @@ class PyMCModel(pm.Model):
     ... )
     >>> model.fit(X, y)
     Inference data...
-    >>> X_new = rng.normal(loc=0, scale=1, size=(20,2))
-    >>> model.predict(X_new)
-    Inference data...
     >>> model.score(X, y)
     r2        0.19157
     r2_std    0.11238
     dtype: float64
+    >>> X_new = rng.normal(loc=0, scale=1, size=(20,2))
+    >>> model.predict(X_new)
+    Inference data...
     """
 
     def __init__(self, sample_kwargs: Optional[Dict[str, Any]] = None):

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -59,9 +59,9 @@ class PyMCModel(pm.Model):
     ... )
     >>> model.fit(X, y)
     Inference data...
-    >>> model.score(X, y)
-    r2        0.19157
-    r2_std    0.11238
+    >>> model.score(X, y)  # doctest: +ELLIPSIS
+    r2        ...
+    r2_std    ...
     dtype: float64
     >>> X_new = rng.normal(loc=0, scale=1, size=(20,2))
     >>> model.predict(X_new)


### PR DESCRIPTION
* Previously, the `r2_score` was calculated by comparing `y_true` and `y_pred`, where `y_pred` was the likelihood-influenced predictions i.e. with the observation noise added. Now we set `y_pred` to be based on the model's expected outcomes.
* Closes #428

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--429.org.readthedocs.build/en/429/

<!-- readthedocs-preview causalpy end -->