### PR TITLE
Fix to minor bug in simulated data generation function

### DIFF
--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -125,12 +125,12 @@ def generate_time_series_data(
         The intercept
 
     """
-    x = np.arange(0, 100, 1)
+    x = np.arange(0, N, 1)
     df = pd.DataFrame(
         {
             "temperature": np.sin(x * 0.5) + 1,
-            "linear": np.linspace(0, 1, 100),
-            "causal effect": 10 * gamma(10).pdf(np.arange(0, 100, 1) - treatment_time),
+            "linear": np.linspace(0, 1, N),
+            "causal effect": 10 * gamma(10).pdf(np.arange(0, N, 1) - treatment_time),
         }
     )
 

--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -147,7 +147,9 @@ def generate_time_series_data(
     for var in ["deaths_actual", "temperature"]:
         df[var] += norm(0, 0.1).rvs(N)
 
-    # add intercept
+    # add intercept column of ones (for modeling purposes)
+    # This is correctly a column of ones, not beta_intercept, as beta_intercept
+    # is already incorporated in the data generation above
     df["intercept"] = np.ones(df.shape[0])
 
     return df


### PR DESCRIPTION
Closes #433

> P.S.: In the same function, should the input intercept (i.e. `beta_intercept`) in the output dataframe instead of the constant `1`

I believe the answer to this is "no". The `beta_intercept` input is being used in the data generation process, but the purpose of `df["intercept"] = np.ones(df.shape[0])` is to create input data for modelling where it's common to create a column of zeros. Though practically I think this is not needed or is even being used because it's being taken care of by `patsy` based on the user-provided model formula. But for the moment I've just added an explanatory comment.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--505.org.readthedocs.build/en/505/

<!-- readthedocs-preview causalpy end -->