### PR TITLE
docs: improve parameter docstrings in InversePropensityWeighting class

### DIFF
--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -131,8 +131,9 @@ class InversePropensityWeighting(BaseExperiment):
         Checks that both the treatment variable (left-hand side of the formula)
         and the ``outcome_variable`` exist in ``self.data``, and that the
         treatment variable has at most two unique values.  Note that a
-        constant (single-value) treatment passes this check without error;
-        downstream estimators will simply return zero treatment effect.
+        constant (single-value) treatment passes this check without error
+        but may cause downstream estimators to fail or produce undefined
+        results.
 
         Raises
         ------

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -97,7 +97,13 @@ class InversePropensityWeighting(BaseExperiment):
         self.algorithm()
 
     def _build_design_matrices(self) -> None:
-        """Build design matrices for propensity score model."""
+        """Build design matrices for the propensity score model.
+
+        Uses the patsy formula stored in ``self.formula`` to construct treatment
+        and covariate matrices from ``self.data``.  Also creates an augmented
+        design matrix (``self.X_outcome``) that includes the treatment indicator,
+        for use with doubly-robust outcome modelling.
+        """
         t, X = dmatrices(self.formula, self.data)
         self._t_design_info = t.design_info
         self._t_design_info = X.design_info
@@ -112,11 +118,26 @@ class InversePropensityWeighting(BaseExperiment):
         self.coords["outcome_coeffs"] = self.X_outcome.columns
 
     def algorithm(self) -> None:
-        """Run the experiment algorithm: fit propensity score model."""
+        """Run the experiment algorithm by fitting the propensity score model.
+
+        Delegates to ``self.model.fit`` with the covariate matrix ``self.X``,
+        treatment vector ``self.t``, and coordinate metadata ``self.coords``.
+        """
         self.model.fit(X=self.X, t=self.t, coords=self.coords)  # type: ignore[call-arg]
 
     def input_validation(self) -> None:
-        """Validate the input data and model formula for correctness"""
+        """Validate the input data and model formula for correctness.
+
+        Checks that both the treatment variable (left-hand side of the formula)
+        and the ``outcome_variable`` exist in ``self.data``, and that the
+        treatment variable is binary (exactly two unique values).
+
+        Raises
+        ------
+        DataException
+            If the treatment or outcome variable is missing from the data,
+            or if the treatment variable is not binary.
+        """
         treatment = self.formula.split("~")[0]
         test = treatment.strip() in self.data.columns
         test = test & (self.outcome_variable in self.data.columns)
@@ -138,7 +159,26 @@ class InversePropensityWeighting(BaseExperiment):
             )
 
     def _prepare_ps(self, ps: np.ndarray, eps: float = 1e-6) -> np.ndarray:
