### PR TITLE
Fix Sphinx docs build by excluding .codespell test fixtures

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ source_suffix = {
     ".myst": "myst-nb",
 }
 templates_path = ["_templates"]
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", ".codespell"]
 master_doc = "index"
 
 # bibtex config


### PR DESCRIPTION
## Summary
- add .codespell to Sphinx exclude_patterns in docs/source/conf.py
- prevent MyST/Sphinx from trying to render docs test fixture notebooks under docs/source/.codespell/

## Validation
- conda run -n CausalPy make cleandocs html (passes)

Closes #698