### PR TITLE
Update AGENTS backwards compatibility guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@
 - **Formulas**: Use patsy for formula parsing (via `dmatrices()`)
 - **Custom exceptions**: Use project-specific exceptions from `causalpy.custom_exceptions`: `FormulaException`, `DataException`, `BadIndexException`
 - **File organization**: Experiments in `causalpy/experiments/`, PyMC models in `causalpy/pymc_models.py`, scikit-learn models in `causalpy/skl_models.py`
+- **Backwards compatibility**: Avoid preserving backwards compatibility for API elements introduced within the same PR; only maintain compatibility for previously released APIs.
 
 ## Code quality checks
 


### PR DESCRIPTION
## Summary

Clarify that backwards compatibility should only be preserved for released APIs, not for APIs introduced within the same PR.

Fixes #684

## Changes

- Document the backwards compatibility guidance in `AGENTS.md`.

## Testing

- Not run (documentation-only change).

## Checklist

- [ ] Pre-commit checks pass
- [ ] All tests pass
- [ ] Documentation updated (if applicable)
- [x] Follows project coding conventions

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--686.org.readthedocs.build/en/686/

<!-- readthedocs-preview causalpy end -->