### PR TITLE
Add pipeline workflow documentation

### DIFF
--- a/docs/source/notebooks/pipeline_workflow.ipynb
+++ b/docs/source/notebooks/pipeline_workflow.ipynb
@@ -1,0 +1,213 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Pipeline Workflow\n",
+    "\n",
+    "CausalPy provides a composable pipeline API that chains causal inference steps into a single, reproducible workflow. Instead of manually calling experiment construction, sensitivity analysis, and report generation separately, you can define them as steps in a pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sklearn.linear_model import LinearRegression\n",
+    "\n",
+    "import causalpy as cp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Manual approach (before pipeline)\n",
+    "\n",
+    "Traditionally, a CausalPy analysis involves several sequential steps:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (\n",
+    "    cp.load_data(\"its\")\n",
+    "    .assign(date=lambda x: pd.to_datetime(x[\"date\"]))\n",
+    "    .set_index(\"date\")\n",
+    ")\n",
+    "treatment_time = pd.to_datetime(\"2017-01-01\")\n",
+    "\n",
+    "model = cp.create_causalpy_compatible_class(LinearRegression())\n",
+    "\n",
+    "# Step 1: Fit the experiment\n",
+    "result = cp.InterruptedTimeSeries(\n",
+    "    df,\n",
+    "    treatment_time,\n",
+    "    formula=\"y ~ 1 + t\",\n",
+    "    model=model,\n",
+    ")\n",
+    "\n",
+    "# Step 2: Get effect summary\n",
+    "summary = result.effect_summary()\n",
+    "print(summary.text)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pipeline approach\n",
+    "\n",
+    "The pipeline wraps these steps into a single, declarative workflow. Each step is configured upfront, and the pipeline validates everything before running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (\n",
+    "    cp.load_data(\"its\")\n",
+    "    .assign(date=lambda x: pd.to_datetime(x[\"date\"]))\n",
+    "    .set_index(\"date\")\n",
+    ")\n",
+    "\n",
+    "result = cp.Pipeline(\n",
+    "    data=df,\n",
+    "    steps=[\n",
+    "        cp.EstimateEffect(\n",
+    "            method=cp.InterruptedTimeSeries,\n",
+    "            treatment_time=pd.to_datetime(\"2017-01-01\"),\n",
+    "            formula=\"y ~ 1 + t\",\n",
+    "            model=cp.create_causalpy_compatible_class(LinearRegression()),\n",
+    "        ),\n",
+    "        cp.GenerateReport(include_plots=False),\n",
+    "    ],\n",
+    ").run()\n",
+    "\n",
+    "print(\"Experiment type:\", type(result.experiment).__name__)\n",
+    "print(\"Effect summary available:\", result.effect_summary is not None)\n",
+    "print(\"Report generated:\", result.report is not None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Adding sensitivity analysis\n",
+    "\n",
+    "The `SensitivityAnalysis` step runs a suite of diagnostic checks against the fitted experiment. Checks are pluggable, and you can choose which ones to run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result = cp.Pipeline(\n",
+    "    data=df,\n",
+    "    steps=[\n",
+    "        cp.EstimateEffect(\n",
+    "            method=cp.InterruptedTimeSeries,\n",
+    "            treatment_time=pd.to_datetime(\"2017-01-01\"),\n",
+    "            formula=\"y ~ 1 + t\",\n",
+    "            model=cp.create_causalpy_compatible_class(LinearRegression()),\n",
+    "        ),\n",
+    "        cp.SensitivityAnalysis(\n",
+    "            checks=[\n",
+    "                cp.checks.PlaceboInTime(n_folds=2),\n",
+    "            ]\n",
+    "        ),\n",
+    "        cp.GenerateReport(include_plots=False),\n",
+    "    ],\n",
+    ").run()\n",
+    "\n",
+    "print(f\"Sensitivity checks run: {len(result.sensitivity_results)}\")\n",
+    "for check_result in result.sensitivity_results:\n",
+    "    print(f\"  - {check_result.check_name}: {check_result.text[:80]}...\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Available checks\n",
+    "\n",
+    "CausalPy provides a range of sensitivity checks, each applicable to specific experiment types:\n",
+    "\n",
+    "| Check | Applicable methods | Description |\n",
+    "|-------|-------------------|-------------|\n",
+    "| `PlaceboInTime` | ITS, SC | Shifts treatment time backward to test for spurious effects |\n",
+    "| `PriorSensitivity` | All Bayesian | Re-fits with different priors |\n",
+    "| `ConvexHullCheck` | SC | Validates treated values are within control range |\n",
+    "| `PersistenceCheck` | ITS (3-period) | Checks if effects persist after intervention ends |\n",
+    "| `PreTreatmentPlaceboCheck` | Staggered DiD | Validates parallel trends via pre-treatment effects |\n",
+    "| `BandwidthSensitivity` | RD, RKink | Re-fits with multiple bandwidths |\n",
+    "| `LeaveOneOut` | SC | Drops each control unit and refits |\n",
+    "| `PlaceboInSpace` | SC | Treats each control as placebo treated |\n",
+    "| `McCraryDensityTest` | RD | Tests for running variable manipulation |"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pipeline result\n",
+    "\n",
+    "The `PipelineResult` object contains all accumulated outputs:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"result.experiment      ->\", type(result.experiment).__name__)\n",
+    "print(\"result.effect_summary  ->\", type(result.effect_summary).__name__)\n",
+    "print(\"result.sensitivity_results ->\", len(result.sensitivity_results), \"checks\")\n",
+    "print(\"result.report          ->\", \"HTML\" if result.report else \"None\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The effect summary provides both a table and prose:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if result.effect_summary is not None:\n",
+    "    print(result.effect_summary.text)\n",
+    "    display(result.effect_summary.table)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary

Closes #748. Part of the pipeline epic (#722). Stacks on #754.

Adds a how-to notebook `docs/source/notebooks/pipeline_workflow.ipynb` demonstrating the pipeline API:

- Compares the manual step-by-step approach with the pipeline approach
- Shows `EstimateEffect` + `GenerateReport` basic pipeline
- Demonstrates adding `SensitivityAnalysis` with `PlaceboInTime`
- Reference table of all available sensitivity checks and their applicable methods
- Explores the `PipelineResult` object (experiment, effect_summary, sensitivity_results, report)

## Test plan

- [x] `pre-commit run --files ...` — all hooks pass
- [ ] CI passes
- [ ] Notebook runs end-to-end (requires all upstream PRs merged)


Made with [Cursor](https://cursor.com)