### PR TITLE
Cap ArviZ below 1.0 pending migration

### DIFF
--- a/docs/source/notebooks/its_lift_test.ipynb
+++ b/docs/source/notebooks/its_lift_test.ipynb
@@ -126,11 +126,14 @@
     }
    ],
    "source": [
+    "import inspect\n",
+    "\n",
     "import arviz as az\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import pandas as pd\n",
     "from pymc_marketing.mmm.transformers import geometric_adstock, logistic_saturation\n",
+    "from pytensor.xtensor import as_xtensor\n",
     "\n",
     "import causalpy as cp\n",
     "\n",
@@ -351,7 +354,7 @@
        "2022-03-07        18293.912145       0.0  28050.950984  20000.000000"
       ]
      },
-     "execution_count": 3,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -415,12 +418,7 @@
        "<Figure size 1400x800 with 4 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 791,
-       "width": 1385
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -505,6 +503,7 @@
     "\n",
     "# Apply transformations to each channel\n",
     "df_transformed = pd.DataFrame(index=date_range)\n",
+    "needs_named_dim = \"dim\" in inspect.signature(geometric_adstock).parameters\n",
     "\n",
     "for channel in channels:\n",
     "    # Get channel spend\n",
@@ -515,15 +514,25 @@
     "    spend_max = spend.max()\n",
     "    spend_scaled = spend / spend_max if spend_max > 0 else spend\n",
     "\n",
-    "    # Apply Geometric Adstock transformation\n",
-    "    spend_adstocked = geometric_adstock(\n",
-    "        x=spend_scaled, alpha=channel_params[channel][\"alpha\"]\n",
-    "    ).eval()\n",
-    "\n",
-    "    # Apply Logistic Saturation transformation\n",
-    "    spend_transformed = logistic_saturation(\n",
-    "        x=spend_adstocked, lam=channel_params[channel][\"lam\"]\n",
-    "    ).eval()\n",
+    "    if needs_named_dim:\n",
+    "        spend_adstocked = geometric_adstock(\n",
+    "            x=as_xtensor(spend_scaled, dims=(\"time\",)),\n",
+    "            alpha=channel_params[channel][\"alpha\"],\n",
+    "            dim=\"time\",\n",
+    "        )\n",
+    "        spend_transformed = logistic_saturation(\n",
+    "            x=spend_adstocked,\n",
+    "            lam=channel_params[channel][\"lam\"],\n",
+    "        ).eval()\n",
+    "    else:\n",
+    "        spend_adstocked = geometric_adstock(\n",
+    "            x=spend_scaled,\n",
+    "            alpha=channel_params[channel][\"alpha\"],\n",
+    "        ).eval()\n",
+    "        spend_transformed = logistic_saturation(\n",
+    "            x=spend_adstocked,\n",
+    "            lam=channel_params[channel][\"lam\"],\n",
+    "        ).eval()\n",
     "\n",
     "    df_transformed[f\"{channel}_transformed\"] = spend_transformed"
    ]
@@ -547,12 +556,7 @@
        "<Figure size 640x480 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 429,
-       "width": 547
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -683,7 +687,7 @@
        "2022-01-31  5441.232581  4      1              5                  0"
       ]
      },
-     "execution_count": 7,
+     "execution_count": null,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -794,12 +798,7 @@
        "<Figure size 1400x800 with 2 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 791,
-       "width": 1391
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -917,21 +916,21 @@
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Initializing NUTS using jitter+adapt_diag...\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Multiprocess sampling (4 chains in 4 jobs)\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "NUTS: [beta, y_hat_sigma]\n"
@@ -962,42 +961,42 @@
      "output_type": "display_data"
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling 4 chains for 1_000 tune and 1_000 draw iterations (4_000 + 4_000 draws total) took 7 seconds.\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling: [beta, y_hat, y_hat_sigma]\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling: [y_hat]\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling: [y_hat]\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling: [y_hat]\n"
      ]
     },
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
       "Sampling: [y_hat]\n"
@@ -1046,12 +1045,7 @@
        "<Figure size 700x800 with 3 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 811,
-       "width": 711
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -1306,12 +1300,7 @@
        "<Figure size 1000x800 with 2 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 790,
-       "width": 989
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -1471,12 +1460,7 @@
        "<Figure size 1000x400 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 390,
-       "width": 989
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],
@@ -1581,12 +1565,7 @@
        "<Figure size 1000x400 with 1 Axes>"
       ]
      },
-     "metadata": {
-      "image/png": {
-       "height": 390,
-       "width": 989
-      }
-     },
+     "metadata": {},
      "output_type": "display_data"
     }
    ],

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.12
-  - arviz>=0.14.0
+  - arviz<1.0,>=0.14.0
   - codespell
   - graphviz
   - interrogate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 dependencies = [
-    "arviz>=0.14.0",
+    "arviz>=0.14.0,<1.0",
     "graphviz",
     "ipython!=8.7.0",
     "jinja2",


### PR DESCRIPTION
## Summary
- Cap ArviZ below 1.0 for current CausalPy releases so dependency resolution does not produce incompatible ArviZ 1.0 installs.
- Regenerate `environment.yml` after updating `pyproject.toml`.
- Track the future ArviZ 1.0 migration separately in #809 while upstream PyMC and `pymc-extras` support stabilizes.

Closes #800

## Test plan
- [x] `$CONDA_EXE run -n CausalPy prek run --all-files`

Made with [Cursor](https://cursor.com)