### PR TITLE
fix: add pip to environment.yml to prevent system pip fallback

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,6 @@ dependencies:
   - xarray>=v2022.11.0
   - pymc-extras>=0.3.0
   - pymc-bart
-  - python>=3.11
+  - python>=3.12
+  - pip
   - "marimo[mcp]"


### PR DESCRIPTION
## Summary

This PR fixes an issue where `conda env create -f environment.yml` would create an environment that uses the wrong `pip` executable, causing confusing installation errors.

## Problem

When setting up the development environment, users encountered this error:

```
ERROR: Package 'causalpy' requires a different Python: 3.10.16 not in '>=3.11'
```

This occurred even when the conda environment had Python 3.12+ installed. The root cause:

1. The `environment.yml` did not include `pip` as a dependency
2. Without pip in the conda environment, the shell falls back to the system pip (e.g., Homebrew's `/opt/homebrew/bin/pip` on macOS)
3. The system pip is linked to a different Python version (3.10), causing the version mismatch error

## Solution

1. **Added `pip` as an explicit dependency** - This ensures pip is installed within the conda environment and the correct pip is used
2. **Bumped minimum Python from 3.11 to 3.12** - Aligns with current development practices and ensures consistent solver behavior

## Testing

After this fix:
- `which pip` correctly shows `/path/to/mambaforge/envs/CausalPy/bin/pip`
- `pip install -e ".[test]"` works without version mismatch errors
- `make test` runs successfully



<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--632.org.readthedocs.build/en/632/

<!-- readthedocs-preview causalpy end -->