### PR TITLE
Clean up experiments/: typos, annotations, and constants

### DIFF
--- a/causalpy/constants.py
+++ b/causalpy/constants.py
@@ -12,7 +12,8 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """
-Shared constants for experiment modules.
+Shared constants for the CausalPy package.
 """
 
+HDI_PROB: float = 0.94
 LEGEND_FONT_SIZE: int = 12

--- a/causalpy/experiments/constants.py
+++ b/causalpy/experiments/constants.py
@@ -1,0 +1,18 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Shared constants for experiment modules.
+"""
+
+LEGEND_FONT_SIZE: int = 12

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -107,7 +107,7 @@ class DifferenceInDifferences(BaseExperiment):
         group_variable_name: str,
         post_treatment_variable_name: str = "post_treatment",
         model: PyMCModel | RegressorMixin | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray | float | None
@@ -335,7 +335,7 @@ class DifferenceInDifferences(BaseExperiment):
         return f"Causal impact = {convert_to_string(self.causal_impact, round_to=round_to)}"
 
     def _bayesian_plot(
-        self, round_to: int | None = None, **kwargs: dict
+        self, round_to: int | None = None, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
         """
         Plot the results
@@ -485,7 +485,7 @@ class DifferenceInDifferences(BaseExperiment):
         return fig, ax
 
     def _ols_plot(
-        self, round_to: int | None = 2, **kwargs: dict
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
         """Generate plot for difference-in-differences"""
         fig, ax = plt.subplots()

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -26,11 +26,11 @@ from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -517,7 +517,7 @@ class DifferenceInDifferences(BaseExperiment):
             "o",
             c="C1",
             markersize=10,
-            label="model fit (treament group)",
+            label="model fit (treatment group)",
         )
         # Plot counterfactual - post-test for treatment group IF no treatment
         # had occurred.

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -46,9 +46,9 @@ from causalpy.utils import (
     round_num,
 )
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class DifferenceInDifferences(BaseExperiment):

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -282,7 +282,7 @@ class DifferenceInDifferences(BaseExperiment):
                 "Require a `unit` column to label unique units. This is used for plotting purposes"  # noqa: E501
             )
 
