### PR TITLE
Improve UML workflow branch and PR handling

### DIFF
--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -58,9 +58,18 @@ jobs:
       - name: Create PR for changes
         if: steps.changes.outputs.changes_exist == 'true'
         run: |
-          git checkout -b update-uml-diagrams
+          BRANCH_NAME="update-uml-diagrams"
+
+          # Delete the branch locally and remotely if it exists
+          git branch -D $BRANCH_NAME 2>/dev/null || true
+          git push origin --delete $BRANCH_NAME 2>/dev/null || true
+
+          # Create and push the new branch
+          git checkout -b $BRANCH_NAME
           git commit -m "Update UML Diagrams"
-          git push -u origin update-uml-diagrams
+          git push -u origin $BRANCH_NAME
+
+          # Create PR (will fail gracefully if PR already exists)
           gh pr create \
             --base main \
             --title "Update UML Diagrams" \
@@ -68,6 +77,6 @@ jobs:
             This PR was created automatically by the [UML workflow](https://github.com/pymc-labs/CausalPy/blob/main/.github/workflows/uml.yml).
             See the logs [here](https://github.com/pymc-labs/CausalPy/actions/workflows/uml.yml) for more details." \
             --label "no releasenotes" \
-            --reviewer drbenvincent
+            --reviewer drbenvincent || echo "PR may already exist"
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes the recurring failure in the UML diagram update workflow caused by existing branch conflicts.

The workflow was failing with "Updates were rejected because the remote contains work that you do not have locally" when the update-uml-diagrams branch already existed from a previous run.

Now deletes any existing branch (locally and remotely) before creating a new one, ensuring clean branch creation on each run. Also adds graceful handling if the PR already exists.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--581.org.readthedocs.build/en/581/

<!-- readthedocs-preview causalpy end -->