### PR TITLE
Add pre-commit nbformat validation for notebooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,12 @@ repos:
           - "marimo[mcp]"
   - repo: local
     hooks:
+      - id: validate-notebooks
+        name: Validate notebook schema
+        entry: python scripts/validate_notebooks.py
+        language: python
+        files: \.ipynb$
+        additional_dependencies: [nbformat]
       - id: validate-bibtex
         name: Validate BibTeX files
         entry: python -c "import sys; from pybtex.database.input import bibtex; parser = bibtex.Parser(); [parser.parse_file(f) for f in sys.argv[1:]]"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,8 @@ See the [python-environment skill](.github/skills/python-environment/SKILL.md) f
 - **API documentation**: Auto-generated from docstrings via Sphinx autodoc, no manual API docs needed
 - **Build**: Use `make html` to build documentation
 - **Doctest**: Use `make doctest` to test that Python examples in doctests work
+- **Notebook schema validation**: `pre-commit run --all-files` runs `validate-notebooks` to catch `.ipynb` files that are valid JSON but invalid nbformat.
+- **Notebook validation failure recovery**: Re-open and save (or re-run) in a notebook-aware editor; if it still fails, restore from `main` and reapply intended edits with notebook-aware tooling; rerun `pre-commit run --all-files`; for docs notebook changes run `$CONDA_EXE run -n CausalPy make html` before pushing.
 - **Scratch files**: Put temporary notes and generated markdown in `.scratch/` (untracked). Move anything that should be kept into a tracked location.
   - **PR drafts**: Create PR summary markdown files in `.scratch/pr_summaries/` (untracked).
   - **Issue drafts**: Create issue draft markdown files in `.scratch/issue_summaries/` (untracked).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -213,7 +213,11 @@ We recommend that your contribution complies with the following guidelines befor
 
 - Documentation follows [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
 
+- Notebook files are validated by pre-commit using `nbformat` schema checks (`validate-notebooks`). Run `pre-commit run --all-files` before pushing to catch malformed `.ipynb` files early.
+
 - If you have changed the documentation, you should [build the docs locally](#Building-the-documentation-locally) and check that the changes look correct.
+
+- If notebook schema validation fails (`validate-notebooks`), use this recovery loop: (1) reopen and save or re-run the notebook in a notebook-aware editor, (2) if it still fails, restore the notebook from `main` and reapply only the intended edits with notebook-aware tooling, (3) rerun `pre-commit run --all-files`, and (4) for docs notebook changes run `conda run -n CausalPy make html` before pushing.
 
 - Run any of the pre-existing examples in `CausalPy/docs/source/*` that contain analyses that would be affected by your changes to ensure that nothing breaks. This is a useful opportunity to not only check your work for bugs that might not be revealed by unit test, but also to show how your contribution improves CausalPy for end users.
 

--- a/causalpy/tests/test_notebook_validation.py
+++ b/causalpy/tests/test_notebook_validation.py
@@ -1,0 +1,79 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the notebook schema validation script."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import nbformat
+from nbformat.v4 import new_code_cell, new_notebook, new_output
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+VALIDATOR_SCRIPT = REPO_ROOT / "scripts" / "validate_notebooks.py"
+
+
+def _run_validator(notebook_path: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(VALIDATOR_SCRIPT), str(notebook_path)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _build_notebook() -> dict:
+    return new_notebook(
+        cells=[
+            new_code_cell(
+                source="print('hello')",
+                outputs=[
+                    new_output(output_type="stream", name="stdout", text="hello\n")
+                ],
+            )
+        ]
+    )
+
+
+def test_validate_notebooks_accepts_valid_notebook(tmp_path: Path) -> None:
+    notebook_path = tmp_path / "valid.ipynb"
+    with notebook_path.open("w", encoding="utf-8") as notebook_file:
+        nbformat.write(_build_notebook(), notebook_file)
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0
+    assert result.stderr == ""
+
+
+def test_validate_notebooks_reports_schema_details_for_invalid_output(
+    tmp_path: Path,
+) -> None:
+    notebook_path = tmp_path / "invalid.ipynb"
+    notebook = _build_notebook()
+    notebook["cells"][0]["outputs"][0].pop("name")
+
+    with notebook_path.open("w", encoding="utf-8") as notebook_file:
+        json.dump(notebook, notebook_file)
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 1
+    assert str(notebook_path) in result.stderr
+    assert "cell[0]" in result.stderr
+    assert "output[0]" in result.stderr
+    assert "required property" in result.stderr

--- a/scripts/validate_notebooks.py
+++ b/scripts/validate_notebooks.py
@@ -1,0 +1,126 @@
+"""Validate Jupyter notebooks against the nbformat schema."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any
+
+import nbformat
+from nbformat import NotebookNode
+from nbformat.validator import NotebookValidationError
+
+
+def _extract_path_index(path_segments: list[Any], segment_name: str) -> int | None:
+    """Return the integer index that follows a path segment name."""
+    for i, segment in enumerate(path_segments[:-1]):
+        if segment == segment_name and isinstance(path_segments[i + 1], int):
+            return path_segments[i + 1]
+    return None
+
+
+def _get_output_type(
+    notebook: NotebookNode,
+    cell_index: int | None,
+    output_index: int | None,
+) -> str | None:
+    """Return output_type for the failing output object if available."""
+    if cell_index is None or output_index is None:
+        return None
+
+    try:
+        output = notebook["cells"][cell_index]["outputs"][output_index]
+    except (IndexError, KeyError, TypeError):
+        return None
+
+    if isinstance(output, dict):
+        return output.get("output_type")
+    return None
+
+
+def _format_validation_error(
+    notebook_path: Path,
+    notebook: NotebookNode,
+    error: NotebookValidationError,
+) -> str:
+    """Format a NotebookValidationError into actionable stderr output."""
+    path_segments = list(getattr(error, "absolute_path", []))
+    cell_index = _extract_path_index(path_segments, "cells")
+    output_index = _extract_path_index(path_segments, "outputs")
+    output_type = _get_output_type(notebook, cell_index, output_index)
+
+    details = [f"{notebook_path}: notebook schema validation failed"]
+
+    location_parts = []
+    if cell_index is not None:
+        location_parts.append(f"cell[{cell_index}]")
+    if output_index is not None:
+        location_parts.append(f"output[{output_index}]")
+    if output_type is not None:
+        location_parts.append(f"type={output_type}")
+    if location_parts:
+        details.append(f"  location: {' '.join(location_parts)}")
+
+    if path_segments:
+        details.append(f"  path: {'/'.join(str(segment) for segment in path_segments)}")
+
+    details.append(f"  error: {error.message}")
+    return "\n".join(details)
+
+
+def validate_notebook(notebook_path: Path) -> tuple[bool, str | None]:
+    """Validate a single notebook and return (is_valid, error_message)."""
+    try:
+        with notebook_path.open(encoding="utf-8") as f:
+            notebook = nbformat.read(f, as_version=4)
+    except Exception as error:  # noqa: BLE001
+        return False, f"{notebook_path}: failed to read notebook: {error}"
+
+    try:
+        nbformat.validate(notebook)
+    except NotebookValidationError as error:
+        return False, _format_validation_error(notebook_path, notebook, error)
+
+    return True, None
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Validate Jupyter notebooks against nbformat schema.",
+    )
+    parser.add_argument(
+        "notebooks",
+        nargs="*",
+        type=Path,
+        help="Notebook files to validate.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run validation for all provided notebook paths."""
+    args = parse_args()
+    if not args.notebooks:
+        return 0
+
+    invalid_count = 0
+    for notebook_path in args.notebooks:
+        is_valid, error_message = validate_notebook(notebook_path)
+        if is_valid:
+            continue
+        invalid_count += 1
+        if error_message is not None:
+            print(error_message, file=sys.stderr)
+
+    if invalid_count == 0:
+        return 0
+
+    notebook_word = "notebook" if invalid_count == 1 else "notebooks"
+    print(f"Validation failed for {invalid_count} {notebook_word}.", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #770

## Summary
- add a local pre-commit hook to validate `*.ipynb` files with `nbformat`
- add `scripts/validate_notebooks.py` with file/cell/output-oriented validation errors
- add pytest coverage for valid and deliberately corrupted notebook schemas
- document notebook validation and failure recovery guidance in contributor docs

## Validation
- `conda run -n CausalPy python -m pytest --no-cov causalpy/tests/test_notebook_validation.py -v`
- `conda run -n CausalPy pre-commit run --all-files`
