### PR TITLE
adding safety check for extreme propensity scores.

### DIFF
--- a/docs/source/notebooks/inv_prop_pymc.ipynb
+++ b/docs/source/notebooks/inv_prop_pymc.ipynb
@@ -24,6 +24,14 @@
                 "\n",
                 "We will use inverse propensity score weighting techniques to estimate the average treatment effect. There are a range of weighting techniques available: we have implemented `raw`, `robust`, `doubly robust` and `overlap` weighting schemes all of which aim to estimate the average treatment effect. The idea of a propensity score (very broadly) is to derive a one-number summary of individual's probability of adopting a particular treatment. This score is typically calculated by fitting a predictive logit model on all an individual's observed attributes predicting whether or not the those attributes drive the individual towards the treatment status. In the case of the NHEFS data we want a model to measure the propensity for each individual to quit smoking. \n",
                 "\n",
+                "> ### 🎯 Target Causal Estimands\n",
+                "> \n",
+                "> Propensity score weighting allows us to estimate different causal effects by changing the \"target population\" we are interested in. The choice of weight determines which estimand you are calculating:\n",
+                ">\n",
+                "> * **ATE (Average Treatment Effect):** Estimates the effect if the entire population were treated vs. the entire population being untreated. Targeted by the `make_raw_adjustments` and `make_robust_adjustments` methods.\n",
+                "> * **ATO (Average Treatment Effect among the Overlap):** Targeted by `make_overlap_adjustments`. This focuses on units with \"clinical equipoise\"—those who had a reasonable probability of being in either group. It is highly robust to outliers and eliminates the need for artificial clipping.\n",
+                "> * **Doubly Robust:** The `make_doubly_robust_adjustment` combines a propensity model and an outcome model. It targets the **ATE** but provides \"two chances\" to be correct: if *either* the propensity model or the outcome model is correctly specified, the estimate remains unbiased.\n",
+                "\n",
                 "The reason we want this propensity score is because with observed data we often have a kind of imbalance in our covariate profiles across treatment groups. Meaning our data might be unrepresentative in some crucial aspect. This prevents us cleanly reading off treatment effects by looking at simple group differences. These \"imbalances\" can be driven by selection effects into the treatment status so that if we want to estimate the average treatment effect in the population as a whole we need to be wary that our sample might not give us generalisable insight into the treatment differences. Using propensity scores as a measure of the prevalance to adopt the treatment status in the population, we can cleverly weight the observed data to privilege observations of \"rare\" occurrence in each group. For example, if smoking is the treatment status and regular running is generally not common among the group of smokers, then on the occasion we see a smoker marathon runner we should heavily weight their outcome measure to overcome their low prevalence in the treated group but real presence in the unmeasured population. Inverse propensity weighting tries to define weighting schemes are inversely proportional to an individual's propensity score so as to better recover an estimate which mitigates (somewhat) the risk of selection effect bias. For more details and illustration of these themes see the PyMC examples [write up](https://www.pymc.io/projects/examples/en/latest/causal_inference/bayesian_nonparametric_causal.html) on Non-Parametric Bayesian methods. {cite:p}`forde2024nonparam`\n"
             ]
         },
@@ -1178,7 +1186,7 @@
             "name": "python",
             "nbconvert_exporter": "python",
             "pygments_lexer": "ipython3",
-            "version": "3.11.9"
+            "version": "3.14.2"
         }
     },
     "nbformat": 4,


### PR DESCRIPTION
Just adding the suggested safety check to prevent the divide by 0 error, it's not really clipping in the sense where we clip to provide better estimates. Just creating a PR to see if the paper mill will run.

Aiming to deal with this error: https://github.com/pymc-labs/CausalPy/issues/645

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--649.org.readthedocs.build/en/649/

<!-- readthedocs-preview causalpy end -->