### PR TITLE
Add SoftmaxWeightedSumFitter for synthetic control

### DIFF
--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -678,6 +678,187 @@ class WeightedSumFitter(PyMCModel):
             self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
 
 
+def _softmax_simplex_weights(
+    name: str,
+    prior: "Prior",
+    n_rows: int,
+    dims: list[str],
+) -> "pt.TensorVariable":
+    """Create simplex weights via softmax-over-Normal-logits with pinned reference.
+
+    Pins the first logit to zero (removing softmax shift invariance), samples
+    ``N - 1`` unconstrained Normal logits, and applies softmax to produce
+    weights on the simplex.
+
+    Parameters
+    ----------
+    name : str
+        Name for the PyMC Deterministic variable (e.g., "beta", "omega").
+    prior : Prior
+        Prior for the raw logits. Must be a Normal prior with appropriate dims.
+    n_rows : int
+        Number of rows in the weight matrix (e.g., n_treated for SC, 1 for SDiD).
+    dims : list[str]
+        Dimension names for the output Deterministic.
+
+    Returns
+    -------
+    pt.TensorVariable
+        Simplex weights as a PyMC Deterministic.
+    """
+    raw = prior.create_variable(f"{name}_raw")
+    if n_rows == 1 and raw.ndim == 1:
+        # 1D case: raw is shape (N-1,), produce 1D simplex of shape (N,)
+        zero_logit = pt.zeros((1,))
+        tilde = pt.concatenate([zero_logit, raw], axis=0)
+        return pm.Deterministic(name, pt.special.softmax(tilde, axis=-1), dims=dims)
+    zero_logit = pt.zeros((n_rows, 1))
+    tilde = pt.concatenate([zero_logit, raw], axis=-1)
+    return pm.Deterministic(name, pt.special.softmax(tilde, axis=-1), dims=dims)
+
+
+class SoftmaxWeightedSumFitter(PyMCModel):
+    r"""
+    Weighted sum model with softmax-over-Normal-logits parameterization.
+
+    An alternative to :class:`WeightedSumFitter` for synthetic control experiments.
+    Instead of a Dirichlet prior on the simplex weights, this model places Normal
+    priors on unconstrained logits and maps them to the simplex via the softmax
+    transform. The first logit is pinned to zero to remove the softmax's shift
+    invariance.
+
+    Defines the PyMC model:
+
+    .. math::
+        \tilde{\beta}_1 &= 0 \\
+        \tilde{\beta}_{j} &\sim \mathrm{Normal}(0, \sigma) \quad j = 2, \ldots, N \\
+        \beta &= \mathrm{softmax}(\tilde{\beta}) \\
+        \mu &= X \cdot \beta \\
+        y &\sim \mathrm{Normal}(\mu, \sigma_y) \\
+
+    Notes
+    -----
+    The softmax-Normal parameterization and the Dirichlet prior used by
+    :class:`WeightedSumFitter` both produce simplex-valued weights, but they
+    encode different prior beliefs and regularization behavior:
+
+    - **Dirichlet** (:class:`WeightedSumFitter`): With concentration ``a=1`` the
+      prior is uniform on the simplex. Setting ``a < 1`` encourages sparsity
+      (weights concentrating on fewer donors), while ``a > 1`` encourages
+      uniformity. Regularization strength is controlled by the concentration
+      parameter.
+
+    - **Softmax-Normal** (this class): The prior scale ``sigma`` on the logits
+      controls regularization. Small ``sigma`` shrinks logits toward zero,
+      producing near-uniform weights (DiD-like behavior). Large ``sigma`` allows
+      the data to concentrate weight on a few well-matching control units
+      (SC-like behavior). The default ``sigma=1.0`` provides moderate
+      regularization.
+
+    This parameterization is motivated by the Bayesian Synthetic
+    Difference-in-Differences (SDiD) formulation, where the prior scale plays
+    the role of the :math:`\ell_2` regularization parameter :math:`\zeta` in the
+    frequentist SDiD of Arkhangelsky et al. (2021).
+
+    Example
+    --------
+    >>> import causalpy as cp
+    >>> import numpy as np
+    >>> import xarray as xr
+    >>> from causalpy.pymc_models import SoftmaxWeightedSumFitter
+    >>> sc = cp.load_data("sc")
+    >>> control_units = ['a', 'b', 'c', 'd', 'e', 'f', 'g']
+    >>> X = xr.DataArray(
+    ...     sc[control_units].values,
+    ...     dims=["obs_ind", "coeffs"],
+    ...     coords={"obs_ind": sc.index, "coeffs": control_units},
+    ... )
+    >>> y = xr.DataArray(
+    ...     sc['actual'].values.reshape((sc.shape[0], 1)),
+    ...     dims=["obs_ind", "treated_units"],
+    ...     coords={"obs_ind": sc.index, "treated_units": ["actual"]},
+    ... )
+    >>> coords = {
+    ...     "coeffs": control_units,
+    ...     "treated_units": ["actual"],
+    ...     "obs_ind": np.arange(sc.shape[0]),
+    ... }
+    >>> wsf = SoftmaxWeightedSumFitter(sample_kwargs={"progressbar": False})
+    >>> wsf.fit(X, y, coords=coords)
+    Inference data...
+    """  # noqa: W605
+
+    default_priors = {
+        "y_hat": Prior(
+            "Normal",
+            sigma=Prior("HalfNormal", sigma=1, dims=["treated_units"]),
+            dims=["obs_ind", "treated_units"],
+        ),
+    }
+
+    def priors_from_data(self, X, y) -> dict[str, Any]:
+        """
+        Set Normal prior for logit weights based on number of control units.
+
+        The prior is placed on ``N - 1`` unconstrained logits (the first logit is
+        pinned to zero). The default scale ``sigma=1.0`` provides moderate
+        regularization, equivalent to ``zeta=1.0`` in the frequentist SDiD.
+
+        Parameters
+        ----------
+        X : xarray.DataArray
+            Control unit data with shape (n_obs, n_control_units).
+        y : xarray.DataArray
+            Treated unit outcome data.
+
+        Returns
+        -------
+        dict[str, Prior]
+            Dictionary containing:
+            - "beta_raw": Normal prior with dims ["treated_units", "coeffs_raw"]
+        """
+        return {
+            "beta_raw": Prior(
+                "Normal",
+                mu=0,
+                sigma=1.0,
+                dims=["treated_units", "coeffs_raw"],
+            ),
+        }
+
+    def build_model(
+        self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None
+    ) -> None:
+        """
+        Build the PyMC model with softmax-parameterized simplex weights.
+        """
+        coeffs_raw = (
+            coords["coeffs"][1:]
+            if coords and "coeffs" in coords
+            else list(range(1, X.shape[1]))
+        )
+
+        with self:
+            coords_with_raw = dict(coords) if coords else {}
+            coords_with_raw["coeffs_raw"] = coeffs_raw
+            self.add_coords(coords_with_raw)
+
+            X = pm.Data("X", X, dims=["obs_ind", "coeffs"])
+            y = pm.Data("y", y, dims=["obs_ind", "treated_units"])
+
+            beta = _softmax_simplex_weights(
+                name="beta",
+                prior=self.priors["beta_raw"],
+                n_rows=y.shape[1],
+                dims=["treated_units", "coeffs"],
+            )
+
+            mu = pm.Deterministic(
+                "mu", pt.dot(X, beta.T), dims=["obs_ind", "treated_units"]
+            )
+            self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
+
+
 class InstrumentalVariableRegression(PyMCModel):
     """Custom PyMC model for instrumental linear regression
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -706,9 +706,15 @@ def _softmax_simplex_weights(
     pt.TensorVariable
         Simplex weights as a PyMC Deterministic.
     """
