### PR TITLE
Add workflow to sync PR labels from closing issues

### DIFF
--- a/.github/workflows/pr-issue-label-sync.yml
+++ b/.github/workflows/pr-issue-label-sync.yml
@@ -11,9 +11,6 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
       - name: Sync labels from closing issues
         uses: williambdean/closing-labels@v0.0.6
         with:


### PR DESCRIPTION
Introduces a GitHub Actions workflow that synchronizes labels from issues closed by a pull request, excluding 'help wanted' and 'good first issue' labels. This helps maintain label consistency between issues and pull requests.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--601.org.readthedocs.build/en/601/

<!-- readthedocs-preview causalpy end -->