### PR TITLE
Update badges on GitHub landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 
 ----
 
-![Build](https://github.com/pymc-labs/CausalPy/workflows/ci/badge.svg)
-[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json)]([https://codecov.io/gh/pymc-labs/CausalPy](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/charliermarsh/ruff/main/assets/badge/v1.json))
+![Build Status](https://github.com/pymc-labs/CausalPy/workflows/ci/badge.svg?branch=main)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/CausalPy.svg)](https://badge.fury.io/py/CausalPy)
 ![GitHub Repo stars](https://img.shields.io/github/stars/pymc-labs/causalpy?style=social)
 ![Read the Docs](https://img.shields.io/readthedocs/causalpy)


### PR DESCRIPTION
* The build badge now reflects the status of `main`. Previously if the latest ci build failed (even if it was from developmental work in a feature branch), the badge would show as failed. That gave a misleading picture of the repo status.
* I also updated the Ruff badge. Previous it was red, and red is angry and bad.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--465.org.readthedocs.build/en/465/

<!-- readthedocs-preview causalpy end -->