+    if prior.distribution != "Normal":
+        raise ValueError(
+            f"_softmax_simplex_weights expects a Normal prior, got {prior.distribution}"
+        )
     raw = prior.create_variable(f"{name}_raw")
     if n_rows == 1 and raw.ndim == 1:
-        # 1D case: raw is shape (N-1,), produce 1D simplex of shape (N,)
+        # When the prior has no "treated_units" dim (e.g. SDiD's omega_raw with
+        # dims=["coeffs_raw"]), PyMC creates a 1D tensor.  Concatenate along
+        # axis 0 to produce a 1D simplex of shape (N,).
         zero_logit = pt.zeros((1,))
         tilde = pt.concatenate([zero_logit, raw], axis=0)
         return pm.Deterministic(name, pt.special.softmax(tilde, axis=-1), dims=dims)
@@ -804,6 +810,31 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         pinned to zero). The default scale ``sigma=1.0`` provides moderate
         regularization, equivalent to ``zeta=1.0`` in the frequentist SDiD.
 
+        Unlike :meth:`WeightedSumFitter.priors_from_data`, which must read
+        ``X.shape[1]`` to size the Dirichlet concentration vector, the Normal
+        prior here broadcasts automatically via its ``dims``, so the data shape
+        is not needed.
+
+        To control regularization strength, pass a custom ``beta_raw`` prior::
+
+            # Tighter regularization (more DiD-like, near-uniform weights):
+            model = SoftmaxWeightedSumFitter(
+                priors={
+                    "beta_raw": Prior(
+                        "Normal", mu=0, sigma=0.1, dims=["treated_units", "coeffs_raw"]
+                    )
+                }
+            )
+
+            # Looser regularization (more SC-like, data-driven sparse weights):
+            model = SoftmaxWeightedSumFitter(
+                priors={
+                    "beta_raw": Prior(
+                        "Normal", mu=0, sigma=10, dims=["treated_units", "coeffs_raw"]
+                    )
+                }
+            )
+
         Parameters
         ----------
         X : xarray.DataArray