-        """Checks for extreme propensity scores and clips them for stability."""
+        """Check for extreme propensity scores and clip them for numerical stability.
+
+        Parameters
+        ----------
+        ps : np.ndarray
+            Raw propensity scores for each observation, expected in [0, 1].
+        eps : float, optional
+            Clipping tolerance.  Scores are capped to the interval
+            ``[eps, 1 - eps]``.  Defaults to 1e-6.
+
+        Returns
+        -------
+        np.ndarray
+            Clipped propensity scores in ``[eps, 1 - eps]``.
+
+        Warns
+        -----
+        UserWarning
+            If any scores fall outside ``[eps, 1 - eps]`` before clipping.
+        """
         if np.any((ps < eps) | (ps > 1 - eps)):
             warnings.warn(
                 f"Extreme propensity scores detected (outside [{eps}, {1 - eps}]). "
@@ -151,9 +191,25 @@ class InversePropensityWeighting(BaseExperiment):
     def make_robust_adjustments(
         self, ps: np.ndarray
     ) -> tuple[pd.Series, pd.Series, int, int]:
-        """This estimator is discussed in Aronow
-        and Miller's book as being related to the
-        Horvitz Thompson method"""
+        """Compute inverse-propensity-weighted outcomes using the robust (Horvitz-Thompson) scheme.
+
+        This estimator is discussed in Aronow and Miller's
+        *Foundations of Agnostic Statistics* as being related to the
+        Horvitz-Thompson method.
+
+        Parameters
+        ----------
+        ps : np.ndarray
+            Propensity scores for each observation.
+
+        Returns
+        -------
+        tuple[pd.Series, pd.Series, int, int]
+            A tuple of ``(weighted_outcome0, weighted_outcome1, n_ntrt, n_trt)``
+            where the weighted outcomes are the IPW-adjusted outcome values for the
+            control and treated groups, and ``n_ntrt`` / ``n_trt`` are the
+            corresponding group sizes used for normalisation.
+        """
         ps = self._prepare_ps(ps)  # <--- Safety Check
         X = pd.DataFrame(self.X, columns=self.labels)
         X["ps"] = ps
@@ -174,9 +230,27 @@ class InversePropensityWeighting(BaseExperiment):
     def make_raw_adjustments(
         self, ps: np.ndarray
     ) -> tuple[pd.Series, pd.Series, int, int]:
-        """This estimator is discussed in Aronow and
-        Miller as the simplest of base form of
-        inverse propensity weighting schemes"""
+        """Compute inverse-propensity-weighted outcomes using the raw (basic) scheme.
+
+        This is the simplest form of inverse propensity weighting, as discussed
+        in Aronow and Miller's *Foundations of Agnostic Statistics*.  Each
+        observation is weighted by the reciprocal of its propensity score (or
+        ``1 - ps`` for the control group).
+
+        Parameters
+        ----------
+        ps : np.ndarray
+            Propensity scores for each observation.
+
+        Returns
+        -------
+        tuple[pd.Series, pd.Series, int, int]
+            A tuple of ``(weighted_outcome0, weighted_outcome1, n_ntrt, n_trt)``
+            where the weighted outcomes are the IPW-adjusted outcome values for the
+            control and treated groups.  ``n_ntrt`` and ``n_trt`` are both equal
+            to the total number of observations (the raw scheme normalises by
+            the full sample size).
+        """
         ps = self._prepare_ps(ps)  # <--- Safety Check
         X = pd.DataFrame(self.X, columns=self.labels)
         X["ps"] = ps
@@ -196,10 +270,27 @@ class InversePropensityWeighting(BaseExperiment):
     def make_overlap_adjustments(
         self, ps: np.ndarray
     ) -> tuple[pd.Series, pd.Series, pd.Series, pd.Series]:
-        """This weighting scheme was adapted from
-        Lucy D’Agostino McGowan's blog on
-        Propensity Score Weights referenced in
-        the primary CausalPy explainer notebook"""
+        """Compute inverse-propensity-weighted outcomes using the overlap scheme.
+
+        This weighting scheme was adapted from Lucy D’Agostino McGowan’s blog
+        on propensity score weights, referenced in the primary CausalPy
+        explainer notebook.  Overlap weights target the population for which
+        there is clinical equipoise (i.e., where propensity scores are near
+        0.5), reducing sensitivity to extreme scores.
+
+        Parameters
+        ----------
+        ps : np.ndarray
+            Propensity scores for each observation.
+
+        Returns
+        -------
+        tuple[pd.Series, pd.Series, pd.Series, pd.Series]
+            A tuple of ``(weighted_outcome0, weighted_outcome1, n_ntrt, n_trt)``
+            where the weighted outcomes and normalisation terms are all
+            ``pd.Series`` (unlike the raw/robust schemes which return integer
+            counts).
+        """
         ps = self._prepare_ps(ps)  # <--- Safety Check
         X = pd.DataFrame(self.X, columns=self.labels)
         X["ps"] = ps
@@ -219,12 +310,27 @@ class InversePropensityWeighting(BaseExperiment):
     def make_doubly_robust_adjustment(
         self, ps: np.ndarray
     ) -> tuple[pd.Series, pd.Series, None, None]:
-        """The doubly robust weighting scheme is also
-        discussed in Aronow and Miller, but a bit more generally
-        than our implementation here. Here we have specified
-        the outcome model to be a simple OLS model.
-        In this way the compromise between the outcome model and
-        the propensity model is always done with OLS."""
+        """Compute doubly-robust adjusted outcomes.
+
+        The doubly-robust weighting scheme is discussed in Aronow and Miller's
+        *Foundations of Agnostic Statistics*.  This implementation fixes the
+        outcome model to ordinary least squares (OLS), so the compromise
+        between the outcome model and the propensity model is always performed
+        with a linear regression.
+
+        Parameters
+        ----------
+        ps : np.ndarray
+            Propensity scores for each observation.
+
+        Returns
+        -------
+        tuple[pd.Series, pd.Series, None, None]
+            A tuple of ``(weighted_outcome0, weighted_outcome1, None, None)``.
+            The two ``None`` values are returned for interface consistency with
+            the other adjustment methods; no explicit group sizes are needed
+            because the doubly-robust estimator averages over all observations.
+        """
         ps = self._prepare_ps(ps)  # <--- Safety Check
         X = pd.DataFrame(self.X, columns=self.labels)
         X["ps"] = ps
@@ -401,6 +507,39 @@ class InversePropensityWeighting(BaseExperiment):
         prop_draws: int = 100,
         ate_draws: int = 300,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
+        """Plot the Average Treatment Effect and propensity score distributions.
+
+        Produces a three-panel figure:
+
+        * **Top panel** -- Weighted and unweighted histograms of posterior
+          propensity scores for treated and control groups, drawn from
+          ``prop_draws`` posterior samples.
+        * **Bottom-left panel** -- Histograms of the reweighted potential
+          outcomes E[Y(1)] and E[Y(0)].
+        * **Bottom-right panel** -- Histogram of the ATE distribution with a
+          vertical line at its posterior mean.
+
+        Parameters
+        ----------
+        idata : az.InferenceData | None, optional
+            ArviZ InferenceData with posterior propensity score samples.
+            If ``None``, uses ``self.model.idata``.
+        method : str | None, optional
+            Weighting scheme to apply.  One of ``'robust'``, ``'raw'``,
+            ``'overlap'``, or ``'doubly_robust'``.  If ``None``, falls back
+            to ``self.weighting_scheme``.
+        prop_draws : int, optional
+            Number of posterior draws used for the propensity score histogram.
+            Defaults to 100.
+        ate_draws : int, optional
+            Number of posterior draws used to compute ATE samples.
+            Defaults to 300.
+
+        Returns
+        -------
+        tuple[plt.Figure, list[plt.Axes]]
+            The matplotlib Figure and a list of three Axes objects.
+        """
         if idata is None:
             idata = self.model.idata
         if method is None:
@@ -531,8 +670,31 @@ class InversePropensityWeighting(BaseExperiment):
     def weighted_percentile(
         self, data: np.ndarray, weights: np.ndarray, perc: float
     ) -> float:
-        """
-        perc : percentile in [0-1]!
+        """Compute a weighted percentile of the data.
+
+        Sorts ``data`` and ``weights`` together, builds a weighted empirical
+        CDF, and linearly interpolates to find the value at the requested
+        percentile.
+
+        Parameters
+        ----------
+        data : np.ndarray
+            One-dimensional array of data values.
+        weights : np.ndarray
+            Non-negative weights corresponding to each element of ``data``.
+        perc : float
+            Desired percentile expressed as a fraction in ``[0, 1]``
+            (e.g., 0.5 for the median).
+
+        Returns
+        -------
+        float
+            The interpolated data value at the given weighted percentile.
+
+        Raises
+        ------
+        ValueError
+            If ``perc`` is not between 0 and 1.
         """
         if not (0 <= perc <= 1):
             raise ValueError("Percentile must be between 0 and 1.")
@@ -550,12 +712,31 @@ class InversePropensityWeighting(BaseExperiment):
         idata: az.InferenceData | None = None,
         weighting_scheme: str | None = None,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """
-        Plotting function takes a single covariate and shows the
-        differences in the ECDF between the treatment and control
-        groups before and after weighting. It provides a visual
-        check on the balance achieved by using the different weighting
-        schemes
+        """Plot the empirical CDF of a covariate before and after IPW adjustment.
+
+        Produces a two-panel figure comparing the raw (unweighted) ECDFs of
+        the treated and control groups with the reweighted ECDFs.  This serves
+        as a visual balance diagnostic: well-balanced covariates should show
+        overlapping ECDFs in the right-hand panel.
+
+        Parameters
+        ----------
+        covariate : str
+            Name of the covariate column (must be one of the model's design
+            matrix labels) to check for balance.
+        idata : az.InferenceData | None, optional
+            ArviZ InferenceData containing posterior propensity score samples.
+            If ``None``, uses ``self.model.idata``.
+        weighting_scheme : str | None, optional
+            Weighting scheme to apply.  One of ``'raw'``, ``'robust'``, or
+            ``'overlap'``.  If ``None``, falls back to
+            ``self.weighting_scheme``.
+
+        Returns
+        -------
+        tuple[plt.Figure, list[plt.Axes]]
+            The matplotlib Figure and a list of two Axes objects (raw ECDF on
+            the left, weighted ECDF on the right).
         """
         if idata is None:
             idata = self.model.idata
@@ -636,10 +817,46 @@ class InversePropensityWeighting(BaseExperiment):
         prefix: str = "Post-period",
         **kwargs: Any,
     ) -> EffectSummary:
