### PR TITLE
Modernize conda/mamba/micromamba instructions

### DIFF
--- a/.cursor/rules/basic.mdc
+++ b/.cursor/rules/basic.mdc
@@ -5,4 +5,4 @@ You will act as helpful assistant in the causalpy library, and help the user in 
 
 **Important:**
 - If you modify a file with marimo, always check and run your mcp to validate active sessions and if the code is active validate your changes are working.
-- If you are modifying code from causalpy core code then activate conda env `CausalPy`, and run pre-commit every time you create or modify a file.
+- If you are modifying code from causalpy core code, run commands in the `CausalPy` environment via `$CONDA_EXE run -n CausalPy <command>` (see AGENTS.md for CONDA_EXE detection), and run pre-commit every time you create or modify a file.

--- a/.github/skills/python-environment/SKILL.md
+++ b/.github/skills/python-environment/SKILL.md
@@ -54,4 +54,9 @@ $CONDA_EXE env update --file environment.yml --prune
 
 ## Troubleshooting
 
-If you hit issues with an outdated `mamba` or `micromamba`, you can self-update: `$CONDA_EXE self-update`. As of 2026-02-13, current versions are conda 26.1.0, mamba/micromamba 2.5.0.
+If you hit issues with an outdated tool, update it:
+
+- **mamba / micromamba**: `$CONDA_EXE self-update`
+- **conda**: `conda update -n base conda`
+
+As of 2026-02-13, current versions are conda 26.1.0, mamba/micromamba 2.5.0.

--- a/.github/skills/python-environment/SKILL.md
+++ b/.github/skills/python-environment/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: python-environment
+description: Detect and configure a conda-compatible tool, create the CausalPy environment, and run commands inside it. Use before any task that requires Python execution.
+---
+
+# Python Environment
+
+Set up and run commands inside the CausalPy conda environment.
+
+## Detect the conda tool
+
+Use whichever of `mamba`, `micromamba`, or `conda` is available (checked in that order):
+
+```bash
+# Check for mamba, micromamba, or conda (in preference order) on $PATH
+CONDA_EXE=$(for c in mamba micromamba conda; do command -v "$c" &>/dev/null && echo "$c" && break; done)
+```
+
+If `CONDA_EXE` is empty, no conda-compatible tool was found. Propose installing micromamba to the user:
+
+```bash
+"${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+```
+
+After installation, set `CONDA_EXE=micromamba`.
+
+## Create the environment
+
+```bash
+$CONDA_EXE env create -f environment.yml
+```
+
+## Install the package (required after creating or updating the environment)
+
+```bash
+$CONDA_EXE run -n CausalPy make setup
+```
+
+## Run commands
+
+Always use `run -n` instead of `activate`:
+
+```bash
+$CONDA_EXE run -n CausalPy <command>
+```
+
+For example: `$CONDA_EXE run -n CausalPy pytest`, `$CONDA_EXE run -n CausalPy pre-commit run --all-files`.
+
+## Update an existing environment
+
+```bash
+$CONDA_EXE env update --file environment.yml --prune
+```
+
+## Troubleshooting
+
+If you hit issues with an outdated `mamba` or `micromamba`, you can self-update: `$CONDA_EXE self-update`. As of 2026-02-13, current versions are conda 26.1.0, mamba/micromamba 2.5.0.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,8 +2,9 @@
 
 ## Environment
 
-- Before running Python-related commands (e.g., `python`, `pytest`, `pre-commit`, `ruff`, `mypy`), activate the conda environment: `source ~/mambaforge/etc/profile.d/conda.sh && conda activate CausalPy`
-- If shell activation is not available or unreliable, run commands via `conda run -n CausalPy ...` instead.
+Use `mamba`, `micromamba`, or `conda` (in that preference order) to manage the `CausalPy` environment. Always run commands via `$CONDA_EXE run -n CausalPy <command>` -- never use `$CONDA_EXE activate`.
+
+See the [python-environment skill](.github/skills/python-environment/SKILL.md) for full setup instructions: tool detection, environment creation, editable install, and troubleshooting.
 
 ## Testing preferences
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,16 +25,31 @@ CausalPy welcomes contributions from interested individuals or groups. These gui
 
 ## Quick Start
 
-After forking this repository on GitHub, get up and running in 4 commands:
+After forking this repository on GitHub, get up and running in a few commands.
+
+Throughout this guide, `conda` is used as a placeholder -- you can substitute `mamba` or `micromamba` in any command. If none are installed, install micromamba:
+
+```bash
+"${SHELL}" <(curl -L micro.mamba.pm/install.sh)
+```
+
+Then:
 
 ```bash
 git clone git@github.com:<your-github-handle>/CausalPy.git && cd CausalPy
-mamba env create -f environment.yml
-conda activate CausalPy
-make setup  # Installs package + all dev dependencies + pre-commit hooks
+conda env create -f environment.yml
+conda run -n CausalPy make setup  # Installs package + all dev dependencies + pre-commit hooks
 ```
 
