### PR TITLE
Fix mypy type: ignore codes in panel_regression.py

### DIFF
--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -557,7 +557,7 @@ class PanelRegression(BaseExperiment):
         """
         # Get posterior predictions
         if isinstance(self.model, PyMCModel):
-            mu = self.model.idata.posterior["mu"]  # type: ignore[attr-defined]
+            mu = self.model.idata.posterior["mu"]  # type: ignore[union-attr]
             pred_mean = mu.mean(dim=["chain", "draw"]).values.flatten()
             pred_lower = mu.quantile(0.025, dim=["chain", "draw"]).values.flatten()
             pred_upper = mu.quantile(0.975, dim=["chain", "draw"]).values.flatten()
@@ -673,7 +673,7 @@ class PanelRegression(BaseExperiment):
 
         if isinstance(self.model, PyMCModel):
             # Bayesian: get posterior means
-            beta = self.model.idata.posterior["beta"]  # type: ignore[attr-defined]
+            beta = self.model.idata.posterior["beta"]  # type: ignore[union-attr]
             unit_fe_indices = [self.labels.index(name) for name in unit_fe_names]
 
             # Get mean and std for each unit FE

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -680,7 +680,7 @@ class PanelRegression(BaseExperiment):
             fe_means = []
             for idx in unit_fe_indices:
                 fe_means.append(
-                    float(beta.sel(coeffs=self.labels[idx]).mean(dim=["chain", "draw"]))
+                    beta.sel(coeffs=self.labels[idx]).mean(dim=["chain", "draw"]).item()
                 )
 
             ax.hist(

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -680,7 +680,10 @@ class PanelRegression(BaseExperiment):
             fe_means = []
             for idx in unit_fe_indices:
                 fe_means.append(
-                    beta.sel(coeffs=self.labels[idx]).mean(dim=["chain", "draw"]).item()
+                    beta.sel(coeffs=self.labels[idx])
+                    .mean(dim=["chain", "draw"])
+                    .squeeze("treated_units", drop=True)
+                    .item()
                 )
 
             ax.hist(

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -290,6 +290,9 @@ def test_panel_regression_plot_coefficients(mock_pymc_sample, small_panel_data):
 
 
 @pytest.mark.integration
+@pytest.mark.filterwarnings(
+    "error:Conversion of an array with ndim > 0 to a scalar:DeprecationWarning"
+)
 def test_panel_regression_plot_unit_effects(mock_pymc_sample, small_panel_data):
     """Test plot_unit_effects method."""
     result = cp.PanelRegression(


### PR DESCRIPTION
## Summary

Fix two bugs in `panel_regression.py`:
1. Wrong `type: ignore` error codes that cause mypy to fail during pre-commit
2. `plot_unit_effects` crashes with `TypeError` when posterior has a `treated_units` dimension

Fixes #852

## Changes

- `panel_regression.py:560` -- `[attr-defined]` replaced with `[union-attr]`
- `panel_regression.py:676` -- `[attr-defined]` replaced with `[union-attr]`
- `panel_regression.py:683` -- `float(...)` replaced with `.squeeze("treated_units", drop=True).item()` to handle non-0d xarray result, matching existing idiom at lines 852-858

## Testing

- `pre-commit run --files causalpy/experiments/panel_regression.py` passes (mypy green)
- `test_panel_regression_plot_unit_effects` fails on main with the same `TypeError`; the `.item()` fix resolves it
- Test hardened with `filterwarnings` to promote the ndim>0 scalar `DeprecationWarning` to an error, catching this regression on all Python versions

---
*Edit (2026-04-17): addressed review feedback -- added `.squeeze("treated_units", drop=True)` and `filterwarnings` test hardening.*