### PR TITLE
Handle xtensor BSTS pymc-marketing components

### DIFF
--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 """Custom PyMC models for causal inference"""
 
+import inspect
 import warnings
 from typing import Any, Literal
 
@@ -28,6 +29,44 @@ from pymc_extras.prior import Prior
 
 from causalpy.utils import round_num
 from causalpy.variable_selection_priors import VariableSelectionPrior
+
+
+def _as_xtensor_obs_ind(x: Any) -> Any:
+    """Convert a tensor-like input to an obs_ind xtensor."""
+    import pytensor.xtensor as ptx
+
+    return ptx.as_xtensor(x, dims=("obs_ind",))
+
+
+def _uses_xtensor_api(function: Any) -> bool:
+    """Return True when an upstream transform expects xtensor inputs."""
+    try:
+        return "as_xtensor" in inspect.getsource(function)
+    except (OSError, TypeError):
+        code = getattr(function, "__code__", None)
+        return code is not None and "as_xtensor" in code.co_names
+
+
+def _call_time_component_apply(
+    component: Any,
+    t: Any,
+) -> Any:
+    """Call time components across tensor and xtensor variants."""
+    parameters = inspect.signature(component.apply).parameters
+    if _uses_xtensor_api(component.apply) or (
+        "sum" in parameters and "result_callback" not in parameters
+    ):
+        t = _as_xtensor_obs_ind(t)
+    result = component.apply(t)
+    return getattr(result, "values", result)
+
+
+def _call_seasonality_component_apply(
+    seasonality_component: Any,
+    dayofperiod: Any,
+) -> Any:
+    """Call seasonality components across tensor and xtensor variants."""
+    return _call_time_component_apply(seasonality_component, dayofperiod)
 
 
 class PyMCModel(pm.Model):
@@ -1441,12 +1480,16 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
             # Seasonal component
             season_component = pm.Deterministic(
                 "season_component",
-                seasonality_component_instance.apply(t_season_data),
+                _call_seasonality_component_apply(
+                    seasonality_component_instance, t_season_data
+                ),
                 dims="obs_ind",
             )
 
             # Trend component
-            trend_component_values = trend_component_instance.apply(t_trend_data)
+            trend_component_values = _call_time_component_apply(
+                trend_component_instance, t_trend_data
+            )
             trend_component = pm.Deterministic(
                 "trend_component",
                 trend_component_values,

--- a/causalpy/tests/test_pymc_models_compat.py
+++ b/causalpy/tests/test_pymc_models_compat.py
@@ -1,0 +1,115 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Compatibility tests for optional pymc-marketing components in pymc_models."""
+
+import pytensor.tensor as pt
+
+from causalpy.pymc_models import (
+    _call_seasonality_component_apply,
+    _call_time_component_apply,
+    _uses_xtensor_api,
+)
+
+
+def test_call_seasonality_component_apply_supports_tensor_input():
+    calls: dict[str, object] = {}
+
+    class FakeSeasonalityComponent:
+        def apply(self, dayofperiod, result_callback=None):  # noqa: ANN001, ARG002
+            calls["dayofperiod"] = dayofperiod
+            return "seasonality-result"
+
+    signal = pt.vector("signal")
+
+    result = _call_seasonality_component_apply(FakeSeasonalityComponent(), signal)
+
+    assert result == "seasonality-result"
+    assert calls == {"dayofperiod": signal}
+
+
+def test_call_seasonality_component_apply_supports_xtensor_signature():
+    calls: dict[str, object] = {}
+
+    class FakeXTensorResult:
+        def __init__(self, values: str) -> None:
+            self.values = values
+
+    class FakeSeasonalityComponent:
+        def apply(self, dayofperiod, sum=True):  # noqa: ANN001, FBT002
+            calls["has_dims"] = hasattr(dayofperiod.type, "dims")
+            calls["sum"] = sum
+            return FakeXTensorResult("xtensor-result")
+
+    result = _call_seasonality_component_apply(
+        FakeSeasonalityComponent(),
+        pt.vector("signal"),
+    )
+
+    assert result == "xtensor-result"
+    assert calls == {
+        "has_dims": True,
+        "sum": True,
+    }
+
+
+def test_call_time_component_apply_supports_tensor_input():
+    calls: dict[str, object] = {}
+
+    class FakeTimeComponent:
+        def apply(self, t):  # noqa: ANN001
+            calls["t"] = t
+            return "time-result"
+
+    signal = pt.vector("signal")
+
+    result = _call_time_component_apply(FakeTimeComponent(), signal)
+
+    assert result == "time-result"
+    assert calls == {"t": signal}
+
+
+def test_call_time_component_apply_supports_xtensor_source():
+    calls: dict[str, object] = {}
+
+    class FakeXTensorResult:
+        def __init__(self, values: str) -> None:
+            self.values = values
+
+    class FakeTimeComponent:
+        def apply(self, t):  # noqa: ANN001
+            # as_xtensor compatibility path
+            calls["has_dims"] = hasattr(t.type, "dims")
+            return FakeXTensorResult("xtensor-time-result")
+
+    result = _call_time_component_apply(FakeTimeComponent(), pt.vector("signal"))
+
+    assert result == "xtensor-time-result"
+    assert calls == {"has_dims": True}
+
+
+def test_uses_xtensor_api_falls_back_to_code_names(monkeypatch):
+    namespace: dict[str, object] = {}
+    exec(  # noqa: S102
+        "def fake_transform(x):\n    return as_xtensor(x)\n",
+        {},
+        namespace,
+    )
+    fake_transform = namespace["fake_transform"]
+
+    def raise_oserror(_function):  # noqa: ANN001
+        raise OSError("source unavailable")
+
+    monkeypatch.setattr("causalpy.pymc_models.inspect.getsource", raise_oserror)
+
+    assert _uses_xtensor_api(fake_transform)


### PR DESCRIPTION
## Summary
- add a small compatibility layer for `BayesianBasisExpansionTimeSeries` trend and seasonality components when newer `pymc-marketing` installs expect xtensor inputs
- keep the change scoped to shared BSTS code in `pymc_models.py`, separate from TF-ITS transfer-function adstock and saturation support
- add focused unit tests plus targeted BSTS integration coverage for the new helper paths

## Test plan
- [x] `CONDA_EXE run -n CausalPy pytest --no-cov causalpy/tests/test_pymc_models_compat.py causalpy/tests/test_integration_its_new_timeseries.py::test_its_with_bsts_model causalpy/tests/test_integration_pymc_examples.py::test_bayesian_structural_time_series causalpy/tests/test_timeseries_model_coverage.py::TestBayesianBasisExpansionTimeSeriesCoverage::test_data_setter_error_x_mismatch causalpy/tests/test_timeseries_model_coverage.py::TestBayesianBasisExpansionTimeSeriesCoverage::test_data_setter_error_missing_exog_vars`
- [x] `CONDA_EXE run -n CausalPy prek run --files causalpy/pymc_models.py causalpy/tests/test_pymc_models_compat.py`
- [x] `CONDA_EXE run -n CausalPy prek run --all-files`

Made with [Cursor](https://cursor.com)