### PR TITLE
fix: welcome workflow fails on fork PRs due to GITHUB_TOKEN restrictions

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,7 +1,7 @@
 name: Welcome New Contributors
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   issues:
     types: [opened]
@@ -49,7 +49,7 @@ jobs:
       # FIRST_TIMER: never contributed to any GitHub repo
       # FIRST_TIME_CONTRIBUTOR: contributed elsewhere but not to this repo
       - name: Add first-time-contributor label
-        if: github.event_name == 'pull_request' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
+        if: github.event_name == 'pull_request_target' && (github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' || github.event.pull_request.author_association == 'FIRST_TIMER')
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |


### PR DESCRIPTION
## Summary

Fixes the welcome workflow so it correctly posts welcome comments and adds the `first-time-contributor` label on pull requests opened from forks.

Fixes #738

## Changes

- Changed the workflow trigger from `pull_request` to `pull_request_target` so the workflow runs in the base repository context and receives full declared token permissions (write access to issues and pull-requests), even for fork PRs.
- Updated the `if` condition on the label step to match the new event name (`pull_request_target`).

## Why this is safe

The workflow **does not check out or execute any code from the fork**. It only uses GitHub APIs to post a comment and add a label, so `pull_request_target` introduces no security risk here.

## Testing

- This is a CI-only change; no code or tests to run locally.
- Verification will happen when the next first-time contributor opens a PR from a fork.
