### PR TITLE
Update issue-to-pr skill

### DIFF
--- a/.cursor/commands/issue-to-pr.md
+++ b/.cursor/commands/issue-to-pr.md
@@ -1,3 +1,4 @@
 # Issue to Pull Request
 
-This command points to the `pr-workflows` Skill in `.github/skills/pr-workflows/`. Specifically, see `.github/skills/pr-workflows/reference/issue-to-pr.md`.
+This command points to the `pr-workflows` Skill in
+`.github/skills/pr-workflows/`. Specifically, see `.github/skills/pr-workflows/reference/issue-to-pr.md`.

--- a/.cursor/commands/issue-to-pr.md
+++ b/.cursor/commands/issue-to-pr.md
@@ -1,0 +1,3 @@
+# Issue to Pull Request
+
+This command points to the `pr-workflows` Skill in `.github/skills/pr-workflows/`. Specifically, see `.github/skills/pr-workflows/reference/issue-to-pr.md`.

--- a/.cursor/commands/issue2pr.md
+++ b/.cursor/commands/issue2pr.md
@@ -1,4 +1,3 @@
 # Issue to Pull Request
 
-This command points to the `pr-workflows` Skill in
-`.github/skills/pr-workflows/` (issue → PR workflow).
+This command points to the `pr-workflows` Skill in `.github/skills/pr-workflows/`. Specifically .github/skills/pr-workflows/reference/issue-to-pr.md

--- a/.cursor/commands/issue2pr.md
+++ b/.cursor/commands/issue2pr.md
@@ -1,3 +1,0 @@
-# Issue to Pull Request
-
-This command points to the `pr-workflows` Skill in `.github/skills/pr-workflows/`. Specifically .github/skills/pr-workflows/reference/issue-to-pr.md

--- a/.github/skills/pr-workflows/reference/issue-to-pr.md
+++ b/.github/skills/pr-workflows/reference/issue-to-pr.md
@@ -5,6 +5,12 @@ description: Transform a GitHub issue into a complete pull request through a str
 
 # Issue → PR Workflow
 
+## Branch preflight (required before any code edits)
+1. Check current branch and working tree state.
+2. Switch to `main` and update it from remote.
+3. Create the issue branch from `main`: `git checkout -b issue-<number>-<short-description>`
+4. Only start implementation after confirming the new branch is based on `main`.
+
 ## Discovery
 1. Fetch issue details:
    ```bash
@@ -14,9 +20,8 @@ description: Transform a GitHub issue into a complete pull request through a str
 3. Estimate complexity and share approach before implementation.
 
 ## Implementation
-1. Create a branch: `git checkout -b issue-<number>-<short-description>`
-2. Implement the fix, following `AGENTS.md` policies.
-3. Run pre-commit and tests until green (see `pre-commit.md`).
+1. Implement the fix, following `AGENTS.md` policies.
+2. Run pre-commit and tests until green (see `pre-commit.md`).
 
 ## Prepare PR
 1. Create `.github/pr_summaries/<issue_number> - <short-description>.md` with:

--- a/.github/skills/pr-workflows/reference/issue-to-pr.md
+++ b/.github/skills/pr-workflows/reference/issue-to-pr.md
@@ -8,7 +8,7 @@ description: Transform a GitHub issue into a complete pull request through a str
 ## Branch preflight (required before any code edits)
 1. Check current branch and working tree state.
 2. Switch to `main` and update it from remote.
-3. Create the issue branch from `main`: `git checkout -b issue-<number>-<short-description>`
+3. Create the issue branch from `main`: `git checkout -b issue-<issue_number>-<short-description>`
 4. Only start implementation after confirming the new branch is based on `main`.
 
 ## Discovery
@@ -35,6 +35,6 @@ description: Transform a GitHub issue into a complete pull request through a str
 
 ## Create PR
 ```bash
-git push -u origin issue-<number>-<short-description>
+git push -u origin issue-<issue_number>-<short-description>
 gh pr create --title "<PR title>" --body-file .github/pr_summaries/<issue_number> - <short-description>.md --base main
 ```


### PR DESCRIPTION
## Summary
- add an explicit branch preflight section to the issue-to-pr workflow requiring branch creation from `main` before any code edits
- update the implementation section to assume branch creation already happened in preflight
- rename the Cursor command from `issue2pr` to `issue-to-pr` and point it to `.github/skills/pr-workflows/reference/issue-to-pr.md`

## Test plan
- [x] `CONDA_EXE=$(for c in mamba micromamba conda; do command -v \"$c\" >/dev/null 2>&1 && echo \"$c\" && break; done) && \"$CONDA_EXE\" run -n CausalPy pre-commit run --files .cursor/commands/issue-to-pr.md .github/skills/pr-workflows/reference/issue-to-pr.md`