### PR TITLE
Fix custom exceptions to preserve messages

### DIFF
--- a/causalpy/custom_exceptions.py
+++ b/causalpy/custom_exceptions.py
@@ -21,6 +21,7 @@ class BadIndexException(Exception):
     index and an event, typically a treatment or intervention."""
 
     def __init__(self, message: str):
+        super().__init__(message)
         self.message = message
 
 
@@ -29,6 +30,7 @@ class FormulaException(Exception):
     formula"""
 
     def __init__(self, message: str):
+        super().__init__(message)
         self.message = message
 
 
@@ -36,4 +38,5 @@ class DataException(Exception):
     """Exception raised given when there is some error in user-provided dataframe"""
 
     def __init__(self, message: str):
+        super().__init__(message)
         self.message = message

--- a/causalpy/tests/test_custom_exceptions.py
+++ b/causalpy/tests/test_custom_exceptions.py
@@ -1,0 +1,34 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import pytest
+
+from causalpy.custom_exceptions import (
+    BadIndexException,
+    DataException,
+    FormulaException,
+)
+
+
+@pytest.mark.parametrize(
+    ("exc_type", "message"),
+    [
+        (BadIndexException, "Index type mismatch"),
+        (FormulaException, "Invalid formula provided"),
+        (DataException, "Dataset is missing required columns"),
+    ],
+)
+def test_custom_exceptions_preserve_message(exc_type, message):
+    exc = exc_type(message)
+    assert str(exc) == message
+    assert exc.message == message


### PR DESCRIPTION
## Summary
- Call `super().__init__(message)` in custom exceptions while preserving `self.message`.
- Add regression tests for exception string rendering.

## Testing
- `conda run -n CausalPy python -m pytest` (fails: PyTensor compiledir permission error)
- `PYTENSOR_FLAGS="compiledir=/tmp/pytensor" conda run -n CausalPy python -m pytest` (timed out at 120s)

Closes #665
