### PR TITLE
Align issue-to-pr draft path with AGENTS guidance

### DIFF
--- a/.github/skills/pr-workflows/reference/issue-to-pr.md
+++ b/.github/skills/pr-workflows/reference/issue-to-pr.md
@@ -24,7 +24,7 @@ description: Transform a GitHub issue into a complete pull request through a str
 2. Run pre-commit and tests until green (see `pre-commit.md`).
 
 ## Prepare PR
-1. Create `.github/pr_summaries/<issue_number> - <short-description>.md` with:
+1. Create `.scratch/pr_summaries/<issue_number> - <short-description>.md` with:
    - Summary
    - Fixes #<issue_number>
    - Changes
@@ -36,5 +36,5 @@ description: Transform a GitHub issue into a complete pull request through a str
 ## Create PR
 ```bash
 git push -u origin issue-<issue_number>-<short-description>
-gh pr create --title "<PR title>" --body-file .github/pr_summaries/<issue_number> - <short-description>.md --base main
+gh pr create --title "<PR title>" --body-file .scratch/pr_summaries/<issue_number> - <short-description>.md --base main
 ```


### PR DESCRIPTION
# PR: Align issue-to-pr draft path with AGENTS guidance

Closes #769

## Issue Summary

The issue-to-pr workflow reference still instructed contributors to write PR draft markdown under `.github/pr_summaries/`, which conflicts with the AGENTS guidance to keep drafts in `.scratch/pr_summaries/`.

## Root Cause

The reference document in `.github/skills/pr-workflows/reference/issue-to-pr.md` had not been updated after the project convention moved PR drafts to the untracked scratch area.

## Solution

Updated the workflow reference to point to `.scratch/pr_summaries/` in both the “Prepare PR” instructions and the `gh pr create --body-file` command example.

## Changes Made

- `.github/skills/pr-workflows/reference/issue-to-pr.md`: Replaced `.github/pr_summaries/...` with `.scratch/pr_summaries/...` in two locations.

## Testing

- [x] Existing tests pass
- [x] New tests added (if applicable)
- [x] Manual verification completed

### Commands run

- `$CONDA_EXE run -n CausalPy pre-commit run --all-files`

## Notes

This is a documentation-only update and does not change runtime package behavior.