-        """
-        Generate a decision-ready summary of causal effects.
+        """Generate a decision-ready summary of causal effects.
 
-        Note: effect_summary is not yet implemented for InversePropensityWeighting experiments.
+        .. note::
+
+            This method is not yet implemented for
+            ``InversePropensityWeighting`` experiments.  Calling it will raise
+            ``NotImplementedError``.
+
+        Parameters
+        ----------
+        window : str | tuple | slice, optional
+            Time window for analysis.  Defaults to ``"post"``.
+        direction : ``"increase"`` | ``"decrease"`` | ``"two-sided"``, optional
+            Direction for tail probability calculation.  Defaults to
+            ``"increase"``.
+        alpha : float, optional
+            Significance level for HDI/CI intervals.  Defaults to 0.05.
+        cumulative : bool, optional
+            Whether to include cumulative effect statistics.  Defaults to
+            ``True``.
+        relative : bool, optional
+            Whether to include relative effect statistics.  Defaults to
+            ``True``.
+        min_effect : float | None, optional
+            ROPE threshold for practical equivalence.  Defaults to ``None``.
+        treated_unit : str | None, optional
+            For multi-unit experiments, the unit to analyse.  Defaults to
+            ``None``.
+        period : ``"intervention"`` | ``"post"`` | ``"comparison"`` | None, optional
+            Period to summarise for multi-period experiments.  Defaults to
+            ``None``.
+        prefix : str, optional
+            Label prefix for prose generation.  Defaults to ``"Post-period"``.
+        **kwargs : Any
+            Additional keyword arguments (currently unused).
+
+        Raises
+        ------
+        NotImplementedError
+            Always raised; this method is a placeholder for future work.
         """
         raise NotImplementedError(
             "effect_summary is not yet implemented for InversePropensityWeighting experiments."

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -130,7 +130,7 @@ class InversePropensityWeighting(BaseExperiment):
 
         Checks that both the treatment variable (left-hand side of the formula)
         and the ``outcome_variable`` exist in ``self.data``, and that the
-        treatment variable is binary (exactly two unique values).
+        treatment variable is binary (at most two unique values).
 
         Raises
         ------
@@ -827,7 +827,7 @@ class InversePropensityWeighting(BaseExperiment):
 
         Parameters
         ----------
-        window : str | tuple | slice, optional
+        window : Literal["post"] | tuple | slice, optional
             Time window for analysis.  Defaults to ``"post"``.
         direction : ``"increase"`` | ``"decrease"`` | ``"two-sided"``, optional
             Direction for tail probability calculation.  Defaults to

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -130,13 +130,15 @@ class InversePropensityWeighting(BaseExperiment):
 
         Checks that both the treatment variable (left-hand side of the formula)
         and the ``outcome_variable`` exist in ``self.data``, and that the
-        treatment variable is binary (at most two unique values).
+        treatment variable has at most two unique values.  Note that a
+        constant (single-value) treatment passes this check without error;
+        downstream estimators will simply return zero treatment effect.
 
         Raises
         ------
         DataException
             If the treatment or outcome variable is missing from the data,
-            or if the treatment variable is not binary.
+            or if the treatment variable has more than two unique values.
         """
         treatment = self.formula.split("~")[0]
         test = treatment.strip() in self.data.columns
