### PR TITLE
Fix invalid escape sequence warnings in variable_selection_priors.py

### DIFF
--- a/causalpy/variable_selection_priors.py
+++ b/causalpy/variable_selection_priors.py
@@ -60,7 +60,7 @@ def _relaxed_bernoulli_transform(
 
 
 class SpikeAndSlabPrior:
-    """
+    r"""
     Spike-and-slab prior using pymc-extras Prior class.
 
     Creates a mixture prior with a point mass at zero (spike) and a diffuse
@@ -141,7 +141,7 @@ class SpikeAndSlabPrior:
 
 
 class HorseshoePrior:
-    """
+    r"""
     Regularized horseshoe prior using pymc-extras Prior class.
 
     Provides continuous shrinkage with heavy tails, allowing strong signals


### PR DESCRIPTION
## Summary
- Use raw docstrings (`r"""`) for `SpikeAndSlabPrior` and `HorseshoePrior` so that LaTeX math markup (e.g. `\beta`, `\cdot`, `\lambda`) is not misinterpreted as Python escape sequences.
- Fixes `SyntaxWarning: "\c" is an invalid escape sequence` (and similar) which will become errors in future Python versions.

## Test plan
- [x] `pre-commit run --all-files` passes
- [ ] CI passes

Made with [Cursor](https://cursor.com)