-        if _is_variable_dummy_coded(self.data[self.group_variable_name]) is False:
+        if not _is_variable_dummy_coded(self.data[self.group_variable_name]):
             raise DataException(
                 f"""The grouping variable {self.group_variable_name} should be dummy
                 coded. Consisting of 0's and 1's only."""

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -261,10 +261,9 @@ class DifferenceInDifferences(BaseExperiment):
             raise ValueError("Model type not recognized")
 
     def input_validation(self) -> None:
+        """Validate the input data and model formula for correctness"""
         # Validate formula structure and interaction interaction terms
         self._validate_formula_interaction_terms()
-
-        """Validate the input data and model formula for correctness"""
         # Check if post_treatment_variable_name is in formula
         if self.post_treatment_variable_name not in self.formula:
             raise FormulaException(

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -30,6 +30,7 @@ from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (
@@ -45,8 +46,6 @@ from causalpy.utils import (
     get_interaction_terms,
     round_num,
 )
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -329,7 +329,7 @@ class DifferenceInDifferences(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _causal_impact_summary_stat(self, round_to: int | None = None) -> str:
-        """Computes the mean and 94% credible interval bounds for the causal impact."""
+        """Computes the mean and credible interval bounds for the causal impact."""
         return f"Causal impact = {convert_to_string(self.causal_impact, round_to=round_to)}"
 
     def _bayesian_plot(

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -126,7 +126,7 @@ class InstrumentalVariable(BaseExperiment):
         vs_prior_type=None,
         vs_hyperparams=None,
         binary_treatment=False,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Instrumental Variable Regression"

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -30,7 +30,7 @@ from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
-from causalpy.utils import round_num
+from causalpy.utils import HDI_PROB, round_num
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
@@ -886,7 +886,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
         return (fig, ax)
 
-    def get_plot_data_bayesian(self, hdi_prob: float = 0.94) -> pd.DataFrame:
+    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
         """
         Recover the data of the experiment along with the prediction and causal impact information.
 

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -126,7 +126,6 @@ class InterruptedTimeSeries(BaseExperiment):
     after the intervention ends.
     """
 
-    expt_type = "Interrupted Time Series"
     supports_ols = True
     supports_bayes = True
     _default_model_class = LinearRegression

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -32,9 +32,9 @@ from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import round_num
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class InterruptedTimeSeries(BaseExperiment):

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -138,7 +138,7 @@ class InterruptedTimeSeries(BaseExperiment):
         formula: str,
         model: PyMCModel | RegressorMixin | None = None,
         treatment_end_time: int | float | pd.Timestamp | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.pre_y: xr.DataArray
@@ -601,7 +601,7 @@ class InterruptedTimeSeries(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: dict
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results
@@ -797,7 +797,7 @@ class InterruptedTimeSeries(BaseExperiment):
         return fig, ax
 
     def _ols_plot(
-        self, round_to: int | None = 2, **kwargs: dict
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -27,12 +27,11 @@ from sklearn.base import RegressorMixin
 
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import HDI_PROB, round_num
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 
@@ -226,7 +225,7 @@ class InterruptedTimeSeries(BaseExperiment):
             )
 
         # get the model predictions of the observed (pre-intervention) data
-        if isinstance(self.model, (PyMCModel, RegressorMixin)):
+        if isinstance(self.model, PyMCModel | RegressorMixin):
             self.pre_pred = self.model.predict(X=self.pre_X)
 
         # calculate the counterfactual (post period)

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -25,13 +25,13 @@ from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
-from causalpy.utils import HDI_PROB, round_num
+from causalpy.utils import round_num
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -31,7 +31,7 @@ from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
-from causalpy.utils import round_num
+from causalpy.utils import HDI_PROB, round_num
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
@@ -626,7 +626,7 @@ class PiecewiseITS(BaseExperiment):
         plt.tight_layout()
         return fig, ax
 
-    def get_plot_data_bayesian(self, hdi_prob: float = 0.94) -> pd.DataFrame:
+    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
         """
         Recover the data of the experiment along with prediction and effect information.
 

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -154,7 +154,7 @@ class PiecewiseITS(BaseExperiment):
         data: pd.DataFrame,
         formula: str,
         model: PyMCModel | RegressorMixin | None = None,
-        **kwargs: dict[str, Any],
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
 
@@ -446,7 +446,7 @@ class PiecewiseITS(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: dict[str, Any]
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results for Bayesian models.
@@ -563,7 +563,7 @@ class PiecewiseITS(BaseExperiment):
         return fig, ax
 
     def _ols_plot(
-        self, round_to: int | None = 2, **kwargs: dict[str, Any]
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results for OLS models.

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -26,13 +26,13 @@ from matplotlib import pyplot as plt
 from patsy import dmatrices
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
-from causalpy.utils import HDI_PROB, round_num
+from causalpy.utils import round_num
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -144,7 +144,6 @@ class PiecewiseITS(BaseExperiment):
       the evaluation of public health interventions: a tutorial. Int J Epidemiol.
     """
 
-    expt_type = "Piecewise Interrupted Time Series"
     supports_ols = True
     supports_bayes = True
     _default_model_class = LinearRegression
@@ -159,6 +158,7 @@ class PiecewiseITS(BaseExperiment):
         super().__init__(model=model)
 
         # Store configuration
+        self.expt_type = "Piecewise Interrupted Time Series"
         self.formula = formula
         self.data = data.copy()
 

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -33,9 +33,9 @@ from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
 from causalpy.utils import round_num
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class PiecewiseITS(BaseExperiment):

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -27,13 +27,12 @@ from patsy import dmatrices
 from sklearn.base import RegressorMixin
 
 from causalpy.custom_exceptions import FormulaException
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
 from causalpy.utils import HDI_PROB, round_num
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -34,9 +34,9 @@ from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
 from causalpy.utils import _is_variable_dummy_coded, round_num
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class PrePostNEGD(BaseExperiment):

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -26,14 +26,14 @@ from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
 )
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
-from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, round_num
+from causalpy.utils import _is_variable_dummy_coded, round_num
 
 from .base import BaseExperiment
 
@@ -217,7 +217,7 @@ class PrePostNEGD(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            r"$CI_{94%}$"
+            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         causal_impact = f"{round_num(self.causal_impact.mean(), round_to)}, "

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -29,12 +29,11 @@ from sklearn.base import RegressorMixin
 from causalpy.custom_exceptions import (
     DataException,
 )
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
 from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, round_num
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 
@@ -214,7 +213,9 @@ class PrePostNEGD(BaseExperiment):
 
     def _causal_impact_summary_stat(self, round_to: int | None = 2) -> str:
         """Computes the mean and 94% credible interval bounds for the causal impact."""
-        percentiles = self.causal_impact.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
+        percentiles = self.causal_impact.quantile(
+            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+        ).values
         ci = (
             r"$CI_{94%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -97,7 +97,7 @@ class PrePostNEGD(BaseExperiment):
         group_variable_name: str,
         pretreatment_variable_name: str,
         model: PyMCModel | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray
@@ -235,7 +235,7 @@ class PrePostNEGD(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = None, **kwargs: dict
+        self, round_to: int | None = None, **kwargs: Any
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """Generate plot for ANOVA-like experiments with non-equivalent group designs."""
         fig, ax = plt.subplots(

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -217,7 +217,7 @@ class PrePostNEGD(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
+            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         causal_impact = f"{round_num(self.causal_impact.mean(), round_to)}, "

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -184,7 +184,7 @@ class PrePostNEGD(BaseExperiment):
         (new_x_treated,) = build_design_matrices([self._x_design_info], x_pred_treated)
         self.pred_treated = self.model.predict(X=np.asarray(new_x_treated))
 
-        # Evaluate causal impact as equal to the trestment effect
+        # Evaluate causal impact as equal to the treatment effect
         self.causal_impact = self.model.idata.posterior["beta"].sel(
             {"coeffs": self._get_treatment_effect_coeff()}
         )

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -32,7 +32,7 @@ from causalpy.custom_exceptions import (
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
-from causalpy.utils import _is_variable_dummy_coded, round_num
+from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, round_num
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
@@ -214,7 +214,7 @@ class PrePostNEGD(BaseExperiment):
 
     def _causal_impact_summary_stat(self, round_to: int | None = 2) -> str:
         """Computes the mean and 94% credible interval bounds for the causal impact."""
-        percentiles = self.causal_impact.quantile([0.03, 1 - 0.03]).values
+        percentiles = self.causal_impact.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
         ci = (
             r"$CI_{94%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -212,7 +212,7 @@ class PrePostNEGD(BaseExperiment):
         raise NameError("Unable to find coefficient name for the treatment effect")
 
     def _causal_impact_summary_stat(self, round_to: int | None = 2) -> str:
-        """Computes the mean and 94% credible interval bounds for the causal impact."""
+        """Computes the mean and credible interval bounds for the causal impact."""
         percentiles = self.causal_impact.quantile(
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -339,7 +339,7 @@ class RegressionDiscontinuity(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
+            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         discon = f"""

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -244,7 +244,7 @@ class RegressionDiscontinuity(BaseExperiment):
                 "A predictor called `treated` should be in the formula"
             )
 
-        if _is_variable_dummy_coded(self.data["treated"]) is False:
+        if not _is_variable_dummy_coded(self.data["treated"]):
             raise DataException(
                 """The treated variable should be dummy coded. Consisting of 0's and 1's only."""  # noqa: E501
             )

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -16,7 +16,7 @@ Regression discontinuity design
 """
 
 import warnings  # noqa: I001
-
+from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
@@ -29,15 +29,18 @@ from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
-from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, convert_to_string, round_num
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
+from causalpy.reporting import EffectSummary, _effect_summary_rd
+from causalpy.utils import (
+    HDI_PROB,
+    _is_variable_dummy_coded,
+    convert_to_string,
+    round_num,
+)
 
 from .base import BaseExperiment
-from causalpy.reporting import EffectSummary, _effect_summary_rd
-from typing import Any, Literal
 
 
 class RegressionDiscontinuity(BaseExperiment):
@@ -333,7 +336,9 @@ class RegressionDiscontinuity(BaseExperiment):
         # create strings to compose title
         title_info = f"{round_num(self.score['unit_0_r2'], round_to)} (std = {round_num(self.score['unit_0_r2_std'], round_to)})"
         r2 = f"Bayesian $R^2$ on fit data = {title_info}"
-        percentiles = self.discontinuity_at_threshold.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
+        percentiles = self.discontinuity_at_threshold.quantile(
+            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+        ).values
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -31,7 +31,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
-from causalpy.utils import _is_variable_dummy_coded, convert_to_string, round_num
+from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, convert_to_string, round_num
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
@@ -333,7 +333,7 @@ class RegressionDiscontinuity(BaseExperiment):
         # create strings to compose title
         title_info = f"{round_num(self.score['unit_0_r2'], round_to)} (std = {round_num(self.score['unit_0_r2_std'], round_to)})"
         r2 = f"Bayesian $R^2$ on fit data = {title_info}"
-        percentiles = self.discontinuity_at_threshold.quantile([0.03, 1 - 0.03]).values
+        percentiles = self.discontinuity_at_threshold.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -33,11 +33,11 @@ from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.utils import _is_variable_dummy_coded, convert_to_string, round_num
 
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
+
 from .base import BaseExperiment
 from causalpy.reporting import EffectSummary, _effect_summary_rd
 from typing import Any, Literal
-
-LEGEND_FONT_SIZE = 12
 
 
 class RegressionDiscontinuity(BaseExperiment):

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -101,7 +101,7 @@ class RegressionDiscontinuity(BaseExperiment):
         epsilon: float = 0.001,
         bandwidth: float = np.inf,
         donut_hole: float = 0.0,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Discontinuity"
@@ -296,7 +296,7 @@ class RegressionDiscontinuity(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: dict
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
         """Generate plot for regression discontinuity designs."""
         fig, ax = plt.subplots()
@@ -372,7 +372,7 @@ class RegressionDiscontinuity(BaseExperiment):
         return (fig, ax)
 
     def _ols_plot(
-        self, round_to: int | None = None, **kwargs: dict
+        self, round_to: int | None = None, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
         """Generate plot for regression discontinuity designs."""
         fig, ax = plt.subplots()

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -29,12 +29,11 @@ from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rd
 from causalpy.utils import (
-    HDI_PROB,
     _is_variable_dummy_coded,
     convert_to_string,
     round_num,
@@ -340,7 +339,7 @@ class RegressionDiscontinuity(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            r"$CI_{94\%}$"
+            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         discon = f"""

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -171,7 +171,7 @@ class RegressionKink(BaseExperiment):
                 "A predictor called `treated` should be in the formula"
             )
 
-        if _is_variable_dummy_coded(self.data["treated"]) is False:
+        if not _is_variable_dummy_coded(self.data["treated"]):
             raise DataException(
                 """The treated variable should be dummy coded. Consisting of 0's and 1's only."""  # noqa: E501
             )

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -34,7 +34,7 @@ from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 from typing import Any, Literal
-from causalpy.utils import _is_variable_dummy_coded, round_num
+from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, round_num
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
@@ -272,7 +272,7 @@ class RegressionKink(BaseExperiment):
         # create strings to compose title
         title_info = f"{round_num(self.score['unit_0_r2'], round_to if round_to is not None else 2)} (std = {round_num(self.score['unit_0_r2_std'], round_to if round_to is not None else 2)})"
         r2 = f"Bayesian $R^2$ on all data = {title_info}"
-        percentiles = self.gradient_change.quantile([0.03, 1 - 0.03]).values
+        percentiles = self.gradient_change.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to if round_to is not None else 2)}, {round_num(percentiles[1], round_to if round_to is not None else 2)}]"

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -272,7 +272,9 @@ class RegressionKink(BaseExperiment):
         # create strings to compose title
         title_info = f"{round_num(self.score['unit_0_r2'], round_to if round_to is not None else 2)} (std = {round_num(self.score['unit_0_r2_std'], round_to if round_to is not None else 2)})"
         r2 = f"Bayesian $R^2$ on all data = {title_info}"
-        percentiles = self.gradient_change.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).values
+        percentiles = self.gradient_change.quantile(
+            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+        ).values
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to if round_to is not None else 2)}, {round_num(percentiles[1], round_to if round_to is not None else 2)}]"

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -30,17 +30,15 @@ from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rkink
 
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
+
 from .base import BaseExperiment
 from typing import Any, Literal
-from causalpy.utils import round_num
+from causalpy.utils import _is_variable_dummy_coded, round_num
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
-from causalpy.utils import _is_variable_dummy_coded
-
-
-LEGEND_FONT_SIZE = 12
 
 
 class RegressionKink(BaseExperiment):

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -76,7 +76,7 @@ class RegressionKink(BaseExperiment):
         running_variable_name: str = "x",
         epsilon: float = 0.001,
         bandwidth: float = np.inf,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Kink"
@@ -248,7 +248,7 @@ class RegressionKink(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: dict
+        self, round_to: int | None = 2, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
         """Generate plot for regression kink designs."""
         fig, ax = plt.subplots()

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -30,11 +30,11 @@ from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rkink
 
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 
 from .base import BaseExperiment
 from typing import Any, Literal
-from causalpy.utils import HDI_PROB, _is_variable_dummy_coded, round_num
+from causalpy.utils import _is_variable_dummy_coded, round_num
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
@@ -276,7 +276,7 @@ class RegressionKink(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            r"$CI_{94\%}$"
+            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to if round_to is not None else 2)}, {round_num(percentiles[1], round_to if round_to is not None else 2)}]"
         )
         grad_change = f"""

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -276,7 +276,7 @@ class RegressionKink(BaseExperiment):
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).values
         ci = (
-            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
+            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to if round_to is not None else 2)}, {round_num(percentiles[1], round_to if round_to is not None else 2)}]"
         )
         grad_change = f"""

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -33,6 +33,7 @@ from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
+from causalpy.utils import HDI_PROB
 
 from .base import BaseExperiment
 
@@ -444,7 +445,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         self,
         treated_data: pd.DataFrame,
         pretreatment_data: pd.DataFrame,
-        hdi_prob: float = 0.94,
+        hdi_prob: float = HDI_PROB,
     ) -> None:
         """Aggregate effects for Bayesian model with posterior uncertainty.
 
@@ -816,7 +817,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         return fig, [ax]
 
-    def get_plot_data_bayesian(self, hdi_prob: float = 0.94) -> pd.DataFrame:
+    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
         """Get plotting data for Bayesian model.
 
         Parameters
@@ -832,7 +833,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         """
         # If the requested hdi_prob matches what was used during aggregation,
         # return the pre-computed results
-        stored_hdi_prob = getattr(self, "hdi_prob_", 0.94)
+        stored_hdi_prob = getattr(self, "hdi_prob_", HDI_PROB)
         if np.isclose(hdi_prob, stored_hdi_prob):
             return self.att_event_time_.copy()
 

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -32,9 +32,9 @@ from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class StaggeredDifferenceInDifferences(BaseExperiment):

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -152,7 +152,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         model: PyMCModel | RegressorMixin | None = None,
         event_window: tuple[int, int] | None = None,
         reference_event_time: int = -1,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         # NOTE: kwargs is accepted for API compatibility with other experiment classes
         # and is intentionally not used inside this constructor.
@@ -645,7 +645,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         print("\nModel coefficients:")
         self.print_coefficients(round_to)
 
-    def _bayesian_plot(self, **kwargs: dict) -> tuple[plt.Figure, list[plt.Axes]]:
+    def _bayesian_plot(self, **kwargs: Any) -> tuple[plt.Figure, list[plt.Axes]]:
         """Plot event-study results for Bayesian model.
 
         Returns
@@ -723,7 +723,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         return fig, [ax]
 
-    def _ols_plot(self, **kwargs: dict) -> tuple[plt.Figure, list[plt.Axes]]:
+    def _ols_plot(self, **kwargs: Any) -> tuple[plt.Figure, list[plt.Axes]]:
         """Plot event-study results for OLS model.
 
         Returns

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -28,11 +28,10 @@ from matplotlib import pyplot as plt
 from patsy import dmatrices
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
-from causalpy.utils import HDI_PROB
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -29,10 +29,9 @@ from patsy import dmatrices
 from sklearn.base import RegressorMixin
 
 from causalpy.custom_exceptions import DataException, FormulaException
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.utils import HDI_PROB
 
 from .base import BaseExperiment

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -33,6 +33,7 @@ from causalpy.reporting import EffectSummary
 from causalpy.utils import check_convex_hull_violation, round_num
 
 from causalpy.experiments.constants import LEGEND_FONT_SIZE
+from causalpy.utils import HDI_PROB
 
 from .base import BaseExperiment
 
@@ -670,7 +671,7 @@ class SyntheticControl(BaseExperiment):
         return self.plot_data
 
     def get_plot_data_bayesian(
-        self, hdi_prob: float = 0.94, treated_unit: str | None = None
+        self, hdi_prob: float = HDI_PROB, treated_unit: str | None = None
     ) -> pd.DataFrame:
         """
         Recover the data of the PrePostFit experiment along with the prediction and causal impact information.

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -32,9 +32,9 @@ from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
 from causalpy.utils import check_convex_hull_violation, round_num
 
-from .base import BaseExperiment
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 
-LEGEND_FONT_SIZE = 12
+from .base import BaseExperiment
 
 
 class SyntheticControl(BaseExperiment):

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -25,13 +25,13 @@ import xarray as xr
 from matplotlib import pyplot as plt
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
-from causalpy.utils import HDI_PROB, check_convex_hull_violation, round_num
+from causalpy.utils import check_convex_hull_violation, round_num
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -27,13 +27,11 @@ from sklearn.base import RegressorMixin
 
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.experiments.constants import LEGEND_FONT_SIZE
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
-from causalpy.utils import check_convex_hull_violation, round_num
-
-from causalpy.experiments.constants import LEGEND_FONT_SIZE
-from causalpy.utils import HDI_PROB
+from causalpy.utils import HDI_PROB, check_convex_hull_violation, round_num
 
 from .base import BaseExperiment
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -97,7 +97,7 @@ class SyntheticControl(BaseExperiment):
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
         min_donor_correlation: float = 0.0,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
         # rename the index to "obs_ind"
@@ -383,7 +383,7 @@ class SyntheticControl(BaseExperiment):
         self,
         round_to: int | None = None,
         treated_unit: str | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results for a specific treated unit
@@ -549,7 +549,7 @@ class SyntheticControl(BaseExperiment):
         self,
         round_to: int | None = None,
         treated_unit: str | None = None,
-        **kwargs: dict,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results for OLS model for a specific treated unit

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -26,7 +26,7 @@ from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 from pandas.api.extensions import ExtensionArray
 
-from causalpy.utils import HDI_PROB
+from causalpy.constants import HDI_PROB
 
 
 def plot_xY(

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -26,13 +26,15 @@ from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 from pandas.api.extensions import ExtensionArray
 
+from causalpy.utils import HDI_PROB
+
 
 def plot_xY(
     x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
     Y: xr.DataArray,
     ax: plt.Axes,
     plot_hdi_kwargs: dict[str, Any] | None = None,
-    hdi_prob: float = 0.94,
+    hdi_prob: float = HDI_PROB,
     label: str | None = None,
 ) -> tuple[Line2D, PolyCollection]:
     """Plot HDI intervals.
@@ -93,7 +95,7 @@ def plot_xY(
 
 def get_hdi_to_df(
     x: xr.DataArray,
-    hdi_prob: float = 0.94,
+    hdi_prob: float = HDI_PROB,
 ) -> pd.DataFrame:
     """Calculate and recover HDI intervals.
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -418,7 +418,7 @@ class PyMCModel(pm.Model):
         ) -> None:
             """Print one row of the coefficient table"""
             formatted_name = f"  {name: <{max_label_length}}"
-            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, {HDI_PROB*100:.0f}% HDI [{round_num(coeff_samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, {round_num(coeff_samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"  # noqa: E501
+            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, {HDI_PROB * 100:.0f}% HDI [{round_num(coeff_samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, {round_num(coeff_samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"  # noqa: E501
             print(f"  {formatted_name}  {formatted_val}")
 
         def print_coefficients_for_unit(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -26,7 +26,7 @@ from arviz import r2_score
 from patsy import dmatrix
 from pymc_extras.prior import Prior
 
-from causalpy.utils import round_num
+from causalpy.utils import HDI_PROB, round_num
 from causalpy.variable_selection_priors import VariableSelectionPrior
 
 
@@ -417,7 +417,7 @@ class PyMCModel(pm.Model):
         ) -> None:
             """Print one row of the coefficient table"""
             formatted_name = f"  {name: <{max_label_length}}"
-            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, 94% HDI [{round_num(coeff_samples.quantile(0.03).data, round_to)}, {round_num(coeff_samples.quantile(1 - 0.03).data, round_to)}]"  # noqa: E501
+            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, 94% HDI [{round_num(coeff_samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, {round_num(coeff_samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"  # noqa: E501
             print(f"  {formatted_name}  {formatted_val}")
 
         def print_coefficients_for_unit(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -26,7 +26,8 @@ from arviz import r2_score
 from patsy import dmatrix
 from pymc_extras.prior import Prior
 
-from causalpy.utils import HDI_PROB, round_num
+from causalpy.constants import HDI_PROB
+from causalpy.utils import round_num
 from causalpy.variable_selection_priors import VariableSelectionPrior
 
 
@@ -417,7 +418,7 @@ class PyMCModel(pm.Model):
         ) -> None:
             """Print one row of the coefficient table"""
             formatted_name = f"  {name: <{max_label_length}}"
-            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, 94% HDI [{round_num(coeff_samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, {round_num(coeff_samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"  # noqa: E501
+            formatted_val = f"{round_num(coeff_samples.mean().data, round_to)}, {HDI_PROB*100:.0f}% HDI [{round_num(coeff_samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, {round_num(coeff_samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"  # noqa: E501
             print(f"  {formatted_name}  {formatted_val}")
 
         def print_coefficients_for_unit(

--- a/causalpy/tests/test_piecewise_its.py
+++ b/causalpy/tests/test_piecewise_its.py
@@ -952,7 +952,6 @@ def test_piecewise_its_post_impact_attributes():
 
 def test_piecewise_its_class_attributes():
     """Test that class-level attributes are correctly set."""
-    assert cp.PiecewiseITS.expt_type == "Piecewise Interrupted Time Series"
     assert cp.PiecewiseITS.supports_ols is True
     assert cp.PiecewiseITS.supports_bayes is True
 
@@ -966,6 +965,9 @@ def test_piecewise_its_instance_attributes():
         formula="y ~ 1 + t + step(t, 50) + ramp(t, 50)",
         model=LinearRegression(),
     )
+
+    # Check expt_type is set as an instance attribute
+    assert result.expt_type == "Piecewise Interrupted Time Series"
 
     # Check formula and time column extraction
     assert result.formula == "y ~ 1 + t + step(t, 50) + ramp(t, 50)"

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -20,8 +20,6 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
-HDI_PROB: float = 0.94
-
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -30,6 +28,8 @@ import xarray as xr
 
 if TYPE_CHECKING:
     from causalpy.experiments.synthetic_control import SyntheticControl
+
+HDI_PROB: float = 0.94
 
 
 def _is_variable_dummy_coded(series: pd.Series) -> bool:
@@ -108,7 +108,9 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
         return f"{x:.2f}"
     elif isinstance(x, xr.DataArray):
         # In the case of an xarray object, we return the mean and 94% CI
-        percentiles = x.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).to_numpy()
+        percentiles = x.quantile(
+            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+        ).to_numpy()
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import re
 from typing import TYPE_CHECKING, Any, Literal
 
+HDI_PROB: float = 0.94
+
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -106,7 +108,7 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
         return f"{x:.2f}"
     elif isinstance(x, xr.DataArray):
         # In the case of an xarray object, we return the mean and 94% CI
-        percentiles = x.quantile([0.03, 1 - 0.03]).to_numpy()
+        percentiles = x.quantile([(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]).to_numpy()
         ci = (
             r"$CI_{94\%}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -112,7 +112,7 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).to_numpy()
         ci = (
-            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
+            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         return f"{x.mean().to_numpy():.2f}" + ci

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -29,7 +29,7 @@ import xarray as xr
 if TYPE_CHECKING:
     from causalpy.experiments.synthetic_control import SyntheticControl
 
-HDI_PROB: float = 0.94
+from causalpy.constants import HDI_PROB
 
 
 def _is_variable_dummy_coded(series: pd.Series) -> bool:
@@ -112,7 +112,7 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).to_numpy()
         ci = (
-            r"$CI_{94\%}$"
+            rf"$CI_{{{HDI_PROB*100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         return f"{x.mean().to_numpy():.2f}" + ci

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -96,7 +96,7 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
     -------
     str
         Formatted string representation. For floats, returns rounded
-        decimal. For DataArrays, returns mean with 94% credible interval.
+        decimal. For DataArrays, returns mean with credible interval.
 
     Raises
     ------
@@ -107,7 +107,7 @@ def convert_to_string(x: float | xr.DataArray, round_to: int | None = 2) -> str:
         # In the case of a float, we return the number rounded to 2 decimal places
         return f"{x:.2f}"
     elif isinstance(x, xr.DataArray):
-        # In the case of an xarray object, we return the mean and 94% CI
+        # In the case of an xarray object, we return the mean and CI
         percentiles = x.quantile(
             [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
         ).to_numpy()


### PR DESCRIPTION
 Summary

Purely mechanical cleanup of causalpy/experiments/ — no behavioural changes.
Closes: https://github.com/pymc-labs/CausalPy/issues/795

- Fix typos: "treament" → "treatment" (diff_in_diff), "trestment" → "treatment" (prepostnegd)
- Fix **kwargs: dict → **kwargs: Any: 9 experiment files — dict is the wrong annotation for **kwargs values
- Replace is False with not: idiomatic boolean checks in dummy-coded validation (3 files)
- Fix misplaced docstring: DifferenceInDifferences.input_validation() had its docstring after the first executable line
- Standardize expt_type to instance attribute: remove dead class attribute in InterruptedTimeSeries, move to __init__ in PiecewiseITS
  - Extract LEGEND_FONT_SIZE to causalpy/experiments/constants.py (8 files)
  - Extract HDI_PROB to causalpy/utils.py, replace all hardcoded 0.94 defaults and 0.03/1 - 0.03 quantile bounds (10 files)