### PR TITLE
Docs: Rename How-to section to Examples and add method groupings

### DIFF
--- a/docs/source/notebooks/index.md
+++ b/docs/source/notebooks/index.md
@@ -1,6 +1,6 @@
 # Examples
 
-## Cross-sectional methods
+## Panel data methods
 
 :::{toctree}
 :caption: ANCOVA
@@ -8,41 +8,6 @@
 
 ancova_pymc.ipynb
 :::
-
-:::{toctree}
-:caption: Regression Discontinuity
-:maxdepth: 1
-
-rd_skl.ipynb
-rd_pymc.ipynb
-rd_pymc_drinking.ipynb
-:::
-
-:::{toctree}
-:caption: Regression Kink Design
-:maxdepth: 1
-
-rkink_pymc.ipynb
-:::
-
-:::{toctree}
-:caption: Instrumental Variables Regression
-:maxdepth: 1
-
-iv_pymc.ipynb
-iv_weak_instruments.ipynb
-iv_vs_priors.ipynb
-:::
-
-:::{toctree}
-:caption: Inverse Propensity Score Weighting
-:maxdepth: 1
-
-inv_prop_pymc.ipynb
-inv_prop_latent.ipynb
-:::
-
-## Panel data methods
 
 :::{toctree}
 :caption: Synthetic Control
@@ -87,4 +52,39 @@ its_lift_test.ipynb
 :maxdepth: 1
 
 its_pymc_comparative.ipynb
+:::
+
+## Cross-sectional methods
+
+:::{toctree}
+:caption: Regression Discontinuity
+:maxdepth: 1
+
+rd_skl.ipynb
+rd_pymc.ipynb
+rd_pymc_drinking.ipynb
+:::
+
+:::{toctree}
+:caption: Regression Kink Design
+:maxdepth: 1
+
+rkink_pymc.ipynb
+:::
+
+:::{toctree}
+:caption: Instrumental Variables Regression
+:maxdepth: 1
+
+iv_pymc.ipynb
+iv_weak_instruments.ipynb
+iv_vs_priors.ipynb
+:::
+
+:::{toctree}
+:caption: Inverse Propensity Score Weighting
+:maxdepth: 1
+
+inv_prop_pymc.ipynb
+inv_prop_latent.ipynb
 :::

--- a/docs/source/notebooks/index.md
+++ b/docs/source/notebooks/index.md
@@ -1,4 +1,6 @@
-# How-to
+# Examples
+
+## Cross-sectional methods
 
 :::{toctree}
 :caption: ANCOVA
@@ -6,6 +8,41 @@
 
 ancova_pymc.ipynb
 :::
+
+:::{toctree}
+:caption: Regression Discontinuity
+:maxdepth: 1
+
+rd_skl.ipynb
+rd_pymc.ipynb
+rd_pymc_drinking.ipynb
+:::
+
+:::{toctree}
+:caption: Regression Kink Design
+:maxdepth: 1
+
+rkink_pymc.ipynb
+:::
+
+:::{toctree}
+:caption: Instrumental Variables Regression
+:maxdepth: 1
+
+iv_pymc.ipynb
+iv_weak_instruments.ipynb
+iv_vs_priors.ipynb
+:::
+
+:::{toctree}
+:caption: Inverse Propensity Score Weighting
+:maxdepth: 1
+
+inv_prop_pymc.ipynb
+inv_prop_latent.ipynb
+:::
+
+## Panel data methods
 
 :::{toctree}
 :caption: Synthetic Control
@@ -50,37 +87,4 @@ its_lift_test.ipynb
 :maxdepth: 1
 
 its_pymc_comparative.ipynb
-:::
-
-:::{toctree}
-:caption: Regression Discontinuity
-:maxdepth: 1
-
-rd_skl.ipynb
-rd_pymc.ipynb
-rd_pymc_drinking.ipynb
-:::
-
-:::{toctree}
-:caption: Regression Kink Design
-:maxdepth: 1
-
-rkink_pymc.ipynb
-:::
-
-:::{toctree}
-:caption: Instrumental Variables Regression
-:maxdepth: 1
-
-iv_pymc.ipynb
-iv_weak_instruments.ipynb
-iv_vs_priors.ipynb
-:::
-
-:::{toctree}
-:caption: Inverse Propensity Score Weighting
-:maxdepth: 1
-
-inv_prop_pymc.ipynb
-inv_prop_latent.ipynb
 :::


### PR DESCRIPTION
## Summary

Rename the "How-to" documentation section to "Examples" and reorganize notebooks with subheadings for better navigation, aligning with PyMC and PyMC-Marketing documentation style.

Fixes #668

## Changes

- Renamed the main heading from "How-to" to "Examples"
- Added "Cross-sectional methods" subheading grouping:
  - ANCOVA
  - Regression Discontinuity
  - Regression Kink Design
  - Instrumental Variables Regression
  - Inverse Propensity Score Weighting
- Added "Panel data methods" subheading grouping:
  - Synthetic Control
  - Geographical lift testing
  - Difference in Differences
  - Interrupted Time Series
  - Comparative Interrupted Time Series

## Testing

- Pre-commit checks pass
- Documentation structure validated via markdown syntax checks
- ReadTheDocs CI will verify the documentation builds correctly

## Checklist

- [x] Pre-commit checks pass
- [x] All tests pass (documentation-only change)
- [x] Documentation updated
- [x] Follows project coding conventions


<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--678.org.readthedocs.build/en/678/

<!-- readthedocs-preview causalpy end -->