### PR TITLE
update download-artifact@v3 to download-artifact@v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist
@@ -86,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifact
           path: dist


### PR DESCRIPTION
There was an [error](https://github.com/pymc-labs/CausalPy/actions/runs/14512505530/job/40714309555) in the GitHub action which uploads after a new version release. This PR updates `download-artifact@v3` to `download-artifact@v4` given the advice [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).

I'll try to manually trigger the release action again after this is merged.