### PR TITLE
Add welcome workflow for first-time contributors

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,7 +1,7 @@
 name: Welcome New Contributors
 
 on:
-  pull_request
+  pull_request:
     types: [opened]
   issues:
     types: [opened]

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,0 +1,59 @@
+name: Welcome New Contributors
+
+on:
+  pull_request_target:
+    types: [opened]
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  welcome:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-message: |
+            👋 **Welcome to CausalPy, @${{ github.actor }}!**
+
+            Thank you for opening your first issue! We appreciate you taking the time to post this.
+
+            Here are a few things that might help:
+            - 📖 Check out our [documentation](https://causalpy.readthedocs.io/)
+            - 💬 Feel free to ask questions - we're happy to help!
+            - 🐛 If this is a bug report, please ensure you've included steps to reproduce it
+
+            A maintainer will take a look soon. Thanks for being part of the CausalPy community! 🎉
+
+          pr-message: |
+            👋 **Welcome to CausalPy, @${{ github.actor }}!**
+
+            Thank you for opening your first pull request! We're excited to have you contribute to the project. 🎉
+
+            Here are a few tips to help your PR get merged smoothly:
+            - ✅ Make sure all CI checks pass (tests, linting, type checking)
+            - 📝 Run `pre-commit run --all-files` locally before pushing
+            - 📖 Check our [Contributing Guide](https://github.com/pymc-labs/CausalPy/blob/main/CONTRIBUTING.md) for more details
+
+            A maintainer will review your changes soon. Thanks for helping make CausalPy better! 🚀
+
+            ---
+
+            💼 **LinkedIn Shoutout**: Once your PR is merged, we'd love to give you a shoutout on LinkedIn to thank you for your contribution! If you're interested, just drop your LinkedIn profile URL in a comment below.
+
+      # Add label for first-time contributors on PRs
+      - name: Add first-time-contributor label
+        if: github.event_name == 'pull_request_target' && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['first-time-contributor']
+            });

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -46,8 +46,10 @@ jobs:
             💼 **LinkedIn Shoutout**: Once your PR is merged, we'd love to give you a shoutout on LinkedIn to thank you for your contribution! If you're interested, just drop your LinkedIn profile URL in a comment below.
 
       # Add label for first-time contributors on PRs
+      # FIRST_TIMER: never contributed to any GitHub repo
+      # FIRST_TIME_CONTRIBUTOR: contributed elsewhere but not to this repo
       - name: Add first-time-contributor label
-        if: github.event_name == 'pull_request_target' && github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+        if: github.event_name == 'pull_request_target' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -14,10 +14,10 @@ jobs:
   welcome:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/first-interaction@v1
+      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             👋 **Welcome to CausalPy, @${{ github.actor }}!**
 
             Thank you for opening your first issue! We appreciate you taking the time to post this.
@@ -29,7 +29,7 @@ jobs:
 
             A maintainer will take a look soon. Thanks for being part of the CausalPy community! 🎉
 
-          pr-message: |
+          pr_message: |
             👋 **Welcome to CausalPy, @${{ github.actor }}!**
 
             Thank you for opening your first pull request! We're excited to have you contribute to the project. 🎉
@@ -50,7 +50,7 @@ jobs:
       # FIRST_TIME_CONTRIBUTOR: contributed elsewhere but not to this repo
       - name: Add first-time-contributor label
         if: github.event_name == 'pull_request' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             await github.rest.issues.addLabels({

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,7 +1,7 @@
 name: Welcome New Contributors
 
 on:
-  pull_request_target:
+  pull_request
     types: [opened]
   issues:
     types: [opened]

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -49,7 +49,7 @@ jobs:
       # FIRST_TIMER: never contributed to any GitHub repo
       # FIRST_TIME_CONTRIBUTOR: contributed elsewhere but not to this repo
       - name: Add first-time-contributor label
-        if: github.event_name == 'pull_request_target' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
+        if: github.event_name == 'pull_request' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
         uses: actions/github-script@v7
         with:
           script: |


### PR DESCRIPTION
Adds a GitHub Action that automatically:

- Posts a welcome comment on first PRs and issues from new contributors
- Adds a `first-time-contributor` label to first-time PRs
- Includes a LinkedIn shoutout offer for merged contributions

Uses `actions/first-interaction` for welcome messages and `actions/github-script` for labeling.

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--636.org.readthedocs.build/en/636/

<!-- readthedocs-preview causalpy end -->