### PR TITLE
Add Agent-related category to auto-generated release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -21,6 +21,9 @@ changelog:
     - title: Documentation 📖
       labels:
         - documentation
+    - title: Agent-related 🤖
+      labels:
+        - agents
     - title: Maintenance 🔧
       labels:
         - "*"


### PR DESCRIPTION
Adds an "Agent-related" category to `.github/release.yml` so PRs labeled `agents` appear under that heading when generating release notes. The `agents` label has been renamed on the repo accordingly.

Made with [Cursor](https://cursor.com)