-Verify everything works:
+For interactive development, either activate the environment or drop into a subshell:
+
+```bash
+conda activate CausalPy
+# or
+conda run -n CausalPy bash  # no shell init needed
+```
+
+From there, all commands run inside the `CausalPy` environment without prefixing each one. Verify everything works:
 
 ```bash
 make test
@@ -92,11 +107,10 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
 
    Always use a feature branch. It's good practice to never routinely work on the `main` branch of any repository.
 
-1. Create the environment from the `environment.yml` file and activate it:
+1. Create the environment from the `environment.yml` file (remember, `conda` can be substituted with `mamba` or `micromamba`):
 
     ```bash
-    mamba env create -f environment.yml
-    conda activate CausalPy
+    conda env create -f environment.yml
     ```
 
     To update an existing environment after changes to `environment.yml`:
@@ -105,10 +119,20 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
     conda env update --file environment.yml --prune
     ```
 
+    For interactive development, either activate the environment or drop into a subshell:
+
+    ```bash
+    conda activate CausalPy
+    # or
+    conda run -n CausalPy bash  # no shell init needed
+    ```
+
+    Either way, subsequent commands run inside the environment without prefixing each one. You can also prefix individual commands with `conda run -n CausalPy` if you prefer.
+
 1. Install the package and all development dependencies using the automated setup:
 
     ```bash
-    make setup
+    conda run -n CausalPy make setup
     ```
 
     This single command:
@@ -121,7 +145,7 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
 	If you are editing or writing new examples in the form of Jupyter notebooks, you may have to run the following command to make Jupyter Lab aware of the `CausalPy` environment.
 
 	```bash
-	python -m ipykernel install --user --name CausalPy
+	conda run -n CausalPy python -m ipykernel install --user --name CausalPy
 	```
 
 1. You can then work on your changes locally, in your feature branch. Add changed files using `git add` and then `git commit` files:

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ PACKAGE_DIR = causalpy
 init: ## Install the package in editable mode
 	python -m pip install -e . --no-deps
 
-setup: ## Set up complete dev environment (run after conda activate CausalPy)
+setup: ## Set up complete dev environment (run inside CausalPy env, e.g. conda run -n CausalPy make setup)
 	python -m pip install --no-deps -e .
 	python -m pip install -e '.[dev,docs,test,lint]'
 	pre-commit install

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -1717,7 +1717,7 @@ class StateSpaceTimeSeries(PyMCModel):
             except ImportError as err:
                 raise ImportError(
                     "StateSpaceTimeSeries requires pymc-extras when default trend component is used. "
-                    "Install it with `conda install -c conda-forge pymc-extras`."
+                    "Install it with `conda/mamba/micromamba install -c conda-forge pymc-extras`."
                 ) from err
             self._trend_component = st.LevelTrendComponent(order=self.level_order)
         return self._trend_component
@@ -1734,7 +1734,7 @@ class StateSpaceTimeSeries(PyMCModel):
             except ImportError as err:
                 raise ImportError(
                     "StateSpaceTimeSeries requires pymc-extras when default seasonality component is used. "
-                    "Install it with `conda install -c conda-forge pymc-extras`."
+                    "Install it with `conda/mamba/micromamba install -c conda-forge pymc-extras`."
                 ) from err
             self._seasonality_component = st.FrequencySeasonality(
                 season_length=self.seasonal_length, name="freq"

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -16,10 +16,10 @@ To get the latest release you can use pip:
 pip install CausalPy
 ```
 
-or conda:
+or conda/mamba/micromamba:
 
 ```bash
-conda install causalpy -c conda-forge
+conda install causalpy -c conda-forge    # or mamba/micromamba
 ```
 
 Alternatively, if you want the very latest version of the package you can install from GitHub:

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - arviz>=0.14.0
   - graphviz
+  - make
   - ipython!=8.7.0
   - matplotlib>=3.5.3
   - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - numpy
   - pandas
   - patsy
+  - pre-commit
   - pymc>=5.15.1
   - scikit-learn>=1
   - scipy


### PR DESCRIPTION
## Summary

- Replace hardcoded `mambaforge` paths and `conda activate` with tool-agnostic instructions supporting `conda`, `mamba`, or `micromamba`
- Add a new `python-environment` skill as the single source of truth for environment setup (tool detection, env creation, editable install, `run -n` usage)
- AGENTS.md and `.cursor/rules/basic.mdc` now link to the skill instead of duplicating instructions
- CONTRIBUTING.md uses plain `conda` as a generic placeholder, offers both `activate` and subshell workflows for interactive development, and includes micromamba install as a fallback
- Update installation docs and error messages to mention all three tools

Made with [Cursor](https://cursor.com)