### PR TITLE
Add pre-commit hook to validate BibTeX files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,3 +67,11 @@ repos:
     rev: v0.24.1
     hooks:
       - id: validate-pyproject
+  - repo: local
+    hooks:
+      - id: validate-bibtex
+        name: Validate BibTeX files
+        entry: python -c "import sys; from pybtex.database.input import bibtex; parser = bibtex.Parser(); [parser.parse_file(f) for f in sys.argv[1:]]"
+        language: python
+        files: \.bib$
+        additional_dependencies: [pybtex]


### PR DESCRIPTION
## Summary

Adds a pre-commit hook to validate BibTeX (.bib) file syntax using `pybtex`.

## Motivation

A missing `}` in `docs/source/references.bib` caused the remote docs build to fail. This hook prevents such syntax errors from being committed by validating .bib files during pre-commit.

## Changes

- Added a local pre-commit hook (`validate-bibtex`) that uses `pybtex` to parse and validate .bib files
- The hook only runs on `.bib` files and will fail with an error message if there's a syntax issue

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--633.org.readthedocs.build/en/633/

<!-- readthedocs-preview causalpy end -->