### PR TITLE
Better handling of treated input in RegressionDiscontinuityBetter handling treated input

### DIFF
--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -190,6 +190,8 @@ class RegressionDiscontinuity(BaseExperiment):
             raise DataException(
                 """The treated variable should be dummy coded. Consisting of 0's and 1's only."""  # noqa: E501
             )
+        if not self.data['treated'].dtype == 'bool':
+            raise ValueError("The 'treated' column must be of type bool.Please convert your data accordingly.")
 
     def _is_treated(self, x):
         """Returns ``True`` if `x` is greater than or equal to the treatment threshold.

--- a/causalpy/experiments/test_treated_column_valid.py
+++ b/causalpy/experiments/test_treated_column_valid.py
@@ -17,3 +17,4 @@ def test_treated_column_with_booleans():
         _check_treated_column_validity(df, "treated")
     except ValueError:
         pytest.fail("Unexpected ValueError raised")
+

--- a/causalpy/experiments/test_treated_column_valid.py
+++ b/causalpy/experiments/test_treated_column_valid.py
@@ -1,0 +1,19 @@
+import pandas as pd
+import pytest
+
+def _check_treated_column_validity(df, treated_col_name):
+    treated_col = df[treated_col_name]
+    if not pd.api.types.is_bool_dtype(treated_col):
+        raise ValueError(f"The '{treated_col_name}' column must be of boolean dtype (True/False).")
+
+def test_treated_column_with_integers():
+    df = pd.DataFrame({"treated": [0, 1, 0, 1]})
+    with pytest.raises(ValueError, match="treated.*must be of boolean dtype"):
+        _check_treated_column_validity(df, "treated")
+
+def test_treated_column_with_booleans():
+    df = pd.DataFrame({"treated": [True, False, True, False]})
+    try:
+        _check_treated_column_validity(df, "treated")
+    except ValueError:
+        pytest.fail("Unexpected ValueError raised")


### PR DESCRIPTION
This PR addresses issue [#440](https://github.com/pymc-labs/CausalPy/issues/440) by improving the handling of the treated column in RegressionDiscontinuity.

Added a data validation step to ensure the treated column is of boolean type.

Included a test (test_treated_column_valid.py) to check that an exception is raised when the treated column contains integers instead of booleans.

This ensures clearer error messages and prevents mysterious errors when using integer-coded treatments.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--450.org.readthedocs.build/en/450/

<!-- readthedocs-preview causalpy end -->