### PR TITLE
Update github-issues skill with parent-child sub-issue workflow

### DIFF
--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: github-issues
-description: Create, evaluate, and triage GitHub issues for CausalPy. Use when filing a bug, proposing an enhancement, or analyzing an existing issue.
+description: Create, evaluate, and triage GitHub issues for CausalPy. Use when filing a bug, proposing an enhancement, analyzing existing issues, or splitting large work into parent-child sub-issues.
 ---
 
 # GitHub Issues
@@ -11,8 +11,14 @@ This skill covers issue creation, bug reporting, and issue evaluation workflows.
 - Filing a new issue (bug, enhancement, or task)
 - Evaluating an existing issue and proposing next steps
 - Preparing issue content for user review before posting
+- Breaking large work into one parent issue with sub-issues
 
 ## References
 - [Issue creation workflow](reference/issue-creation.md)
 - [Bug report workflow](reference/bug-report.md)
 - [Issue evaluation workflow](reference/issue-evaluation.md)
+- [Parent-child sub-issues workflow](reference/parent-child-issues.md)
+
+## Important behavior
+- If native sub-issues are not available, do not silently switch to fallback.
+- Explain the limitation and ask the user whether to proceed with markdown tracking links.

--- a/.github/skills/github-issues/reference/parent-child-issues.md
+++ b/.github/skills/github-issues/reference/parent-child-issues.md
@@ -1,0 +1,126 @@
+---
+name: parent-child-issues
+description: Create a parent GitHub issue with child issues using gh CLI, with permission and capability checks before any write operations.
+---
+
+# Parent-child issue workflow (gh CLI)
+
+## 1) Preflight checks (no side effects)
+
+```bash
+gh auth status
+gh api graphql -f query='query {
+  repository(owner:"<owner>", name:"<repo>") {
+    viewerPermission
+    hasIssuesEnabled
+  }
+  viewer { login }
+}'
+```
+
+Proceed only when issues are enabled and permission is sufficient to create/edit issues.
+
+## 2) Verify native sub-issue capability (no side effects)
+
+```bash
+gh api graphql -f query='query {
+  repository(owner:"<owner>", name:"<repo>") {
+    issue(number: 1) {
+      number
+      parent { number }
+      subIssues(first: 1) { nodes { number } }
+    }
+  }
+}'
+```
+
+Also confirm mutation availability (at minimum `addSubIssue`):
+
+```bash
+gh api graphql -f query='query { __type(name:"Mutation") { fields { name } } }'
+```
+
+## 3) Draft issue bodies for user review
+
+Create markdown drafts in `.scratch/issue_summaries/` for:
+- one parent tracking issue
+- one draft per child issue
+
+Present drafts for user review before posting.
+
+## 4) Create parent and child issues
+
+Create parent:
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "<parent title>" \
+  --body-file "<path-to-parent-body.md>"
+```
+
+Create each child:
+
+```bash
+gh issue create \
+  --repo <owner>/<repo> \
+  --title "<child title>" \
+  --body-file "<path-to-child-body.md>"
+```
+
+## 5) Link child to parent (native hierarchy)
+
+Get GraphQL node IDs:
+
+```bash
+gh issue view <parent-number> --repo <owner>/<repo> --json id,number,title
+gh issue view <child-number> --repo <owner>/<repo> --json id,number,title
+```
+
+Attach child to parent:
+
+```bash
+gh api graphql \
+  -f query='mutation($issue: ID!, $sub: ID!) {
+    addSubIssue(input: {issueId: $issue, subIssueId: $sub}) {
+      issue { number title url }
+      subIssue { number title url }
+    }
+  }' \
+  -f issue='<PARENT_NODE_ID>' \
+  -f sub='<CHILD_NODE_ID>'
+```
+
+## 6) Verify links rendered correctly
+
+```bash
+gh api graphql -f query='query {
+  repository(owner:"<owner>", name:"<repo>") {
+    issue(number: <parent-number>) {
+      number
+      title
+      subIssues(first: 50) { nodes { number title url } }
+    }
+  }
+}'
+```
+
+## Fallback if native sub-issues are unavailable
+
+Do **not** apply fallback automatically.
+
+When native sub-issues are unavailable, first inform the user:
+- what capability check failed (missing `parent`/`subIssues` fields or no `addSubIssue` mutation)
+- that native hierarchy cannot be created in this repo/account context
+- that a markdown tracking-issue fallback is available
+
+Then explicitly ask whether they want to proceed with fallback. Only continue after user confirmation.
+
+Use a tracking issue body with markdown task links:
+
+```md
+- [ ] #123 Child issue one
+- [ ] #124 Child issue two
+```
+
+This renders correctly on GitHub and preserves parent-child tracking even without native hierarchy.


### PR DESCRIPTION
## Summary
- add a new `github-issues` reference workflow for creating parent-child issues with `gh` + GraphQL
- include required preflight checks for auth, permissions, and native sub-issue capability before any write operations
- require explicit user confirmation before applying markdown tracking-link fallback when native sub-issues are unavailable

## Test plan
- [x] Reviewed `SKILL.md` to ensure parent-child issue decomposition is discoverable and linked
- [x] Reviewed `reference/parent-child-issues.md` for end-to-end workflow coverage
- [x] Confirmed fallback behavior now requires user opt-in rather than silent automatic fallback

Made with [Cursor](https://cursor.com)