### PR TITLE
Fix CI badge to properly reflect main branch status

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ----
 
-![Build Status](https://github.com/pymc-labs/CausalPy/workflows/ci/badge.svg?branch=main)
+<!-- ![Build Status](https://github.com/pymc-labs/CausalPy/workflows/ci/badge.svg?branch=main) -->
+![Build Status](https://github.com/pymc-labs/CausalPy/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/CausalPy.svg)](https://badge.fury.io/py/CausalPy)
 ![GitHub Repo stars](https://img.shields.io/github/stars/pymc-labs/causalpy?style=social)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ----
 
-<!-- ![Build Status](https://github.com/pymc-labs/CausalPy/workflows/ci/badge.svg?branch=main) -->
 ![Build Status](https://github.com/pymc-labs/CausalPy/actions/workflows/ci.yml/badge.svg?branch=main)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![PyPI version](https://badge.fury.io/py/CausalPy.svg)](https://badge.fury.io/py/CausalPy)


### PR DESCRIPTION
## Summary
Fixes the CI badge URL to properly display the status of the `main` branch only, resolving the issue introduced in #465.

## Changes
- Updated the CI badge URL from `/workflows/ci/badge.svg` to `/actions/workflows/ci.yml/badge.svg`
- This uses the correct GitHub Actions badge format that properly supports branch-specific status

## Problem Solved
- The previous badge URL format didn't reliably show main branch status
- Badge now consistently reflects CI status of the main branch, not random PR branches
- Prevents misleading "failing" status when experimental PRs have failing CI

## Testing
- Verified the new badge URL displays correctly
- Badge shows current main branch CI status (passing)

Closes #474 