@@ -832,11 +863,11 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         """
         Build the PyMC model with softmax-parameterized simplex weights.
         """
-        coeffs_raw = (
-            coords["coeffs"][1:]
-            if coords and "coeffs" in coords
-            else list(range(1, X.shape[1]))
-        )
+        if not coords or "coeffs" not in coords:
+            raise ValueError(
+                "coords must include 'coeffs' for SoftmaxWeightedSumFitter"
+            )
+        coeffs_raw = coords["coeffs"][1:]
 
         with self:
             coords_with_raw = dict(coords) if coords else {}

--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -486,6 +486,58 @@ def test_sc(mock_pymc_sample, sc_data):
 
 
 @pytest.mark.integration
+def test_sc_softmax(mock_pymc_sample):
+    """
+    Test Synthetic Control experiment with SoftmaxWeightedSumFitter.
+
+    Verifies that SoftmaxWeightedSumFitter is a drop-in replacement for
+    WeightedSumFitter in the SyntheticControl experiment:
+    1. data is a dataframe
+    2. causalpy.SyntheticControl returns correct type
+    3. the correct number of MCMC chains exists in the posterior inference data
+    4. the correct number of MCMC draws exists in the posterior inference data
+    5. the method get_plot_data returns a DataFrame with expected columns
+    """
+
+    df = cp.load_data("sc")
+    treatment_time = 70
+    result = cp.SyntheticControl(
+        df,
+        treatment_time,
+        control_units=["a", "b", "c", "d", "e", "f", "g"],
+        treated_units=["actual"],
+        model=cp.pymc_models.SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs),
+    )
+    assert isinstance(df, pd.DataFrame)
+    assert isinstance(result, cp.SyntheticControl)
+    assert len(result.idata.posterior.coords["chain"]) == sample_kwargs["chains"]
+    assert len(result.idata.posterior.coords["draw"]) == sample_kwargs["draws"]
+    result.summary()
+
+    fig, ax = result.plot()
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, np.ndarray) and all(
+        isinstance(item, plt.Axes) for item in ax
+    ), "ax must be a numpy.ndarray of plt.Axes"
+
+    plot_data = result.get_plot_data()
+    assert isinstance(plot_data, pd.DataFrame), (
+        "The returned object is not a pandas DataFrame"
+    )
+    expected_columns = [
+        "prediction",
+        "pred_hdi_lower_94",
+        "pred_hdi_upper_94",
+        "impact",
+        "impact_hdi_lower_94",
+        "impact_hdi_upper_94",
+    ]
+    assert set(expected_columns).issubset(set(plot_data.columns)), (
+        f"DataFrame is missing expected columns {expected_columns}"
+    )
+
+
+@pytest.mark.integration
 def test_sc_brexit(mock_pymc_sample):
     """
     Test Synthetic Control experiment on Brexit data.

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -20,7 +20,13 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
-from causalpy.pymc_models import LinearRegression, PyMCModel, WeightedSumFitter
+from causalpy.pymc_models import (
+    LinearRegression,
+    PyMCModel,
+    SoftmaxWeightedSumFitter,
+    WeightedSumFitter,
+    _softmax_simplex_weights,
+)
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
@@ -592,6 +598,113 @@ class TestWeightedSumFitterMultiUnit:
         )
 
 
+class TestSoftmaxSimplexWeights:
+    """Tests for the _softmax_simplex_weights helper."""
+
+    def test_produces_simplex_weights(self):
+        """Test that helper produces a Deterministic variable on the simplex."""
+        prior = Prior("Normal", mu=0, sigma=1.0, dims=["treated_units", "coeffs_raw"])
+        with pm.Model() as model:
+            model.add_coords(
+                {
+                    "coeffs": ["a", "b", "c"],
+                    "coeffs_raw": ["b", "c"],
+                    "treated_units": ["unit_0"],
+                }
+            )
+            _softmax_simplex_weights(
+                name="beta",
+                prior=prior,
+                n_rows=1,
+                dims=["treated_units", "coeffs"],
+            )
+        assert "beta" in [v.name for v in model.deterministics]
+
+    def test_pinned_first_logit(self):
+        """Test that the first logit is pinned (3 coeffs -> 2 raw params)."""
+        prior = Prior("Normal", mu=0, sigma=1.0, dims=["treated_units", "coeffs_raw"])
+        with pm.Model() as model:
+            model.add_coords(
+                {
+                    "coeffs": ["a", "b", "c"],
+                    "coeffs_raw": ["b", "c"],
+                    "treated_units": ["unit_0"],
+                }
+            )
+            _softmax_simplex_weights(
+                name="beta",
+                prior=prior,
+                n_rows=1,
+                dims=["treated_units", "coeffs"],
+            )
+        # Should have beta_raw with 2 free parameters (not 3)
+        raw_vars = [v for v in model.free_RVs if v.name == "beta_raw"]
+        assert len(raw_vars) == 1
+        # beta_raw should have shape (1, 2) — N-1 logits, not N
+        assert raw_vars[0].eval().shape == (1, 2)
+
+
+class TestSoftmaxWeightedSumFitterMultiUnit:
+    """Tests for SoftmaxWeightedSumFitter with multiple treated units."""
+
+    def test_multi_unit_fitting(self, synthetic_control_data):
+        """Test that SoftmaxWeightedSumFitter can fit with multiple treated units."""
+        X, y, coords, control_units, treated_units = synthetic_control_data
+
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        result = wsf.fit(X, y, coords=coords)
+
+        assert isinstance(result, az.InferenceData)
+        assert "posterior" in result.groups()
+        assert "posterior_predictive" in result.groups()
+
+    def test_multi_unit_predictions(self, synthetic_control_data):
+        """Test that predictions work correctly with multiple treated units."""
+        X, y, coords, control_units, treated_units = synthetic_control_data
+
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        wsf.fit(X, y, coords=coords)
+
+        pred = wsf.predict(X)
+        assert isinstance(pred, az.InferenceData)
+        assert "posterior_predictive" in pred.groups()
+
+    def test_coefficients_structure(self, synthetic_control_data):
+        """Test that beta weights sum to 1 along coeffs dim (simplex constraint)."""
+        X, y, coords, control_units, treated_units = synthetic_control_data
+
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        wsf.fit(X, y, coords=coords)
+
+        beta = wsf.idata.posterior["beta"]
+        # Weights should sum to 1 along the coeffs dimension
+        beta_sum = beta.sum(dim="coeffs")
+        np.testing.assert_allclose(beta_sum.values, 1.0, atol=1e-5)
+
+    def test_single_treated_backward_compat(self, single_treated_data):
+        """Test that single treated unit still works."""
+        X, y, coords, control_units, treated_units = single_treated_data
+
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        result = wsf.fit(X, y, coords=coords)
+
+        assert isinstance(result, az.InferenceData)
+        assert "posterior" in result.groups()
+        assert "beta" in result.posterior
+
+    def test_scoring(self, synthetic_control_data):
+        """Test that scoring works with multiple treated units."""
+        X, y, coords, control_units, treated_units = synthetic_control_data
+
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        wsf.fit(X, y, coords=coords)
+
+        scores = wsf.score(X, y)
+        assert isinstance(scores, pd.Series)
+        for i, _unit in enumerate(treated_units):
+            assert f"unit_{i}_r2" in scores.index
+
+
 @pytest.fixture(scope="module")
 def prior_test_data():
     """Generate test data for Prior integration tests (shared across all tests)."""
@@ -665,6 +778,25 @@ class TestPriorIntegration:
         # Check shape matches number of predictors
         assert len(beta_prior.parameters["a"]) == X.shape[1]  # 2 predictors
         assert np.allclose(beta_prior.parameters["a"], np.ones(2))
+
+    def test_softmax_weighted_sum_fitter_priors_from_data(self, prior_test_data):
+        """Test SoftmaxWeightedSumFitter data-driven Normal logit prior generation."""
+        X, y, coords = prior_test_data
+        model = SoftmaxWeightedSumFitter()
+        data_priors = model.priors_from_data(X, y)
+
+        # Should return beta_raw prior based on X shape minus 1 (pinned reference)
+        assert "beta_raw" in data_priors
+        beta_raw_prior = data_priors["beta_raw"]
+
+        # Check it's a Normal prior
+        assert isinstance(beta_raw_prior, Prior)
+        assert beta_raw_prior.distribution == "Normal"
+
+        # Check parameters
+        assert beta_raw_prior.parameters["sigma"] == 1.0
+        assert beta_raw_prior.parameters["mu"] == 0
+        assert beta_raw_prior.dims == ("treated_units", "coeffs_raw")
 
     def test_prior_precedence_system(self, prior_test_data):
         """Test that user priors override data-driven priors override defaults."""

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -643,6 +643,33 @@ class TestSoftmaxSimplexWeights:
         # beta_raw should have shape (1, 2) — N-1 logits, not N
         assert raw_vars[0].eval().shape == (1, 2)
 
+    def test_1d_branch(self):
+        """Test the 1D path when prior has no treated_units dim."""
+        prior = Prior("Normal", mu=0, sigma=1.0, dims=["coeffs_raw"])
+        with pm.Model() as model:
+            model.add_coords({"coeffs": ["a", "b", "c"], "coeffs_raw": ["b", "c"]})
+            result = _softmax_simplex_weights(
+                name="omega",
+                prior=prior,
+                n_rows=1,
+                dims=["coeffs"],
+            )
+        # 1D prior should produce a 1D simplex of shape (3,)
+        assert result.eval().shape == (3,)
+        np.testing.assert_allclose(result.eval().sum(), 1.0)
+
+    def test_rejects_non_normal_prior(self):
+        """Test that a non-Normal prior raises ValueError."""
+        prior = Prior("Dirichlet", a=[1, 1, 1], dims=["coeffs"])
+        with pm.Model():  # noqa: SIM117
+            with pytest.raises(ValueError, match="expects a Normal prior"):
+                _softmax_simplex_weights(
+                    name="beta",
+                    prior=prior,
+                    n_rows=1,
+                    dims=["coeffs"],
+                )
+
 
 class TestSoftmaxWeightedSumFitterMultiUnit:
     """Tests for SoftmaxWeightedSumFitter with multiple treated units."""
@@ -703,6 +730,13 @@ class TestSoftmaxWeightedSumFitterMultiUnit:
         assert isinstance(scores, pd.Series)
         for i, _unit in enumerate(treated_units):
             assert f"unit_{i}_r2" in scores.index
+
+    def test_build_model_raises_without_coeffs_coord(self, synthetic_control_data):
+        """Test that build_model raises ValueError when coords lacks 'coeffs'."""
+        X, y, _coords, _control_units, _treated_units = synthetic_control_data
+        wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
+        with pytest.raises(ValueError, match="coords must include 'coeffs'"):
+            wsf.fit(X, y, coords={"treated_units": ["unit_0"], "obs_ind": [0]})
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Introduces a `_softmax_simplex_weights` helper and `SoftmaxWeightedSumFitter`, providing an alternative to `WeightedSumFitter` for synthetic control that places Normal priors on unconstrained logits and maps to the simplex via softmax (first logit pinned to zero). This parameterisation enables continuous regularisation control via the prior scale, bridging between DiD-uniform and SC-sparse weight regimes.

This PR is the first of two that work towards implementing SDiD 

Relevant Issue: #47 

