### PR TITLE
Update to next version of docs theme

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ version: 2
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.11"
+    python: "3.12"
     # You can also specify other tool versions:
     # nodejs: "16"
     # rust: "1.55"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -63,6 +63,7 @@ extensions = [
     "notfound.extension",
     "sphinx_copybutton",
     "sphinx_design",
+    "sphinx_sitemap",
     "sphinx_togglebutton",
 ]
 
@@ -134,11 +135,16 @@ myst_enable_extensions = [
     "html_admonition",
 ]
 
+# sitemap extension configuration
+site_url = "https://causalpy.readthedocs.io/"
+sitemap_url_scheme = f"{{lang}}{version}/{{link}}"
+
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
 html_theme = "labs_sphinx_theme"
 html_static_path = ["_static"]
+html_extra_path = ["robots.txt"]
 html_favicon = "_static/favicon_logo.png"
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -156,6 +162,7 @@ html_context = {
     "github_version": "main",
     "doc_path": "docs/source/",
     "default_mode": "light",
+    "baseurl": "https://causalpy.readthedocs.io/",
 }
 
 # -- Options for autodoc ----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -174,12 +174,3 @@ autodoc_typehints = "description"
 
 # Don't show class signature with the class' name.
 autodoc_class_signature = "separated"
-
-# Add "Edit on Github" link. Replaces "view page source" ----------------------
-html_context = {
-    "display_github": True,  # Integrate GitHub
-    "github_user": "pymc-labs",  # Username
-    "github_repo": "CausalPy",  # Repo name
-    "github_version": "master",  # Version
-    "conf_py_path": "/docs/source/",  # Path in the checkout to the docs root
-}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,7 +46,7 @@ version = release
 # The version info for the project you're documenting
 if os.environ.get("READTHEDOCS", False):
     rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
-    elif rtd_version.lower() == "latest":
+    if rtd_version.lower() == "latest":
         version = "dev"
 else:
     version = "local"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -43,6 +43,15 @@ copyright = f"2024, {author}"
 release = __version__
 version = release
 
+# The version info for the project you're documenting
+if os.environ.get("READTHEDOCS", False):
+    rtd_version = os.environ.get("READTHEDOCS_VERSION", "")
+    elif rtd_version.lower() == "latest":
+        version = "dev"
+else:
+    version = "local"
+    rtd_version = version
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
@@ -137,7 +146,7 @@ myst_enable_extensions = [
 
 # sitemap extension configuration
 site_url = "https://causalpy.readthedocs.io/"
-sitemap_url_scheme = f"{{lang}}{version}/{{link}}"
+sitemap_url_scheme = f"{{lang}}{rtd_version}/{{link}}"
 
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,0 +1,12 @@
+# Custom robots.txt file
+# It controls the crawling and indexing of your documentation by search engines.
+# Part of the configuration happens through readthedocs and part through extensions
+#
+# You can learn more about robots.txt, including how to customize it, in our rtd docs:
+#
+# * Our documentation on Robots.txt: https://docs.readthedocs.com/platform/stable/reference/robots.html
+# * Our guide about SEO techniques: https://docs.readthedocs.com/platform/stable/guides/technical-docs-seo-guide.html
+
+User-agent: *
+
+Sitemap: https://causalpy.readthedocs.io/en/stable/sitemap.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx_autodoc_defaultargs",
-    "labs-sphinx-theme",
+    "labs-sphinx-theme @ git+https://github.com/pymc-labs/labs-sphinx-theme@v016_update",
     "sphinx-copybutton",
     "sphinx-rtd-theme",
     "statsmodels",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ docs = [
     "labs-sphinx-theme @ git+https://github.com/pymc-labs/labs-sphinx-theme@v016_update",
     "sphinx-copybutton",
     "sphinx-rtd-theme",
+    "sphinx-sitemap",
     "statsmodels",
     "sphinxcontrib-bibtex",
     "sphinx-notfound-page",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ docs = [
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx_autodoc_defaultargs",
-    "labs-sphinx-theme @ git+https://github.com/pymc-labs/labs-sphinx-theme@v016_update",
+    "labs-sphinx-theme",
     "sphinx-copybutton",
     "sphinx-rtd-theme",
     "sphinx-sitemap",


### PR DESCRIPTION
Still not ready to merge, it currently uses the theme from GitHub to test nothing breaks
with the change in minor version. After checking I will make a release of the theme and revert
pyproject.toml


<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--593.org.readthedocs.build/en/593/

<!-- readthedocs-preview causalpy end -->