### PR TITLE
Add sub-issue discovery to github-issues skill

### DIFF
--- a/.github/skills/github-issues/reference/issue-evaluation.md
+++ b/.github/skills/github-issues/reference/issue-evaluation.md
@@ -10,10 +10,26 @@ description: Analyze an issue, check current relevance, and propose next steps o
 gh issue view <issue_number> --json number,title,body,state,labels,comments,assignees
 ```
 
+## Check for sub-issues (native hierarchy)
+
+Always check whether an issue has native sub-issues. The `trackedIssues` / `trackedInIssues` GraphQL fields only cover older markdown task-list tracking and will miss native sub-issues.
+
+```bash
+gh api graphql -f query='query {
+  repository(owner:"<owner>", name:"<repo>") {
+    issue(number: <issue_number>) {
+      subIssues(first: 50) { nodes { number title state url } }
+      parent { number title state url }
+    }
+  }
+}'
+```
+
 ## Analyze context
 - Extract the problem statement and acceptance criteria
 - Summarize discussion history and blockers
 - Identify affected files/modules
+- Review sub-issues (if any) for work breakdown and progress
 
 ## Assess relevance
 - Search codebase for mentioned APIs or modules

--- a/.github/skills/github-issues/reference/parent-child-issues.md
+++ b/.github/skills/github-issues/reference/parent-child-issues.md
@@ -91,7 +91,24 @@ gh api graphql \
   -f sub='<CHILD_NODE_ID>'
 ```
 
-## 6) Verify links rendered correctly
+## 6) Discover existing sub-issues
+
+When evaluating an issue that may already have sub-issues, always use the `subIssues` GraphQL field. Do **not** use `trackedIssues` / `trackedInIssues` -- those only cover older markdown task-list tracking and will miss native sub-issues.
+
+```bash
+gh api graphql -f query='query {
+  repository(owner:"<owner>", name:"<repo>") {
+    issue(number: <issue_number>) {
+      subIssues(first: 50) {
+        nodes { number title state url }
+      }
+      parent { number title state url }
+    }
+  }
+}'
+```
+
+## 7) Verify links rendered correctly
 
 ```bash
 gh api graphql -f query='query {


### PR DESCRIPTION
## Summary

Add sub-issue discovery guidance to the github-issues skill so agents check for native GitHub sub-issues when evaluating issues.

- **issue-evaluation.md**: Add a "Check for sub-issues" step using the `subIssues` / `parent` GraphQL fields, and note to review sub-issues during context analysis.
- **parent-child-issues.md**: Add a "Discover existing sub-issues" section (step 6) with the correct GraphQL query and a warning not to use the older `trackedIssues` / `trackedInIssues` fields.

## Motivation

GitHub's native sub-issues use the `subIssues` GraphQL field, not `trackedIssues`. Without this guidance, agents default to the wrong API and silently miss existing sub-issues on a parent issue.

## Test plan

- [x] Skill files are valid markdown
- [x] No code changes; documentation-only
