### PR TITLE
Exclude causalpy/tests from code coverage

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,7 @@
 coverage:
+  ignore:
+    - "*/conftest.py"
+    - "*/tests/conftest.py"
   status:
     project:
       default:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,10 +72,6 @@ docs = [
 lint = ["interrogate", "pre-commit", "ruff"]
 test = ["pytest", "pytest-cov", "codespell", "nbformat", "nbconvert"]
 
-[metadata]
-description-file = 'README.md'
-license_files = 'LICENSE'
-
 [project.urls]
 Homepage = "https://github.com/pymc-labs/CausalPy"
 "Bug Reports" = "https://github.com/pymc-labs/CausalPy/issues"
@@ -130,3 +126,23 @@ extend-select = [
 [tool.codespell]
 ignore-words = "./docs/source/.codespell/codespell-whitelist.txt"
 skip = "*.ipynb,*.csv,pyproject.toml,docs/source/.codespell/codespell-whitelist.txt"
+
+[tool.coverage.run]
+omit = [
+    "*/conftest.py",
+    "*/tests/conftest.py",
+]
+
+[tool.coverage.report]
+exclude_lines = [
+    "pragma: no cover",
+    "def __repr__",
+    "if self.debug:",
+    "if settings.DEBUG",
+    "raise AssertionError",
+    "raise NotImplementedError",
+    "if 0:",
+    "if __name__ == .__main__.:",
+    "class .*\\bProtocol\\):",
+    "@(abc\\.)?abstractmethod",
+]


### PR DESCRIPTION
Closes #490 from @williambdean 

I vibe coded this, so could do with a close inspection.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--493.org.readthedocs.build/en/493/

<!-- readthedocs-preview causalpy end -->