### PR TITLE
Add new list of written learning resources to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,17 +85,6 @@ CausalPy has a broad range of quasi-experimental methods for causal inference:
 | Instrumental variable regression | Addresses endogeneity by using an instrument variable that is correlated with the endogenous explanatory variable but uncorrelated with the error term. Used when explanatory variables are correlated with the error term, providing consistent estimates of causal effects. |
 | Inverse Propensity Score Weighting | Weights observations by the inverse of the probability of receiving the treatment. Used in causal inference to create a synthetic sample where the treatment assignment is independent of measured covariates, helping to adjust for confounding variables in observational studies. |
 
-## Learning resources
-
-Here are some general resources about causal inference:
-
-* The official [PyMC examples gallery](https://www.pymc.io/projects/examples/en/latest/gallery.html) has a set of examples specifically relating to causal inference.
-* Angrist, J. D., & Pischke, J. S. (2009). Mostly harmless econometrics: An empiricist's companion. Princeton university press.
-* Angrist, J. D., & Pischke, J. S. (2014). Mastering'metrics: The path from cause to effect. Princeton university press.
-* Cunningham, S. (2021). [Causal inference: The Mixtape](https://mixtape.scunning.com). Yale University Press.
-* Huntington-Klein, N. (2021). [The effect: An introduction to research design and causality](https://theeffectbook.net). Chapman and Hall/CRC.
-* Reichardt, C. S. (2019). Quasi-experimentation: A guide to design and analysis. Guilford Publications.
-
 ## License
 
 [Apache License 2.0](LICENSE)

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -2,7 +2,7 @@
 
 ## Awesome Causal Inference
 
-A fantastic one stop shop on resources on a range causal of topics can be found at *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) github repo.
+A fantastic one stop shop of resources on a range of causal topics can be found at *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) github repo.
 
 Covering the essentials from:
 

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -1,21 +1,18 @@
-# Causal written resources
+# Written resources on causal inference
 
-## Awesome Causal Inference
+Below is a list of written resources (books, blog posts, etc.) that are useful for learning about causal inference.
 
-A fantastic one-stop shop for resources on a range of causal topics can be found in *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) GitHub repo.
+## Quasi-experiment resources
 
-Covering the essentials from:
+* Angrist, J. D., & Pischke, J. S. (2009). [Mostly harmless econometrics: An empiricist's companion](https://www.mostlyharmlesseconometrics.com). Princeton university press.
+* Angrist, J. D., & Pischke, J. S. (2014). [Mastering'metrics: The path from cause to effect](https://www.masteringmetrics.com). Princeton University Press.
+* Cunningham, S. (2021). [Causal inference: The Mixtape](https://mixtape.scunning.com). Yale University Press.
+* Huntington-Klein, N. (2021). [The effect: An introduction to research design and causality](https://theeffectbook.net). Chapman and Hall/CRC.
+* Reichardt, C. S. (2019). Quasi-experimentation: A guide to design and analysis. Guilford Publications.
 
-- Academia
-- Industry
-- Books
-- Blogs
-- Code implementations
-- Talks
-- Tutorials
+## Bayesian causal inference resources
+* The official [PyMC examples gallery](https://www.pymc.io/projects/examples/en/latest/gallery.html) has a set of examples specifically relating to causal inference.
 
-## CausalPy focused written resources
+## General causal inference resources
 
-The CausalPy package is designed to allow analysts to easily analyse quasi-experiments. As such, key resources include:
-
-- Charles Reichardts - Quasi-Experimentation: A Guide to Design and Analysis.
+* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference), a curated list of resources on causal inference, including books, blogs, and tutorials.

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -4,7 +4,7 @@
 
 A fantastic one stop shop on resources on a range causal of topics can be found at *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) github repo.
 
-Covering the essential from:
+Covering the essentials from:
 
 - Academia
 - Industry
@@ -16,6 +16,6 @@ Covering the essential from:
 
 ## CausalPy focused written resources
 
-The CausalPy package is built around the allowing the analyst the ease to analyse quasi-experiments. As such key resources include:
+The CausalPy package is designed to allow analysts to easily analyse quasi-experiments. As such, key resources include:
 
-- Charles Reichardts - Quasi-Experimentation: A Guide to Design and Analysis
+- Charles Reichardts - Quasi-Experimentation: A Guide to Design and Analysis.

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -2,7 +2,7 @@
 
 ## Awesome Causal Inference
 
-A fantastic one stop shop of resources on a range of causal topics can be found at *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) github repo.
+A fantastic one-stop shop for resources on a range of causal topics can be found in *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) GitHub repo.
 
 Covering the essentials from:
 

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -1,0 +1,21 @@
+# Causal written resources
+
+## Awesome Causal Inference
+
+A fantastic one stop shop on resources on a range causal of topics can be found at *Matt Courthoud* [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference) github repo.
+
+Covering the essential from:
+
+- Academia
+- Industry
+- Books
+- Blogs
+- Code implementations
+- Talks
+- Tutorials
+
+## CausalPy focused written resources
+
+The CausalPy package is built around the allowing the analyst the ease to analyse quasi-experiments. As such key resources include:
+
+- Charles Reichardts - Quasi-Experimentation: A Guide to Design and Analysis

--- a/docs/source/knowledgebase/index.md
+++ b/docs/source/knowledgebase/index.md
@@ -7,5 +7,5 @@ glossary
 design_notation
 quasi_dags.ipynb
 causal_video_resources
-
+causal_written_resources
 :::


### PR DESCRIPTION
#71 Outline for general markdown for causal inference written resources with update to index.md. Separating the awesome causal inference section by Matt Courthoud and essential written resources for the CausalPy package. 

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--447.org.readthedocs.build/en/447/

<!-- readthedocs-preview causalpy end -->