### PR TITLE
Fix blocking Matplotlib windows during pytest

### DIFF
--- a/causalpy/tests/conftest.py
+++ b/causalpy/tests/conftest.py
@@ -18,9 +18,13 @@ Functions:
 * rng: random number generator with session level scope
 """
 
+import matplotlib
 import numpy as np
 import pandas as pd
 import pytest
+
+# Force a non-interactive backend so plot() calls in tests never open GUI windows.
+matplotlib.use("Agg", force=True)
 
 import causalpy as cp
 


### PR DESCRIPTION
## Summary
- Force Matplotlib to use the non-interactive `Agg` backend in test startup (`causalpy/tests/conftest.py`).
- Prevent pytest runs from opening GUI image windows when tests call `plot()` with `show=True`.
- Keep existing plot behavior intact while making test runs deterministic and non-blocking across local environments.

## Test plan
- [x] `$CONDA_EXE run -n CausalPy python -m pytest causalpy/tests/test_plot_show_parameter.py --no-cov -q`
- [x] `$CONDA_EXE run -n CausalPy prek run --files causalpy/tests/conftest.py`
- [x] `$CONDA_EXE run -n CausalPy prek run --all-files`

Made with [Cursor](https://cursor.com)