### PR TITLE
Support datetime treatment_time in SyntheticControl plots

### DIFF
--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -281,6 +281,18 @@ class SyntheticControl(BaseExperiment):
             print(f"Treated unit: {self.treated_units[0]}")
         self.print_coefficients(round_to)
 
+    @staticmethod
+    def _convert_treatment_time_for_axis(
+        axis: plt.Axes, treatment_time: int | float | pd.Timestamp
+    ) -> int | float | pd.Timestamp:
+        """
+        Convert treatment time into the plotting units expected by a specific axis.
+        """
+        try:
+            return axis.xaxis.convert_units(treatment_time)
+        except (TypeError, ValueError):
+            return treatment_time
+
     def _bayesian_plot(
         self,
         round_to: int | None = None,
@@ -402,8 +414,11 @@ class SyntheticControl(BaseExperiment):
 
         # Intervention line
         for i in [0, 1, 2]:
+            treatment_time = self._convert_treatment_time_for_axis(
+                ax[i], self.treatment_time
+            )
             ax[i].axvline(
-                x=self.treatment_time,
+                x=treatment_time,
                 ls="-",
                 lw=3,
                 color="r",
@@ -528,10 +543,13 @@ class SyntheticControl(BaseExperiment):
             label="Causal impact",
         )
 
-        # Intervention line (see #725 for datetime treatment_time support)
+        # Intervention line
         for i in [0, 1, 2]:
+            treatment_time = self._convert_treatment_time_for_axis(
+                ax[i], self.treatment_time
+            )
             ax[i].axvline(
-                x=self.treatment_time,
+                x=treatment_time,
                 ls="-",
                 lw=3,
                 color="r",

--- a/causalpy/tests/test_integration_skl_examples.py
+++ b/causalpy/tests/test_integration_skl_examples.py
@@ -175,6 +175,31 @@ def test_sc():
 
 
 @pytest.mark.integration
+def test_sc_datetime_treatment_time_plot():
+    """Test SyntheticControl plotting with datetime treatment_time and sklearn model."""
+    df = (
+        cp.load_data("geolift1")
+        .assign(time=lambda x: pd.to_datetime(x["time"]))
+        .set_index("time")
+    )
+    treatment_time = pd.to_datetime("2022-01-01")
+
+    result = cp.SyntheticControl(
+        df,
+        treatment_time,
+        control_units=["Austria", "Belgium", "Bulgaria", "Croatia", "Cyprus"],
+        treated_units=["Denmark"],
+        model=cp.skl_models.WeightedProportion(),
+    )
+
+    fig, ax = result.plot()
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, np.ndarray) and all(
+        isinstance(item, plt.Axes) for item in ax
+    ), "ax must be a numpy.ndarray of plt.Axes"
+
+
+@pytest.mark.integration
 def test_rd_linear_main_effects():
     """
     Test Regression Discontinuity scikit-learn experiment main effects.

--- a/causalpy/tests/test_integration_skl_examples.py
+++ b/causalpy/tests/test_integration_skl_examples.py
@@ -199,6 +199,25 @@ def test_sc_datetime_treatment_time_plot():
     ), "ax must be a numpy.ndarray of plt.Axes"
 
 
+@pytest.mark.parametrize("error_type", [TypeError, ValueError])
+def test_sc_convert_treatment_time_for_axis_fallback(error_type):
+    """Return original treatment_time when axis conversion raises."""
+
+    class FailingXAxis:
+        def convert_units(self, _value):
+            raise error_type("conversion failed")
+
+    class FailingAxis:
+        xaxis = FailingXAxis()
+
+    treatment_time = pd.Timestamp("2022-01-01")
+    converted = cp.SyntheticControl._convert_treatment_time_for_axis(
+        FailingAxis(), treatment_time
+    )
+
+    assert converted is treatment_time
+
+
 @pytest.mark.integration
 def test_rd_linear_main_effects():
     """


### PR DESCRIPTION
## Summary
- convert `SyntheticControl` intervention line positions through each axis unit converter so datetime and numeric `treatment_time` values both render correctly
- apply the fix in both Bayesian and OLS plotting paths
- add an sklearn integration regression test for datetime-index synthetic control plotting

Fixes #725

## Test plan
- [x] `CONDA_EXE=$(for c in mamba micromamba conda; do command -v \"$c\" >/dev/null 2>&1 && echo \"$c\" && break; done) && \"$CONDA_EXE\" run -n CausalPy pytest --no-cov causalpy/tests/test_integration_skl_examples.py -k \"test_sc or test_sc_datetime_treatment_time_plot\"`
- [x] `CONDA_EXE=$(for c in mamba micromamba conda; do command -v \"$c\" >/dev/null 2>&1 && echo \"$c\" && break; done) && \"$CONDA_EXE\" run -n CausalPy pre-commit run --all-files`

Made with [Cursor](https://cursor.com)