### PR TITLE
Align issue-to-pr draft path with AGENTS guidance

### DIFF
--- a/.github/skills/pr-workflows/reference/issue-to-pr.md
+++ b/.github/skills/pr-workflows/reference/issue-to-pr.md
@@ -24,7 +24,7 @@ description: Transform a GitHub issue into a complete pull request through a str
 2. Run pre-commit and tests until green (see `pre-commit.md`).
 
 ## Prepare PR
-1. Create `.github/pr_summaries/<issue_number> - <short-description>.md` with:
+1. Create `.scratch/pr_summaries/<issue_number> - <short-description>.md` with:
    - Summary
    - Fixes #<issue_number>
    - Changes
@@ -36,5 +36,5 @@ description: Transform a GitHub issue into a complete pull request through a str
 ## Create PR
 ```bash
 git push -u origin issue-<issue_number>-<short-description>
-gh pr create --title "<PR title>" --body-file .github/pr_summaries/<issue_number> - <short-description>.md --base main
+gh pr create --title "<PR title>" --body-file .scratch/pr_summaries/<issue_number> - <short-description>.md --base main
 ```


### PR DESCRIPTION
## Summary
- update the `issue-to-pr` workflow reference to use the untracked scratch location for PR draft markdown
- removes mismatch between `AGENTS.md` guidance and the skill reference used by `/issue-to-pr`

## Changes
- `.github/skills/pr-workflows/reference/issue-to-pr.md`
  - `.github/pr_summaries/...` -> `.scratch/pr_summaries/...` (prepare PR step)
  - `gh pr create --body-file` example updated to `.scratch/pr_summaries/...`

## Testing
- [x] `conda run -n CausalPy pre-commit run --all-files`

Made with [Cursor](https://cursor.com)