### PR TITLE
feat: add legend_kwargs parameter to BaseExperiment.plot()

### DIFF
--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -157,7 +157,13 @@ class BaseExperiment(ABC):
         """Optional maketables plugin hook for default statistic rows."""
         return get_maketables_adapter(self.model).default_stat_keys(self)
 
-    def plot(self, *args: Any, show: bool = True, **kwargs: Any) -> tuple:
+    def plot(
+        self,
+        *args: Any,
+        show: bool = True,
+        legend_kwargs: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> tuple:
         """Plot the model.
 
         Internally, this function dispatches to either `_bayesian_plot` or `_ols_plot`
@@ -168,6 +174,10 @@ class BaseExperiment(ABC):
         show : bool, optional
             Whether to automatically display the plot. Defaults to True.
             Set to False if you want to modify the figure before displaying it.
+        legend_kwargs : dict, optional
+            Keyword arguments passed to ``ax.legend()`` to control legend
+            placement. For example, ``legend_kwargs={"loc": "upper left",
+            "bbox_to_anchor": (1.04, 1)}`` moves the legend outside the axes.
         """
         # Apply arviz-darkgrid style only during plotting, then revert
         with plt.style.context(az.style.library["arviz-darkgrid"]):
@@ -177,6 +187,18 @@ class BaseExperiment(ABC):
                 fig, ax = self._ols_plot(*args, **kwargs)
             else:
                 raise ValueError("Unsupported model type")
+
+        # Apply legend customization if requested
+        if legend_kwargs is not None:
+            axes = ax if isinstance(ax, list) else [ax]
+            try:
+                # Handle numpy arrays of axes (e.g., from plt.subplots(nrows=2))
+                axes = list(ax.flat) if hasattr(ax, "flat") else axes
+            except (TypeError, AttributeError):
+                pass
+            for a in axes:
+                if a.get_legend() is not None:
+                    a.legend(**legend_kwargs)
 
         if show:
             plt.show()

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -33,6 +33,57 @@ from causalpy.reporting import EffectSummary
 from causalpy.skl_models import create_causalpy_compatible_class
 
 
+def _apply_legend_kwargs(legend: Any, kwargs: dict[str, Any]) -> None:
+    """Mutate an existing Legend in place without recreating it.
+
+    This preserves custom handles (e.g. ``(Line2D, PolyCollection)`` tuples
+    built by :func:`~causalpy.plot_utils.plot_xY`) that would be lost if the
+    legend were rebuilt with ``ax.legend()``.
+
+    Supported keys: ``loc``, ``bbox_to_anchor``, ``bbox_transform`` (only
+    with ``bbox_to_anchor``), ``fontsize``, ``frameon``, ``title``.
+
+    Raises
+    ------
+    TypeError
+        If *kwargs* contains keys that cannot be applied in place.
+    """
+    _SUPPORTED = {"loc", "bbox_to_anchor", "bbox_transform", "fontsize", "frameon", "title"}
+    unsupported = set(kwargs) - _SUPPORTED
+    if unsupported:
+        raise TypeError(
+            f"legend_kwargs keys not supported for in-place mutation: "
+            f"{sorted(unsupported)}. Supported keys: {sorted(_SUPPORTED)}"
+        )
+    if "bbox_transform" in kwargs and "bbox_to_anchor" not in kwargs:
+        raise TypeError(
+            "bbox_transform requires bbox_to_anchor to be specified as well"
+        )
+
+    if "loc" in kwargs:
+        loc = kwargs["loc"]
+        # set_loc is public in matplotlib >= 3.8; fall back to the stable
+        # private helper for older versions, converting string names to
+        # numeric codes since _set_loc may not accept strings.
+        if hasattr(legend, "set_loc"):
+            legend.set_loc(loc)
+        else:
+            if isinstance(loc, str):  # pragma: no cover
+                loc = legend.codes.get(loc, loc)
+            legend._set_loc(loc)  # pragma: no cover
+    if "bbox_to_anchor" in kwargs:
+        legend.set_bbox_to_anchor(
+            kwargs["bbox_to_anchor"], kwargs.get("bbox_transform")
+        )
+    if "fontsize" in kwargs:
+        for text in legend.get_texts():
+            text.set_fontsize(kwargs["fontsize"])
+    if "frameon" in kwargs:
+        legend.set_frame_on(kwargs["frameon"])
+    if "title" in kwargs:
+        legend.set_title(kwargs["title"])
+
+
 class BaseExperiment(ABC):
     """Base class for quasi experimental designs.
 
@@ -175,9 +226,22 @@ class BaseExperiment(ABC):
             Whether to automatically display the plot. Defaults to True.
             Set to False if you want to modify the figure before displaying it.
         legend_kwargs : dict, optional
-            Keyword arguments passed to ``ax.legend()`` to control legend
-            placement. For example, ``legend_kwargs={"loc": "upper left",
-            "bbox_to_anchor": (1.04, 1)}`` moves the legend outside the axes.
+            Keyword arguments to adjust legend placement and styling.  The
+            existing legend is modified **in place** so that custom handles
+            (e.g. ``(Line2D, PolyCollection)`` tuples) are fully preserved.
+
+            Supported keys: ``loc``, ``bbox_to_anchor``, ``fontsize``,
+            ``frameon``, ``title``.  ``bbox_transform`` is accepted
+            alongside ``bbox_to_anchor``.
+
+        Examples
+        --------
+        Move the legend outside the plot area to avoid overlap:
+
+        >>> fig, ax = result.plot(  # doctest: +SKIP
+        ...     show=False,
+        ...     legend_kwargs={"loc": "upper left", "bbox_to_anchor": (1.04, 1)},
+        ... )
         """
         # Apply arviz-darkgrid style only during plotting, then revert
         with plt.style.context(az.style.library["arviz-darkgrid"]):
@@ -188,17 +252,24 @@ class BaseExperiment(ABC):
             else:
                 raise ValueError("Unsupported model type")
 
-        # Apply legend customization if requested
+        # Apply legend customization if requested.  We mutate the existing
+        # Legend object in place so that custom handles — especially the
+        # (Line2D, PolyCollection) tuples built by plot_xY — are preserved
+        # exactly as the subclass created them.
         if legend_kwargs is not None:
             axes = ax if isinstance(ax, list) else [ax]
-            try:
+            with contextlib.suppress(TypeError, AttributeError):
                 # Handle numpy arrays of axes (e.g., from plt.subplots(nrows=2))
                 axes = list(ax.flat) if hasattr(ax, "flat") else axes
-            except (TypeError, AttributeError):
-                pass
             for a in axes:
-                if a.get_legend() is not None:
-                    a.legend(**legend_kwargs)
+                legend = a.get_legend()
+                if legend is not None:
+                    _apply_legend_kwargs(legend, legend_kwargs)
+            # Recompute layout when the legend is placed outside the axes
+            # so it is not clipped (some subclass plots already call
+            # tight_layout before we get here).
+            if "bbox_to_anchor" in legend_kwargs:
+                fig.tight_layout()
 
         if show:
             plt.show()

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -48,7 +48,14 @@ def _apply_legend_kwargs(legend: Any, kwargs: dict[str, Any]) -> None:
     TypeError
         If *kwargs* contains keys that cannot be applied in place.
     """
-    _SUPPORTED = {"loc", "bbox_to_anchor", "bbox_transform", "fontsize", "frameon", "title"}
+    _SUPPORTED = {
+        "loc",
+        "bbox_to_anchor",
+        "bbox_transform",
+        "fontsize",
+        "frameon",
+        "title",
+    }
     unsupported = set(kwargs) - _SUPPORTED
     if unsupported:
         raise TypeError(
@@ -257,10 +264,13 @@ class BaseExperiment(ABC):
         # (Line2D, PolyCollection) tuples built by plot_xY — are preserved
         # exactly as the subclass created them.
         if legend_kwargs is not None:
-            axes = ax if isinstance(ax, list) else [ax]
-            with contextlib.suppress(TypeError, AttributeError):
-                # Handle numpy arrays of axes (e.g., from plt.subplots(nrows=2))
-                axes = list(ax.flat) if hasattr(ax, "flat") else axes
+            # Normalise ax to a flat list so we can iterate uniformly.
+            if hasattr(ax, "flat"):
+                axes = list(ax.flat)
+            elif isinstance(ax, list):
+                axes = ax
+            else:
+                axes = [ax]
             for a in axes:
                 legend = a.get_legend()
                 if legend is not None:

--- a/causalpy/tests/test_plot_show_parameter.py
+++ b/causalpy/tests/test_plot_show_parameter.py
@@ -12,14 +12,16 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """
-Tests for the plot() method's show parameter functionality.
+Tests for the plot() method's show parameter and legend_kwargs functionality.
 
 This module tests that the plot() method correctly handles the show parameter
-to control automatic plot display in Jupyter notebooks.
+to control automatic plot display in Jupyter notebooks, and that legend_kwargs
+preserves existing legend content while allowing customization.
 """
 
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 from matplotlib import pyplot as plt
 from sklearn.linear_model import LinearRegression
@@ -137,3 +139,293 @@ def test_plot_show_parameter_false_skl(did_data):
         mock_show.assert_not_called()
         assert isinstance(fig, plt.Figure)
         assert isinstance(ax, plt.Axes)
+
+
+# ---------------------------------------------------------------------------
+# legend_kwargs tests
+# ---------------------------------------------------------------------------
+
+
+def _legend_handle_count(legend):
+    """Return the number of handles in a legend (cross-version)."""
+    handles = getattr(
+        legend, "legend_handles", getattr(legend, "legendHandles", None)
+    )
+    return len(handles) if handles is not None else 0
+
+
+@pytest.mark.integration
+def test_legend_kwargs_preserves_labels_pymc(mock_pymc_sample, did_data):
+    """
+    Test that legend_kwargs preserves existing legend labels for PyMC models.
+
+    DiD Bayesian plots create custom legends with (line, patch) tuple handles.
+    Passing legend_kwargs must not drop those entries.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    # Plot without legend_kwargs to get baseline
+    with patch("matplotlib.pyplot.show"):
+        _, ax_baseline = result.plot()
+    baseline_legend = ax_baseline.get_legend()
+    baseline_labels = [t.get_text() for t in baseline_legend.get_texts()]
+    baseline_handle_count = _legend_handle_count(baseline_legend)
+    plt.close("all")
+
+    # Plot with legend_kwargs — in-place mutation must preserve everything
+    with patch("matplotlib.pyplot.show"):
+        _, ax_custom = result.plot(legend_kwargs={"loc": "lower left"})
+    custom_legend = ax_custom.get_legend()
+    custom_labels = [t.get_text() for t in custom_legend.get_texts()]
+
+    assert custom_legend is not None, "Legend must still exist after legend_kwargs"
+    assert custom_labels == baseline_labels, "Legend labels must be preserved"
+    assert _legend_handle_count(custom_legend) == baseline_handle_count, (
+        "Legend handle count must be preserved"
+    )
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_preserves_labels_skl(did_data):
+    """
+    Test that legend_kwargs preserves existing legend labels for OLS models.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    # Plot without legend_kwargs to get baseline
+    with patch("matplotlib.pyplot.show"):
+        _, ax_baseline = result.plot()
+    baseline_legend = ax_baseline.get_legend()
+    baseline_labels = [t.get_text() for t in baseline_legend.get_texts()]
+    baseline_handle_count = _legend_handle_count(baseline_legend)
+    plt.close("all")
+
+    # Plot with legend_kwargs
+    with patch("matplotlib.pyplot.show"):
+        _, ax_custom = result.plot(legend_kwargs={"loc": "lower left"})
+    custom_legend = ax_custom.get_legend()
+    custom_labels = [t.get_text() for t in custom_legend.get_texts()]
+
+    assert custom_legend is not None, "Legend must still exist after legend_kwargs"
+    assert custom_labels == baseline_labels, "Legend labels must be preserved"
+    assert _legend_handle_count(custom_legend) == baseline_handle_count, (
+        "Legend handle count must be preserved"
+    )
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_changes_location_pymc(mock_pymc_sample, did_data):
+    """
+    Test that legend_kwargs with loc does not crash and preserves the legend.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    # Get baseline labels
+    with patch("matplotlib.pyplot.show"):
+        _, ax_baseline = result.plot()
+    baseline_labels = [t.get_text() for t in ax_baseline.get_legend().get_texts()]
+    plt.close("all")
+
+    # Apply loc change — must preserve labels and not crash
+    with patch("matplotlib.pyplot.show"):
+        fig, ax = result.plot(legend_kwargs={"loc": "lower right"})
+    assert isinstance(fig, plt.Figure)
+    legend = ax.get_legend()
+    assert legend is not None
+    assert [t.get_text() for t in legend.get_texts()] == baseline_labels
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_bbox_to_anchor_triggers_layout(mock_pymc_sample, did_data):
+    """
+    Test that bbox_to_anchor triggers fig.tight_layout() to avoid clipping.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    with (
+        patch("matplotlib.pyplot.show"),
+        patch("matplotlib.figure.Figure.tight_layout") as mock_tl,
+    ):
+        fig, ax = result.plot(
+            legend_kwargs={"loc": "upper left", "bbox_to_anchor": (1.04, 1)},
+        )
+    assert isinstance(fig, plt.Figure)
+    assert ax.get_legend() is not None
+    mock_tl.assert_called_once()
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_frameon_and_title(mock_pymc_sample, did_data):
+    """
+    Test that frameon and title kwargs are applied in place.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    with patch("matplotlib.pyplot.show"):
+        _, ax = result.plot(
+            legend_kwargs={"frameon": False, "title": "My Legend"},
+        )
+    legend = ax.get_legend()
+    assert legend is not None
+    assert legend.get_frame_on() is False
+    assert legend.get_title().get_text() == "My Legend"
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_unsupported_key_raises(mock_pymc_sample, did_data):
+    """
+    Test that unsupported legend_kwargs keys raise TypeError.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    with pytest.raises(TypeError, match="not supported"), patch("matplotlib.pyplot.show"):
+        result.plot(legend_kwargs={"ncol": 2})
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_bbox_transform_without_anchor_raises(mock_pymc_sample, did_data):
+    """
+    Test that bbox_transform without bbox_to_anchor raises TypeError.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    with (
+        pytest.raises(TypeError, match="bbox_transform requires bbox_to_anchor"),
+        patch("matplotlib.pyplot.show"),
+    ):
+        result.plot(legend_kwargs={"bbox_transform": None})
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_preserves_fontsize(mock_pymc_sample, did_data):
+    """
+    Test that existing legend fontsize is preserved when not overridden,
+    and that an explicit fontsize override takes effect.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    # Get baseline fontsize
+    with patch("matplotlib.pyplot.show"):
+        _, ax_baseline = result.plot()
+    baseline_fontsize = ax_baseline.get_legend().get_texts()[0].get_fontsize()
+    plt.close("all")
+
+    # legend_kwargs without fontsize — fontsize must be unchanged
+    with patch("matplotlib.pyplot.show"):
+        _, ax_custom = result.plot(legend_kwargs={"loc": "lower right"})
+    assert ax_custom.get_legend().get_texts()[0].get_fontsize() == baseline_fontsize
+    plt.close("all")
+
+    # legend_kwargs with explicit fontsize override
+    with patch("matplotlib.pyplot.show"):
+        _, ax_override = result.plot(legend_kwargs={"fontsize": 8})
+    assert ax_override.get_legend().get_texts()[0].get_fontsize() == 8
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_none_is_noop(mock_pymc_sample, did_data):
+    """
+    Test that legend_kwargs=None (default) does not alter the plot.
+    """
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    with patch("matplotlib.pyplot.show"):
+        fig, ax = result.plot(legend_kwargs=None)
+    assert isinstance(fig, plt.Figure)
+    assert ax.get_legend() is not None
+    plt.close("all")
+
+
+@pytest.mark.integration
+def test_legend_kwargs_multi_axis_its(mock_pymc_sample, its_data):
+    """
+    Test legend_kwargs on a multi-axis experiment (ITS has 3 axes).
+
+    This exercises the numpy-array / list-of-axes flattening logic and
+    verifies that legends on the first axes are preserved.
+    """
+    result = cp.InterruptedTimeSeries(
+        its_data,
+        formula="y ~ 1 + t",
+        treatment_time=pd.to_datetime("2017-01-01"),
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    # Get baseline legend from first axes
+    with patch("matplotlib.pyplot.show"):
+        _, axes_baseline = result.plot()
+    baseline_legend = axes_baseline[0].get_legend()
+    baseline_labels = [t.get_text() for t in baseline_legend.get_texts()]
+    plt.close("all")
+
+    # Apply legend_kwargs — should preserve labels on all legend-bearing axes
+    with patch("matplotlib.pyplot.show"):
+        fig, axes_custom = result.plot(legend_kwargs={"loc": "lower left"})
+    assert isinstance(fig, plt.Figure)
+    custom_legend = axes_custom[0].get_legend()
+    assert custom_legend is not None
+    custom_labels = [t.get_text() for t in custom_legend.get_texts()]
+    assert custom_labels == baseline_labels
+    plt.close("all")

--- a/causalpy/tests/test_plot_show_parameter.py
+++ b/causalpy/tests/test_plot_show_parameter.py
@@ -148,9 +148,7 @@ def test_plot_show_parameter_false_skl(did_data):
 
 def _legend_handle_count(legend):
     """Return the number of handles in a legend (cross-version)."""
-    handles = getattr(
-        legend, "legend_handles", getattr(legend, "legendHandles", None)
-    )
+    handles = getattr(legend, "legend_handles", getattr(legend, "legendHandles", None))
     return len(handles) if handles is not None else 0
 
 
@@ -319,7 +317,10 @@ def test_legend_kwargs_unsupported_key_raises(mock_pymc_sample, did_data):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    with pytest.raises(TypeError, match="not supported"), patch("matplotlib.pyplot.show"):
+    with (
+        pytest.raises(TypeError, match="not supported"),
+        patch("matplotlib.pyplot.show"),
+    ):
         result.plot(legend_kwargs={"ncol": 2})
     plt.close("all")
 


### PR DESCRIPTION
## Summary

Add `legend_kwargs` parameter to `BaseExperiment.plot()` to allow users to control legend placement, fixing the overlap issue in causal impact plots.

## Usage

```python
result.plot(legend_kwargs={"loc": "upper left", "bbox_to_anchor": (1.04, 1)})
```

## Implementation

- New `legend_kwargs: dict | None` parameter in `BaseExperiment.plot()`
- Applied to all axes that have a legend after the plot is created
- Handles single Axes, lists, and numpy arrays of axes
- Skips axes without legends (no-op safety)

## Design decision

Per maintainer feedback, this uses arbitrary kwargs passed to `ax.legend()` rather than a string-based position enum, giving users full control while keeping good defaults.

Closes #341