### PR TITLE
Add zizmor GHA security linter and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels:
+      - "devops"
+      - "no releasenotes"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,7 @@ updates:
     labels:
       - "devops"
       - "no releasenotes"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,15 +6,21 @@ on:
   push:
     branches: [main]
 
+permissions: {}
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.11", "3.14"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: ["3.11", "3.14"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Update pip and setuptools
@@ -34,7 +34,7 @@ jobs:
           python ./docs/source/.codespell/notebook_to_markdown.py --tempdir tmp_markdown
           codespell
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
           name: ${{ matrix.python-version }}

--- a/.github/workflows/label-precommit-prs.yml
+++ b/.github/workflows/label-precommit-prs.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions: {}
+
 jobs:
   label:
     if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'

--- a/.github/workflows/label-precommit-prs.yml
+++ b/.github/workflows/label-precommit-prs.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Add "no releasenotes" label
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1.1.3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           labels: no releasenotes

--- a/.github/workflows/label-precommit-prs.yml
+++ b/.github/workflows/label-precommit-prs.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   label:
-    if: github.actor == 'pre-commit-ci[bot]'
+    if: github.event.pull_request.user.login == 'pre-commit-ci[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write

--- a/.github/workflows/pr-issue-label-sync.yml
+++ b/.github/workflows/pr-issue-label-sync.yml
@@ -4,11 +4,14 @@ on:
   pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited]
 
+permissions: {}
+
 jobs:
   sync:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: read  # to read labels from linked issues
 
     steps:
       - name: Sync labels from closing issues

--- a/.github/workflows/pr-issue-label-sync.yml
+++ b/.github/workflows/pr-issue-label-sync.yml
@@ -1,7 +1,7 @@
 name: "PR Issue Label Sync"
 
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types: [opened, edited]
 
 jobs:

--- a/.github/workflows/pr-issue-label-sync.yml
+++ b/.github/workflows/pr-issue-label-sync.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Sync labels from closing issues
-        uses: williambdean/closing-labels@v0.0.6
+        uses: williambdean/closing-labels@7a4384e0e725b80eee0142265d36c1332fda5f7a # v0.0.6
         with:
           exclude: "help wanted,good first issue"
           respect_unlabeled: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,10 +14,10 @@ jobs:
     name: Build source distribution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
       - name: Build the sdist and the wheel
@@ -43,7 +43,7 @@ jobs:
           echo "Checking import and version number (on release)"
           venv-bdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{ github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: artifact
           path: dist/*
@@ -56,15 +56,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0
         with:
           skip_existing: true
           repository_url: https://test.pypi.org/legacy/
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
       - name: Test pip install from test.pypi
@@ -86,8 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release' && github.event.action == 'published'
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: artifact
           path: dist
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e # v1.13.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,14 +9,19 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   build:
     name: Build source distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: 3.11
@@ -32,8 +37,11 @@ jobs:
           python -m venv venv-sdist
           venv-sdist/bin/python -m pip install ../dist/causalpy*.tar.gz
           echo "Checking import and version number (on release)"
-          venv-sdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{ github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
+          venv-sdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${REF_NAME}' if '${REF_TYPE}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
       - name: Check the bdist installs and imports
         run: |
           mkdir -p test-bdist
@@ -41,8 +49,11 @@ jobs:
           python -m venv venv-bdist
           venv-bdist/bin/python -m pip install ../dist/causalpy*.whl
           echo "Checking import and version number (on release)"
-          venv-bdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${{ github.ref_name }}' if '${{ github.ref_type }}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
+          venv-bdist/bin/python -c "import causalpy; assert causalpy.__version__ == '${REF_NAME}' if '${REF_TYPE}' == 'tag' else causalpy.__version__; print(causalpy.__version__)"
           cd ..
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: artifact
@@ -75,7 +86,9 @@ jobs:
           python -m venv venv-test-pypi
           venv-test-pypi/bin/python -m pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple causalpy
           echo "Checking import and version number"
-          venv-test-pypi/bin/python -c "import causalpy; assert causalpy.__version__ == '${{ github.ref_name }}'"
+          venv-test-pypi/bin/python -c "import causalpy; assert causalpy.__version__ == '${REF_NAME}'"
+        env:
+          REF_NAME: ${{ github.ref_name }}
 
   publish:
     environment: release

--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -11,6 +11,6 @@ jobs:
   documentation-links:
     runs-on: ubuntu-latest
     steps:
-      - uses: readthedocs/actions/preview@v1
+      - uses: readthedocs/actions/preview@b8bba1484329bda1a3abe986df7ebc80a8950333 # v1.5
         with:
           project-slug: "causalpy"

--- a/.github/workflows/rtd-link-preview.yml
+++ b/.github/workflows/rtd-link-preview.yml
@@ -1,6 +1,7 @@
 name: Read the Docs Pull Request Preview
+
 on:
-  pull_request_target:
+  pull_request_target: # zizmor: ignore[dangerous-triggers]
     types:
       - opened
 

--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -11,12 +11,12 @@ jobs:
     steps:
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 

--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -7,13 +7,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: write # to push branches
+      pull-requests: write # to create PRs
     steps:
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: main
+          persist-credentials: true # needed for git push
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron:  '0 12 * * 1'
 
+permissions: {}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions: {}
+
 jobs:
   zizmor:
     name: zizmor latest via PyPI

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,36 @@
+# https://github.com/woodruffw/zizmor
+name: zizmor GHA analysis
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  zizmor:
+    name: zizmor latest via PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: hynek/setup-cached-uv@757bedc3f972eb7227a1aa657651f15a8527c817 # v2.3.0
+
+      - name: Run zizmor 🌈
+        run: uvx zizmor --format sarif . > results.sarif
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@19b2f06db2b6f5108140aeb04014ef02b648f789 # v4.31.11
+        with:
+          # Path to SARIF file relative to the root of the repository
+          sarif_file: results.sarif
+          # Optional category for the results
+          # Used to differentiate multiple results for one commit
+          category: zizmor


### PR DESCRIPTION
## Summary

- Add zizmor GitHub Action to scan workflows for security vulnerabilities
- Add Dependabot configuration for automated GitHub Actions updates with 7-day cooldown
- Fix all zizmor security findings in existing workflows:
  - Add explicit permissions blocks to restrict GITHUB_TOKEN scope
  - Add `persist-credentials: false` to checkout actions
  - Fix spoofable bot actor check in label-precommit-prs.yml
  - Fix template injection in release.yml using environment variables
  - Replace `write-all` with scoped permissions in uml.yml

## Test plan

- [ ] Verify zizmor GHA runs successfully on this PR
- [ ] Verify CI workflow still passes
- [ ] Verify release workflow still works (manual test on next release)

<!-- readthedocs-preview causalpy start -->
----
📚 Documentation preview 📚: https://causalpy--687.org.readthedocs.build/en/687/

<!-- readthedocs-preview causalpy end -->