### PR TITLE
Auto-label pre-commit autoupdate PRs with "no releasenotes"

### DIFF
--- a/.github/workflows/label-precommit-prs.yml
+++ b/.github/workflows/label-precommit-prs.yml
@@ -1,0 +1,18 @@
+name: Label Pre-Commit PRs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    if: github.actor == 'pre-commit-ci[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Add "no releasenotes" label
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: no releasenotes


### PR DESCRIPTION
Resolves the issue where auto-generated pre-commit update PRs were missing the "no releasenotes" label.

This workflow "label-precommit-prs.yml" file checks if a PR title includes "pre-commit autoupdate" and automatically applies the "no releasenotes" label. This ensures consistent labeling of automated PRs and improves release note handling.

Closes #[69]


<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--471.org.readthedocs.build/en/471/

<!-- readthedocs-preview causalpy end -->