@@ -513,7 +515,10 @@ class InversePropensityWeighting(BaseExperiment):
 
         * **Top panel** -- Weighted and unweighted histograms of posterior
           propensity scores for treated and control groups, drawn from
-          ``prop_draws`` posterior samples.
+          ``prop_draws`` posterior samples.  The ``"raw"`` method shows
+          unweighted counts; ``"overlap"`` uses overlap weights; all other
+          methods (``"robust"``, ``"doubly_robust"``) share a common
+          IPW-weighted histogram branch.
         * **Bottom-left panel** -- Histograms of the reweighted potential
           outcomes E[Y(1)] and E[Y(0)].
         * **Bottom-right panel** -- Histogram of the ATE distribution with a

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -46,7 +46,7 @@ class InversePropensityWeighting(BaseExperiment):
         A string denoting the outcome variable in data to be reweighted.
     weighting_scheme : str
         A string denoting which weighting scheme to use among: 'raw',
-        'robust', 'doubly robust' or 'overlap'. See Aronow and Miller
+        'robust', 'doubly_robust' or 'overlap'. See Aronow and Miller
         "Foundations of Agnostic Statistics" for discussion and computation
         of these weighting schemes.
     model : PropensityScore, optional


### PR DESCRIPTION
## Summary

Improve 12 method docstrings in `InversePropensityWeighting` to add missing Parameters, Returns, Raises, and Warns sections.

## Methods updated

| Method | Added |
|--------|-------|
| `_build_design_matrices` | Description of patsy formula usage |
| `algorithm` | Delegation description |
| `input_validation` | Parameters, Raises sections |
| `_prepare_ps` | Parameters, Returns, Warns |
| `make_robust_adjustments` | Parameters, Returns |
| `make_raw_adjustments` | Parameters, Returns |
| `make_overlap_adjustments` | Parameters, Returns |
| `make_doubly_robust_adjustment` | Parameters, Returns |
| `plot_ate` | Full docstring (was missing) |
| `weighted_percentile` | Parameters, Returns, Raises |
| `plot_balance_ecdf` | Parameters, Returns |
| `effect_summary` | Parameters, Raises |

## Codex review corrections

- `input_validation`: "exactly two" → "at most two" unique values (matches `> 2` check)
- `effect_summary`: `window` type `str` → `Literal["post"]` (matches signature)
- `weighting_scheme`: `'doubly robust'` → `'doubly_robust'` (matches implementation)

Ref #388