### PR TITLE
Add formula Parser for Hierarchical DiD

### DIFF
--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -876,3 +876,101 @@ def generate_piecewise_its_data(
     }
 
     return df, params
+
+
+def generate_hlr_data(
+    seed: int = 42,
+    n_groups: int = 12,
+    n_obs_per_group: int = 40,
+    beta_fixed_true: tuple[float, float] = (2.0, 1.4),
+    sigma_random_true: tuple[float, float] = (0.7, 0.5),
+    sigma_noise: float = 0.8,
+) -> tuple[pd.DataFrame, pd.DataFrame, dict[str, np.ndarray]]:
+    r"""Generate grouped synthetic data for hierarchical linear regression.
+
+    Simulates outcomes from a hierarchical data-generating process with fixed and
+    group-level random effects:
+
+    .. math::
+
+        \mu_i = x_i^\top\beta_{\text{fixed}} + z_i^\top\beta_{\text{random}, g(i)}
+
+    .. math::
+
+        y_i = \mu_i + \epsilon_i, \quad \epsilon_i \sim \mathcal{N}(0, \sigma_{\text{noise}})
+
+    Parameters
+    ----------
+    seed : int, optional
+        Seed used to initialize the NumPy random number generator.
+    n_groups : int, optional
+        Number of groups in the grouped structure.
+    n_obs_per_group : int, optional
+        Number of observations generated per group.
+    beta_fixed_true : tuple[float, float], optional
+        True fixed-effect coefficients used in the simulation.
+    sigma_random_true : tuple[float, float], optional
+        Group-level standard deviations for the random intercept and slope.
+    sigma_noise : float, optional
+        Observation-level noise scale.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame, dict[str, np.ndarray]]
+        ``XY`` contains the fixed-effect inputs, group index, and observed
+        outcome. ``Z`` contains the random-effect design matrix. ``params``
+        contains the true simulation values.
+    """
+    rng = np.random.default_rng(seed=seed)
+
+    n_obs_total = n_groups * n_obs_per_group
+
+    group_idx = np.repeat(np.arange(n_groups), n_obs_per_group)
+    x1 = rng.normal(loc=0.0, scale=1.0, size=n_obs_total)
+
+    _X = np.column_stack([np.ones(n_obs_total), x1])
+    _Z = np.column_stack([np.ones(n_obs_total), x1])
+
+    _beta_fixed_true = np.asarray(beta_fixed_true)
+    _sigma_random_true = np.asarray(sigma_random_true)
+
+    beta_random_true = rng.normal(
+        loc=0.0,
+        scale=_sigma_random_true,
+        size=(n_groups, 2),
+    )
+
+    mu_fixed_true = _X @ _beta_fixed_true
+    mu_random_true = np.sum(_Z * beta_random_true[group_idx], axis=1)
+    mu = mu_fixed_true + mu_random_true
+
+    _y = mu + rng.normal(loc=0.0, scale=sigma_noise, size=n_obs_total)
+
+    obs_ind = np.arange(n_obs_total)
+
+    XY = pd.DataFrame(
+        {
+            "1": _X[:, 0],
+            "x1": _X[:, 1],
+            "group_idx": group_idx,
+            "y": _y,
+        },
+        index=obs_ind,
+    )
+    Z = pd.DataFrame(
+        {
+            "1|group": _Z[:, 0],
+            "x1|group": _Z[:, 1],
+        },
+        index=obs_ind,
+    )
+    params = {
+        "mu": mu,
+        "mu_fixed_true": mu_fixed_true,
+        "mu_random_true": mu_random_true,
+        "beta_fixed_true": _beta_fixed_true,
+        "beta_random_true": beta_random_true,
+        "sigma_random_true": _sigma_random_true,
+    }
+
+    return XY, Z, params

--- a/causalpy/formula.py
+++ b/causalpy/formula.py
@@ -11,16 +11,15 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-from dataclasses import dataclass
-from typing import Any, Callable, Mapping, Optional
-
-from collections import OrderedDict
-from dataclasses import dataclass
-from formulaic import Formula
-
-import pandas as pd
-import numpy as np
 import re
+from collections import OrderedDict
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+import pandas as pd
+from formulaic import Formula
 
 _RE_RANDOM_COMPONENT = re.compile(r"\(\s*([^|()]+?)\s*\|\s*([^|()]+?)\s*\)")
 
@@ -77,11 +76,13 @@ class RandomComponent:
 
     @property
     def has_intercept(self) -> bool:
+        """Whether this component includes a random intercept."""
         elements = set(self._elements)
         return "0" not in elements and "-1" not in elements
 
     @property
     def slopes(self) -> list[str]:
+        """Return non-intercept random-slope elements."""
         return [
             element for element in self._elements if element not in ("0", "-1", "1")
         ]
@@ -109,6 +110,13 @@ class MixedModelMatrices:
 
     Examples
     --------
+    >>> data = pd.DataFrame(
+    ...     {
+    ...         "y": [0.1, -0.2, 0.3, 0.0],
+    ...         "x1": [1.0, 0.0, 1.0, 0.5],
+    ...         "store_id": ["s1", "s1", "s2", "s2"],
+    ...     }
+    ... )
     >>> mm = parse_formula("y ~ 1 + x1 + (1 + x1 | store_id)", data)
     >>> mm.lhs.shape[0] == mm.rhs.shape[0] == mm.Z.shape[0]
     True
@@ -123,22 +131,27 @@ class MixedModelMatrices:
 
     @property
     def y(self) -> pd.DataFrame:
+        """Alias for ``lhs`` outcome matrix."""
         return self.lhs
 
     @property
     def X(self) -> pd.DataFrame:
+        """Alias for ``rhs`` fixed-effects design matrix."""
         return self.rhs
 
     @property
     def model_spec(self):
+        """Fixed-effects Formulaic model specification used for ``rhs``."""
         return self.metadata["model_spec"]
 
     @property
     def fixed_model_spec(self):
+        """Explicit fixed-effects model specification alias."""
         return self.metadata["fixed_model_spec"]
 
     @property
     def random_model_spec(self):
+        """Random-effects model specification used for ``Z``."""
         return self.metadata["random_model_spec"]
 
 
@@ -175,10 +188,12 @@ class MixedModelFormula:
 
     @property
     def has_random_effects(self) -> bool:
+        """Whether the parsed formula contains random components."""
         return len(self.random_components) > 0
 
     @property
     def grouping_variables(self) -> list[str]:
+        """Unique grouping-variable names in declaration order."""
         return list(
             OrderedDict.fromkeys(
                 component.grouping for component in self.random_components
@@ -187,10 +202,12 @@ class MixedModelFormula:
 
     @property
     def fixed_formula(self) -> str:
+        """Fixed-effects formula string built from ``lhs`` and ``rhs``."""
         return f"{self.lhs} ~ {self.rhs}"
 
     @property
     def formula(self) -> Formula:
+        """Formulaic ``Formula`` instance for fixed-effects materialization."""
         return Formula(self.fixed_formula)
 
     def __str__(self) -> str:
@@ -202,8 +219,8 @@ class MixedModelFormula:
     def get_model_matrix(
         self,
         data: Any,
-        context: Optional[Mapping[str, Any]] = None,
-        drop_rows: Optional[set[int]] = None,
+        context: Mapping[str, Any] | None = None,
+        drop_rows: set[int] | None = None,
         **attr_overrides: Any,
     ) -> MixedModelMatrices:
         """
@@ -253,7 +270,7 @@ class MixedModelFormula:
         Z = pd.DataFrame(index=rhs.index)
         random_model_spec = None
         random_effect_names: list[str] = []
-        group = {
+        group: dict[str, np.ndarray | int | list[Any] | str | None] = {
             "variable": None,
             "labels": [],
             "n_groups": 0,

--- a/causalpy/formula.py
+++ b/causalpy/formula.py
@@ -1,0 +1,103 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+
+@dataclass(frozen=True, slots=True)
+class RandomComponent:
+    """
+    Parsed random-effects component using lme4 grouping syntax ``(expr | group)``.
+
+    Examples
+    --------
+    >>> rc = RandomComponent(expr="1 + x1", grouping="store_id")
+    >>> str(rc)
+    '(1 + x1 | store_id)'
+    >>> rc.formula_rhs
+    '1 + x1'
+    """
+
+    expr: str
+    grouping: str
+
+    @property
+    def _elements(self) -> list[str]:
+        return [element.strip() for element in self.expr.split("+") if element.strip()]
+
+    @property
+    def has_intercept(self) -> bool:
+        elements = set(self._elements)
+        return "0" not in elements and "-1" not in elements
+
+    @property
+    def slopes(self) -> list[str]:
+        return [element for element in self._elements if element not in ("0", "-1", "1")]
+
+    @property
+    def formula_rhs(self) -> str:
+        """Return the Formulaic RHS equivalent of the random expression."""
+        rhs_terms: list[str] = []
+        if self.has_intercept:
+            rhs_terms.append("1")
+        rhs_terms.extend(self.slopes)
+        return " + ".join(rhs_terms) if rhs_terms else "0"
+
+    def __str__(self) -> str:
+        return f"({self.expr} | {self.grouping})"
+
+
+@dataclass(frozen=True, slots=True)
+class MixedModelMatrices:
+    """
+    Mixed-model matrix container with Formulaic-compatible ``lhs``/``rhs`` access.
+
+    Implements ``lhs``/``rhs`` and ``model_spec`` while extending with mixed-effects
+    attributes (`Z`, `metadata`, `fixed_model_spec`, `random_model_spec`).
+
+    Examples
+    --------
+    >>> mm = parse_formula("y ~ 1 + x1 + (1 + x1 | store_id)", data)
+    >>> mm.lhs.shape[0] == mm.rhs.shape[0] == mm.Z.shape[0]
+    True
+    >>> mm.metadata["group"]["variable"]
+    'store_id'
+    """
+
+    lhs: pd.DataFrame
+    rhs: pd.DataFrame
+    Z: pd.DataFrame
+    metadata: dict[str, Any]
+
+    @property
+    def y(self) -> pd.DataFrame:
+        return self.lhs
+
+    @property
+    def X(self) -> pd.DataFrame:
+        return self.rhs
+
+    @property
+    def model_spec(self):
+        return self.metadata["model_spec"]
+
+    @property
+    def fixed_model_spec(self):
+        return self.metadata["fixed_model_spec"]
+
+    @property
+    def random_model_spec(self):
+        return self.metadata["random_model_spec"]

--- a/causalpy/formula.py
+++ b/causalpy/formula.py
@@ -258,7 +258,7 @@ class MixedModelFormula:
             "labels": [],
             "n_groups": 0,
             "idx": np.asarray([], dtype=np.int32),
-            "terms": [],
+            "components": [],
         }
 
         if self.has_random_effects:
@@ -300,7 +300,7 @@ class MixedModelFormula:
                 "labels": group_labels_list,
                 "n_groups": int(group_labels.shape[0]),
                 "idx": group_idx,
-                "terms": [str(random_component)],
+                "components": [str(random_component)],
             }
 
         metadata = {
@@ -364,7 +364,7 @@ class Parser:
             )
         if len(random_components) > 1:
             raise ValueError(
-                "Multiple random terms are not supported in current version. "
+                "Multiple random components are not supported in current version. "
                 f"Found: {[str(t) for t in random_components]}"
             )
 

--- a/causalpy/formula.py
+++ b/causalpy/formula.py
@@ -161,6 +161,7 @@ class MixedModelFormula:
     Parsed mixed-effects formula object produced by ``Parser.parse(...)``.
 
     This lightweight representation stores:
+
     - ``lhs``: left-hand side variable name
     - ``rhs``: fixed-effects right-hand side expression
     - ``random_components``: parsed lme4-style ``(expr | group)`` components

--- a/causalpy/formula.py
+++ b/causalpy/formula.py
@@ -12,9 +12,46 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Callable, Mapping, Optional
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from formulaic import Formula
 
 import pandas as pd
+import numpy as np
+import re
+
+_RE_RANDOM_COMPONENT = re.compile(r"\(\s*([^|()]+?)\s*\|\s*([^|()]+?)\s*\)")
+
+
+def _canonical_component_name(name: Any) -> str:
+    """Normalize Formulaic intercept labels to stable naming."""
+    text = str(name).strip()
+    return "1" if text == "Intercept" else text
+
+
+def _assert_unique_names(names: list[str], *, context: str) -> None:
+    """Raise an explicit error when normalized names collide."""
+    if len(set(names)) != len(names):
+        raise ValueError(
+            f"Duplicate {context} names detected after normalization: {names}"
+        )
+
+
+def _build_dataframe(
+    matrix: Any,
+    context: str,
+    rename: Callable[[str], str],
+    index: pd.Index | None = None,
+) -> pd.DataFrame:
+    """Build a DataFrame with normalized, unique column names."""
+    frame = pd.DataFrame(matrix, copy=True)
+    frame.columns = [rename(_canonical_component_name(col)) for col in frame.columns]
+    _assert_unique_names(list(frame.columns), context=context)
+    if index is not None:
+        frame.index = index
+    return frame
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,7 +82,9 @@ class RandomComponent:
 
     @property
     def slopes(self) -> list[str]:
-        return [element for element in self._elements if element not in ("0", "-1", "1")]
+        return [
+            element for element in self._elements if element not in ("0", "-1", "1")
+        ]
 
     @property
     def formula_rhs(self) -> str:
@@ -101,3 +140,251 @@ class MixedModelMatrices:
     @property
     def random_model_spec(self):
         return self.metadata["random_model_spec"]
+
+
+@dataclass(frozen=True, slots=True)
+class MixedModelFormula:
+    """
+    Parsed mixed-effects formula object produced by ``Parser.parse(...)``.
+
+    This lightweight representation stores:
+    - ``lhs``: left-hand side variable name
+    - ``rhs``: fixed-effects right-hand side expression
+    - ``random_components``: parsed lme4-style ``(expr | group)`` components
+
+    ``lhs``/``rhs`` naming intentionally mirrors Formulaic's
+    structured formula conventions for easier migration.
+
+    ``get_model_matrix(...)`` materializes aligned pandas ``lhs``, ``rhs``, and
+    ``Z`` matrices using Formulaic and returns them in ``MixedModelMatrices``
+    with minimal mixed-effects metadata.
+
+    Examples
+    --------
+    >>> mf = Parser.parse("y ~ 1 + x1 + (1 + x1 | store_id)")
+    >>> mf.lhs, mf.rhs
+    ('y', '1 + x1')
+    >>> mf.has_random_effects
+    True
+    """
+
+    lhs: str
+    rhs: str
+    random_components: tuple[RandomComponent, ...]
+    _formula: str
+
+    @property
+    def has_random_effects(self) -> bool:
+        return len(self.random_components) > 0
+
+    @property
+    def grouping_variables(self) -> list[str]:
+        return list(
+            OrderedDict.fromkeys(
+                component.grouping for component in self.random_components
+            )
+        )
+
+    @property
+    def fixed_formula(self) -> str:
+        return f"{self.lhs} ~ {self.rhs}"
+
+    @property
+    def formula(self) -> Formula:
+        return Formula(self.fixed_formula)
+
+    def __str__(self) -> str:
+        rhs_parts = [self.rhs] + [
+            str(component) for component in self.random_components
+        ]
+        return f"{self.lhs} ~ {' + '.join(rhs_parts)}"
+
+    def get_model_matrix(
+        self,
+        data: Any,
+        context: Optional[Mapping[str, Any]] = None,
+        drop_rows: Optional[set[int]] = None,
+        **attr_overrides: Any,
+    ) -> MixedModelMatrices:
+        """
+        Build unified mixed-model matrices (`lhs`, `rhs`, `Z`) and metadata.
+
+        Signature mirrors Formulaic's ``ModelSpec.get_model_matrix(...)``.
+        ``attr_overrides`` are forwarded to Formulaic as model-spec overrides.
+        """
+        grouping_variables = self.grouping_variables
+        if len(grouping_variables) > 1:
+            raise ValueError(
+                f"Current version supports a single grouping variable, got: {grouping_variables}"
+            )
+        if len(self.random_components) > 1:
+            raise ValueError(
+                "Current version supports a single random component. "
+                f"Found {len(self.random_components)} components: {[str(c) for c in self.random_components]}"
+            )
+
+        spec_overrides = dict(attr_overrides)
+
+        # Shared drop_rows keeps lhs/rhs/Z aligned under missing-data dropping.
+        shared_drop_rows: set[int] = drop_rows if drop_rows is not None else set()
+
+        fixed_mm = self.formula.get_model_matrix(
+            data,
+            context=context,
+            drop_rows=shared_drop_rows,
+            **spec_overrides,
+        )
+
+        rhs = _build_dataframe(
+            fixed_mm.rhs,
+            context="fixed-effect",
+            rename=lambda name: name,
+        )
+
+        lhs = pd.DataFrame(fixed_mm.lhs, copy=True)
+        if lhs.shape[1] != 1:
+            raise ValueError(
+                f"Expected a single outcome column for mixed regression, got {lhs.shape[1]}."
+            )
+        lhs.columns = [self.lhs]
+
+        fixed_model_spec = fixed_mm.rhs.model_spec
+
+        Z = pd.DataFrame(index=rhs.index)
+        random_model_spec = None
+        random_effect_names: list[str] = []
+        group = {
+            "variable": None,
+            "labels": [],
+            "n_groups": 0,
+            "idx": np.asarray([], dtype=np.int32),
+            "terms": [],
+        }
+
+        if self.has_random_effects:
+            grouping = grouping_variables[0]
+            if grouping not in data.columns:
+                raise ValueError(
+                    f"Grouping variable '{grouping}' not found in data. Available columns: {list(data.columns)}"
+                )
+
+            # Group metadata must follow the same kept rows as lhs/rhs/Z.
+            grouping_values = data.loc[rhs.index, grouping]
+            if grouping_values.isna().any():
+                raise ValueError(
+                    f"Grouping variable '{grouping}' contains missing values."
+                )
+
+            group_idx, group_labels = pd.factorize(grouping_values, sort=False)
+            group_idx = group_idx.astype(np.int32, copy=False)
+            group_labels_list = [str(label) for label in group_labels.tolist()]
+
+            random_component = self.random_components[0]
+            random_mm = Formula(random_component.formula_rhs).get_model_matrix(
+                data,
+                context=context,
+                drop_rows=shared_drop_rows,
+                **spec_overrides,
+            )
+            Z = _build_dataframe(
+                random_mm,
+                context="random-effect",
+                rename=lambda name: f"{name}|{random_component.grouping}",
+                index=rhs.index,
+            )
+
+            random_model_spec = random_mm.model_spec
+            random_effect_names = list(Z.columns)
+            group = {
+                "variable": grouping,
+                "labels": group_labels_list,
+                "n_groups": int(group_labels.shape[0]),
+                "idx": group_idx,
+                "terms": [str(random_component)],
+            }
+
+        metadata = {
+            "outcome_name": self.lhs,
+            "has_random_effects": self.has_random_effects,
+            "fixed_effect_names": list(rhs.columns),
+            "random_effect_names": random_effect_names,
+            "group": group,
+            "model_spec": fixed_model_spec,
+            "fixed_model_spec": fixed_model_spec,
+            "random_model_spec": random_model_spec,
+            "raw_formula": self._formula,
+            "fixed_formula": self.fixed_formula,
+        }
+
+        return MixedModelMatrices(lhs=lhs, rhs=rhs, Z=Z, metadata=metadata)
+
+
+class Parser:
+    """
+    Parser converts a formula string into ``MixedModelFormula``.
+
+    Examples
+    --------
+    >>> parsed = Parser.parse("y ~ 1 + x1 + (1 | store_id)")
+    >>> parsed.fixed_formula
+    'y ~ 1 + x1'
+    >>> parsed.random_components[0].grouping
+    'store_id'
+    """
+
+    _RE_PATTERN = _RE_RANDOM_COMPONENT
+
+    @classmethod
+    def parse(cls, formula: str) -> MixedModelFormula:
+        """
+        Parse a mixed-effects formula into fixed and random components.
+
+        Supports lme4-style random syntax ``(expr | group)`` and returns a
+        ``MixedModelFormula`` for later materialization. This parser currently
+        supports one grouping variable and one random component.
+        """
+        if "~" not in formula:
+            raise ValueError(f"Formula must contain '~': {formula!r}")
+
+        lhs, rhs = formula.split("~", maxsplit=1)
+        lhs_name = lhs.strip()
+        if not lhs_name:
+            raise ValueError(f"Formula must have a left-hand side: {formula!r}")
+
+        random_components = tuple(
+            RandomComponent(expr=expr.strip(), grouping=grouping.strip())
+            for expr, grouping in cls._RE_PATTERN.findall(rhs)
+        )
+
+        grouping_vars = {component.grouping for component in random_components}
+
+        if len(grouping_vars) > 1:
+            raise ValueError(
+                f"Multiple grouping variables are not supported in current version: {grouping_vars}."
+            )
+        if len(random_components) > 1:
+            raise ValueError(
+                "Multiple random terms are not supported in current version. "
+                f"Found: {[str(t) for t in random_components]}"
+            )
+
+        fixed_rhs = cls._RE_PATTERN.sub("", rhs)
+        fixed_rhs = re.sub(r"\+\s*\+", "+", fixed_rhs)
+        fixed_rhs = fixed_rhs.strip().strip("+").strip()
+        if not fixed_rhs:
+            fixed_rhs = "1"
+
+        return MixedModelFormula(
+            lhs=lhs_name,
+            rhs=fixed_rhs,
+            random_components=random_components,
+            _formula=formula.strip(),
+        )
+
+
+def parse_formula(
+    formula: str,
+    data: pd.DataFrame,
+) -> MixedModelMatrices:
+    """Parse and materialize a formula against ``data`` in a single call."""
+    return Parser.parse(formula).get_model_matrix(data=data)

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -586,6 +586,346 @@ class LinearRegression(PyMCModel):
             self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
 
 
+class HierarchicalLinearRegression(PyMCModel):
+    r"""Custom PyMC model for Hierarchical linear regression with fixed and group-level random effects.
+
+    Defines the PyMC model (centered parameterization)
+
+    .. math::
+        \beta_{\text{fixed}} &\sim \mathrm{Normal}(0, 10) \\
+        \sigma_{\text{random}} &\sim \mathrm{HalfNormal}(1) \\
+        \beta_{\text{random}, g} &\sim \mathrm{Normal}(0, \sigma_{\text{random}}) \\
+        \mu &= X \cdot \beta_{\text{fixed}}^{\top} + \sum\left(\beta_{\text{random}}[\mathrm{group\_idx}] \odot Z, \mathrm{axis}=2\right) \\
+        \sigma_{\text{fixed}} &\sim \mathrm{HalfNormal}(1) \\
+        y &\sim \mathrm{Normal}(\mu, \sigma_{\text{fixed}})
+
+    Set priors with keys ``beta_fixed``, ``sigma_random``, and ``sigma_fixed``.
+
+    For the non-centered parameterization:
+
+    .. math::
+        \beta_{\text{group}} &\sim \mathrm{Normal}(0, 1) \\
+        \beta_{\text{random}} &= \beta_{\text{group}} \odot \sigma_{\text{random}}
+
+    Set priors with keys ``beta_fixed``, ``sigma_random``, ``sigma_fixed``, and ``beta_group``.
+
+    Example
+    --------
+    >>> import numpy as np
+    >>> import xarray as xr
+    >>> import pymc as pm
+    >>> rng = np.random.default_rng(42)
+    >>> n_groups, n_obs = 4, 40
+    >>> group_idx = np.repeat(np.arange(n_groups), n_obs // n_groups).astype(np.int32)
+    >>> x1 = rng.normal(size=n_obs)
+    >>> X = xr.DataArray(
+    ...     np.column_stack([np.ones(n_obs), x1]),
+    ...     dims=["obs_ind", "coeffs"],
+    ...     coords={"obs_ind": np.arange(n_obs), "coeffs": ["1", "x1"]},
+    ... )
+    >>> Z = xr.DataArray(
+    ...     np.column_stack([np.ones(n_obs), x1]),
+    ...     dims=["obs_ind", "random_coeffs"],
+    ...     coords={
+    ...         "obs_ind": np.arange(n_obs),
+    ...         "random_coeffs": ["1|group", "x1|group"],
+    ...     },
+    ... )
+    >>> y = xr.DataArray(
+    ...     rng.normal(size=(n_obs, 1)),
+    ...     dims=["obs_ind", "treated_units"],
+    ...     coords={"obs_ind": np.arange(n_obs), "treated_units": ["unit_0"]},
+    ... )
+    >>> coords = {
+    ...     "obs_ind": np.arange(n_obs),
+    ...     "coeffs": ["1", "x1"],
+    ...     "random_coeffs": ["1|group", "x1|group"],
+    ...     "treated_units": ["unit_0"],
+    ...     "groups": np.arange(n_groups),
+    ... }
+    >>> priors = {
+    ...     "beta_fixed": Prior("Normal", mu=0, sigma=10, dims=["treated_units", "coeffs"]),
+    ...     "sigma_fixed": Prior("HalfNormal", sigma=1, dims=["treated_units"]),
+    ...     "sigma_random": Prior("HalfNormal", sigma=1, dims=["treated_units", "random_coeffs"]),
+    ...     "beta_group": Prior("Normal", mu=0, sigma=1, dims=["groups", "treated_units", "random_coeffs"]),
+    ... }
+    >>> model = HierarchicalLinearRegression(
+    ...     sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+    ...     priors=priors,
+    ... )
+    >>> model.build_model(
+    ...     X=X,
+    ...     Z=Z,
+    ...     y=y,
+    ...     group_idx=group_idx,
+    ...     coords=coords,
+    ...     non_centered=True,
+    ... )
+    >>> with model:
+    ...     idata = pm.sample(**model.sample_kwargs)
+    >>> "mu" in idata.posterior
+    True
+    """
+
+    def _build_model_noncentered(
+        self,
+        X: xr.DataArray,
+        Z: xr.DataArray,
+        y: xr.DataArray,
+        group_idx: np.ndarray,
+        coords: dict[str, Any] | None,
+    ) -> None:
+        """Defines the PyMC model (non-centered parametrization).
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Fixed-effects design matrix with dims ``[obs_ind, coeffs]``.
+        Z : xr.DataArray
+            Random-effects design matrix with dims ``[obs_ind, random_coeffs]``.
+        y : xr.DataArray
+            Outcome matrix with dims ``[obs_ind, treated_units]``.
+        group_idx : np.ndarray
+            Integer group index per observation.
+        coords : dict[str, Any] | None
+            Coordinates used by PyMC dimensions.
+        """
+        with self:
+            self.add_coords(coords)
+
+            X_data = pm.Data(name="X", value=X, dims=["obs_ind", "coeffs"])
+            Z_data = pm.Data(name="Z", value=Z, dims=["obs_ind", "random_coeffs"])
+            y_data = pm.Data(name="y", value=y, dims=["obs_ind", "treated_units"])
+            group_idx_data = pm.Data(name="group_idx", value=group_idx, dims="obs_ind")
+
+            beta_fixed = self.priors["beta_fixed"].create_variable(name="beta_fixed")
+            sigma_fixed = self.priors["sigma_fixed"].create_variable(name="sigma_fixed")
+            sigma_random = self.priors["sigma_random"].create_variable(
+                name="sigma_random"
+            )
+            beta_group = self.priors["beta_group"].create_variable(name="beta_group")
+
+            beta_random = pm.Deterministic(
+                name="beta_random",
+                var=beta_group * sigma_random,
+                dims=["groups", "treated_units", "random_coeffs"],
+            )
+
+            mu_fixed = pm.Deterministic(
+                name="mu_fixed",
+                var=pt.dot(X_data, beta_fixed.T),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu_random = pm.Deterministic(
+                name="mu_random",
+                var=pt.sum(beta_random[group_idx_data] * Z_data[:, None, :], axis=2),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu = pm.Deterministic(
+                name="mu",
+                var=mu_fixed + mu_random,
+                dims=["obs_ind", "treated_units"],
+            )
+
+            pm.Normal(
+                name="y_hat",
+                mu=mu,
+                sigma=sigma_fixed,
+                observed=y_data,
+                dims=["obs_ind", "treated_units"],
+            )
+
+    def _build_model_centered(
+        self,
+        X: xr.DataArray,
+        Z: xr.DataArray,
+        y: xr.DataArray,
+        group_idx: np.ndarray,
+        coords: dict[str, Any] | None,
+    ) -> None:
+        """Defines the PyMC model (centered parametrization).
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Fixed-effects design matrix with dims ``[obs_ind, coeffs]``.
+        Z : xr.DataArray
+            Random-effects design matrix with dims ``[obs_ind, random_coeffs]``.
+        y : xr.DataArray
+            Outcome matrix with dims ``[obs_ind, treated_units]``.
+        group_idx : np.ndarray
+            Integer group index per observation.
+        coords : dict[str, Any] | None
+            Coordinates used by PyMC dimensions.
+        """
+        with self:
+            self.add_coords(coords)
+
+            X_data = pm.Data(name="X", value=X, dims=["obs_ind", "coeffs"])
+            Z_data = pm.Data(name="Z", value=Z, dims=["obs_ind", "random_coeffs"])
+            y_data = pm.Data(name="y", value=y, dims=["obs_ind", "treated_units"])
+            group_idx_data = pm.Data(name="group_idx", value=group_idx, dims="obs_ind")
+
+            beta_fixed = self.priors["beta_fixed"].create_variable(name="beta_fixed")
+            sigma_fixed = self.priors["sigma_fixed"].create_variable(name="sigma_fixed")
+            sigma_random = self.priors["sigma_random"].create_variable(
+                name="sigma_random"
+            )
+
+            beta_random = pm.Normal(
+                name="beta_random",
+                mu=0.0,
+                sigma=sigma_random,
+                dims=["groups", "treated_units", "random_coeffs"],
+            )
+
+            mu_fixed = pm.Deterministic(
+                name="mu_fixed",
+                var=pt.dot(X_data, beta_fixed.T),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu_random = pm.Deterministic(
+                name="mu_random",
+                var=pt.sum(beta_random[group_idx_data] * Z_data[:, None, :], axis=2),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu = pm.Deterministic(
+                name="mu",
+                var=mu_fixed + mu_random,
+                dims=["obs_ind", "treated_units"],
+            )
+
+            pm.Normal(
+                name="y_hat",
+                mu=mu,
+                sigma=sigma_fixed,
+                observed=y_data,
+                dims=["obs_ind", "treated_units"],
+            )
+
+    def build_model(  # type: ignore
+        self,
+        X: xr.DataArray,
+        Z: xr.DataArray,
+        y: xr.DataArray,
+        group_idx: np.ndarray,
+        coords: dict[str, Any] | None,
+        non_centered: bool = True,
+    ) -> None:
+        """Defines the PyMC model.
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Fixed-effects design matrix with dims ``[obs_ind, coeffs]``.
+        Z : xr.DataArray
+            Random-effects design matrix with dims ``[obs_ind, random_coeffs]``.
+        y : xr.DataArray
+            Outcome matrix with dims ``[obs_ind, treated_units]``.
+        group_idx : np.ndarray
+            Integer group index per observation.
+        coords : dict[str, Any] | None
+            Coordinates used by PyMC dimensions.
+        non_centered : bool, optional
+            If ``True``, use non-centered parameterization for group effects.
+            If ``False``, use centered parameterization.
+
+        Raises
+        ------
+        ValueError
+            If required priors for the selected parameterization are missing.
+        """
+        parameterization = "non-centered" if non_centered else "centered"
+
+        required_models_priors = {
+            "centered": {"beta_fixed", "sigma_fixed", "sigma_random"},
+            "non-centered": {"beta_fixed", "sigma_fixed", "beta_group", "sigma_random"},
+        }
+
+        required_priors = required_models_priors[parameterization]
+
+        missing_priors = sorted(required_priors.difference(self.priors))
+
+        if missing_priors:
+            missing = ", ".join(missing_priors)
+            raise ValueError(
+                f"Missing required priors for {parameterization} parameterization: {missing}."
+            )
+
+        if non_centered:
+            self._build_model_noncentered(
+                X=X,
+                Z=Z,
+                y=y,
+                group_idx=group_idx,
+                coords=coords,
+            )
+        else:
+            self._build_model_centered(
+                X=X,
+                Z=Z,
+                y=y,
+                group_idx=group_idx,
+                coords=coords,
+            )
+
+    def fit(  # type: ignore
+        self,
+        X: xr.DataArray,
+        Z: xr.DataArray,
+        y: xr.DataArray,
+        group_idx: np.ndarray,
+        coords: dict[str, Any] | None = None,
+        non_centered: bool = True,
+    ) -> az.InferenceData:
+        """Draw posterior and predictive samples for hierarchical linear regression.
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Fixed-effects design matrix with dims ``[obs_ind, coeffs]``.
+        Z : xr.DataArray
+            Random-effects design matrix with dims ``[obs_ind, random_coeffs]``.
+        y : xr.DataArray
+            Outcome matrix with dims ``[obs_ind, treated_units]``.
+        group_idx : np.ndarray
+            Integer group index per observation.
+        coords : dict[str, Any] | None, optional
+            Coordinates used by PyMC dimensions.
+        non_centered : bool, optional
+            If ``True``, use non-centered parameterization for group effects.
+            If ``False``, use centered parameterization.
+
+        Returns
+        -------
+        az.InferenceData
+            Posterior, prior predictive, and posterior predictive samples.
+        """
+        random_seed = self.sample_kwargs.get("random_seed", None)
+
+        self.build_model(
+            X=X,
+            Z=Z,
+            y=y,
+            group_idx=group_idx,
+            coords=coords,
+            non_centered=non_centered,
+        )
+        with self:
+            self.idata = pm.sample(**self.sample_kwargs)
+            if self.idata is None:
+                raise RuntimeError("pm.sample() returned None")
+            self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
+            self.idata.extend(
+                pm.sample_posterior_predictive(
+                    self.idata,
+                    progressbar=False,
+                    random_seed=random_seed,
+                )
+            )
+        return self.idata
+
+
 class WeightedSumFitter(PyMCModel):
     r"""
     Used for synthetic control experiments.

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -912,9 +912,7 @@ class HierarchicalLinearRegression(PyMCModel):
             non_centered=non_centered,
         )
         with self:
-            self.idata = pm.sample(**self.sample_kwargs)
-            if self.idata is None:
-                raise RuntimeError("pm.sample() returned None")
+            self.idata: az.InferenceData = pm.sample(**self.sample_kwargs)
             self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
             self.idata.extend(
                 pm.sample_posterior_predictive(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -667,6 +667,31 @@ class HierarchicalLinearRegression(PyMCModel):
     True
     """
 
+    default_priors = {
+        "beta_fixed": Prior(
+            "Normal",
+            mu=0,
+            sigma=10,
+            dims=["treated_units", "coeffs"],
+        ),
+        "sigma_fixed": Prior(
+            "HalfNormal",
+            sigma=1,
+            dims=["treated_units"],
+        ),
+        "sigma_random": Prior(
+            "HalfNormal",
+            sigma=1,
+            dims=["treated_units", "random_coeffs"],
+        ),
+        "beta_group": Prior(
+            "Normal",
+            mu=0,
+            sigma=1,
+            dims=["groups", "treated_units", "random_coeffs"],
+        ),
+    }
+
     def _build_model_noncentered(
         self,
         X: xr.DataArray,
@@ -844,12 +869,17 @@ class HierarchicalLinearRegression(PyMCModel):
 
         required_priors = required_models_priors[parameterization]
 
-        missing_priors = sorted(required_priors.difference(self.priors))
+        priors_to_check = (
+            self._user_priors if self._user_priors is not None else self.priors
+        )
+        missing_priors = sorted(required_priors.difference(priors_to_check))
 
         if missing_priors:
             missing = ", ".join(missing_priors)
+            prior_source = "custom" if self._user_priors is not None else "configured"
             raise ValueError(
-                f"Missing required priors for {parameterization} parameterization: {missing}."
+                f"Missing required priors for {parameterization} parameterization: {missing}.\n"
+                f"Missing required {prior_source} priors for {parameterization} parameterization: {missing}."
             )
 
         if non_centered:

--- a/causalpy/tests/conftest.py
+++ b/causalpy/tests/conftest.py
@@ -185,3 +185,22 @@ def banks_data():
     df_long["post_treatment"] = df_long.year >= treatment_time
     df_long = df_long.replace({"district": {"Sixth District": 1, "Eighth District": 0}})
     return df_long, treatment_time
+
+
+@pytest.fixture
+def mixed_effect_model_data() -> pd.DataFrame:
+
+    n = 200
+    rng = np.random.default_rng(42)
+
+    return pd.DataFrame(
+        {
+            "y": rng.standard_normal(n),
+            "x1": rng.standard_normal(n),
+            "x2": rng.standard_normal(n),
+            "post": rng.choice([0, 1], size=n),
+            "treated": rng.choice([0, 1], size=n),
+            "size": rng.integers(20, 60, size=n),
+            "store_id": rng.choice(["c1", "c2", "c3", "c4", "c5"], size=n),
+        }
+    )

--- a/causalpy/tests/test_formula.py
+++ b/causalpy/tests/test_formula.py
@@ -19,6 +19,7 @@ from causalpy.formula import Parser, parse_formula
 
 class TestParser:
     def test_parse_extracts_lhs_rhs_and_random(self):
+        """Parses fixed and random components into the expected structured fields."""
         mixed_formula = Parser.parse("y ~ 1 + post * treated + (1 + x1 | store_id)")
         assert mixed_formula.lhs == "y"
         assert mixed_formula.rhs == "1 + post * treated"
@@ -29,16 +30,35 @@ class TestParser:
         assert mixed_formula.random_components[0].formula_rhs == "1 + x1"
 
     def test_parse_rejects_multiple_grouping_variables(self):
+        """Raises when random components reference more than one grouping variable."""
         with pytest.raises(ValueError, match="Multiple grouping variables"):
             Parser.parse("y ~ x1 + (1 | group) + (1 | store_id)")
 
     def test_parse_rejects_multiple_random_components(self):
+        """Raises when more than one random component is provided."""
         with pytest.raises(ValueError, match="Multiple random components"):
             Parser.parse("y ~ x1 + (1 | store_id) + (x1 | store_id)")
+
+    def test_parse_requires_tilde(self):
+        """Raises when the formula omits the lhs-rhs separator '~'."""
+        with pytest.raises(ValueError, match="Formula must contain '~'"):
+            Parser.parse("y + x1")
+
+    def test_parse_requires_non_empty_lhs(self):
+        """Raises when the formula has an empty left-hand side."""
+        with pytest.raises(ValueError, match="Formula must have a left-hand side"):
+            Parser.parse("   ~ 1 + x1 + (1 | store_id)")
+
+    def test_parse_fallback_rhs_to_intercept(self):
+        """Defaults fixed RHS to intercept-only when random terms consume RHS content."""
+        parsed = Parser.parse("y ~ (1 | store_id)")
+        assert parsed.rhs == "1"
+        assert parsed.fixed_formula == "y ~ 1"
 
 
 class TestMixedModelFormula:
     def test_get_model_matrix_fixed_only_returns_empty_z(self, mixed_effect_model_data):
+        """Builds aligned lhs/rhs with an empty Z for fixed-only formulas."""
         mixed_formula = Parser.parse("y ~ 1 + post * treated + size")
         matrices = mixed_formula.get_model_matrix(mixed_effect_model_data)
 
@@ -49,7 +69,18 @@ class TestMixedModelFormula:
         assert matrices.metadata["group"]["variable"] is None
         assert matrices.metadata["group"]["n_groups"] == 0
 
+    def test_get_model_matrix_rejects_missing_grouping_column(
+        self, mixed_effect_model_data
+    ):
+        """Raises when the declared grouping variable column is absent from data."""
+        bad = mixed_effect_model_data.drop(columns=["store_id"])
+        mixed_formula = Parser.parse("y ~ 1 + x1 + (1 | store_id)")
+
+        with pytest.raises(ValueError, match="not found in data"):
+            mixed_formula.get_model_matrix(bad)
+
     def test_get_model_matrix_single_random_term(self, mixed_effect_model_data):
+        """Builds Z columns and group metadata for a single random component."""
         mixed_formula = Parser.parse(
             "y ~ 1 + post * treated + size + (1 + x1 | store_id)"
         )
@@ -69,6 +100,7 @@ class TestMixedModelFormula:
     def test_get_model_matrix_rejects_missing_group_values(
         self, mixed_effect_model_data
     ):
+        """Raises when grouping values contain missing entries."""
         broken = mixed_effect_model_data.copy()
         broken.loc[0, "store_id"] = np.nan
         mixed_formula = Parser.parse("y ~ 1 + x1 + (1 | store_id)")
@@ -79,6 +111,7 @@ class TestMixedModelFormula:
 
 class TestMixedModelMatrices:
     def test_aliases_and_core_fields(self, mixed_effect_model_data):
+        """Exposes y/X aliases and keeps lhs/rhs/Z observation alignment."""
         matrices = parse_formula(
             "y ~ 1 + post * treated + size + (1 + x1 | store_id)",
             mixed_effect_model_data,
@@ -90,6 +123,7 @@ class TestMixedModelMatrices:
         assert matrices.rhs.shape[0] == matrices.Z.shape[0]
 
     def test_model_spec_fields_exist(self, mixed_effect_model_data):
+        """Carries fixed and random model-spec metadata with fixed alias consistency."""
         matrices = parse_formula(
             "y ~ 1 + post * treated + size + (1 + x1 | store_id)",
             mixed_effect_model_data,

--- a/causalpy/tests/test_formula.py
+++ b/causalpy/tests/test_formula.py
@@ -1,5 +1,18 @@
-import pytest
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
 import numpy as np
+import pytest
 
 from causalpy.formula import Parser, parse_formula
 

--- a/causalpy/tests/test_formula.py
+++ b/causalpy/tests/test_formula.py
@@ -1,0 +1,90 @@
+import pytest
+import numpy as np
+
+from causalpy.formula import Parser, parse_formula
+
+
+class TestParser:
+    def test_parse_extracts_lhs_rhs_and_random(self):
+        mixed_formula = Parser.parse("y ~ 1 + post * treated + (1 + x1 | store_id)")
+        assert mixed_formula.lhs == "y"
+        assert mixed_formula.rhs == "1 + post * treated"
+        assert mixed_formula.fixed_formula == "y ~ 1 + post * treated"
+        assert mixed_formula.has_random_effects is True
+        assert len(mixed_formula.random_components) == 1
+        assert mixed_formula.random_components[0].grouping == "store_id"
+        assert mixed_formula.random_components[0].formula_rhs == "1 + x1"
+
+    def test_parse_rejects_multiple_grouping_variables(self):
+        with pytest.raises(ValueError, match="Multiple grouping variables"):
+            Parser.parse("y ~ x1 + (1 | group) + (1 | store_id)")
+
+    def test_parse_rejects_multiple_random_components(self):
+        with pytest.raises(ValueError, match="Multiple random components"):
+            Parser.parse("y ~ x1 + (1 | store_id) + (x1 | store_id)")
+
+
+class TestMixedModelFormula:
+    def test_get_model_matrix_fixed_only_returns_empty_z(self, mixed_effect_model_data):
+        mixed_formula = Parser.parse("y ~ 1 + post * treated + size")
+        matrices = mixed_formula.get_model_matrix(mixed_effect_model_data)
+
+        assert matrices.lhs.shape[0] == matrices.rhs.shape[0]
+        assert matrices.Z.shape[0] == matrices.rhs.shape[0]
+        assert matrices.Z.shape[1] == 0
+        assert matrices.metadata["has_random_effects"] is False
+        assert matrices.metadata["group"]["variable"] is None
+        assert matrices.metadata["group"]["n_groups"] == 0
+
+    def test_get_model_matrix_single_random_term(self, mixed_effect_model_data):
+        mixed_formula = Parser.parse(
+            "y ~ 1 + post * treated + size + (1 + x1 | store_id)"
+        )
+        matrices = mixed_formula.get_model_matrix(mixed_effect_model_data)
+
+        assert matrices.lhs.shape[0] == matrices.rhs.shape[0]
+        assert matrices.Z.shape[0] == matrices.rhs.shape[0]
+        assert list(matrices.Z.columns) == ["1|store_id", "x1|store_id"]
+
+        assert matrices.metadata["has_random_effects"] is True
+        assert matrices.metadata["group"]["variable"] == "store_id"
+        assert (
+            matrices.metadata["group"]["n_groups"]
+            == mixed_effect_model_data["store_id"].nunique()
+        )
+
+    def test_get_model_matrix_rejects_missing_group_values(
+        self, mixed_effect_model_data
+    ):
+        broken = mixed_effect_model_data.copy()
+        broken.loc[0, "store_id"] = np.nan
+        mixed_formula = Parser.parse("y ~ 1 + x1 + (1 | store_id)")
+
+        with pytest.raises(ValueError, match="contains missing values"):
+            mixed_formula.get_model_matrix(broken)
+
+
+class TestMixedModelMatrices:
+    def test_aliases_and_core_fields(self, mixed_effect_model_data):
+        matrices = parse_formula(
+            "y ~ 1 + post * treated + size + (1 + x1 | store_id)",
+            mixed_effect_model_data,
+        )
+
+        assert matrices.y is matrices.lhs
+        assert matrices.X is matrices.rhs
+        assert matrices.lhs.shape[0] == matrices.rhs.shape[0]
+        assert matrices.rhs.shape[0] == matrices.Z.shape[0]
+
+    def test_model_spec_fields_exist(self, mixed_effect_model_data):
+        matrices = parse_formula(
+            "y ~ 1 + post * treated + size + (1 + x1 | store_id)",
+            mixed_effect_model_data,
+        )
+
+        assert "model_spec" in matrices.metadata
+        assert "fixed_model_spec" in matrices.metadata
+        assert "random_model_spec" in matrices.metadata
+        assert matrices.model_spec is matrices.metadata["model_spec"]
+        assert matrices.metadata["model_spec"] is matrices.metadata["fixed_model_spec"]
+        assert "group" in matrices.metadata

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -11,6 +11,8 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+from typing import Any, ClassVar
+
 import arviz as az
 import numpy as np
 import pandas as pd
@@ -20,7 +22,9 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
+from causalpy.data.simulate_data import generate_hlr_data
 from causalpy.pymc_models import (
+    HierarchicalLinearRegression,
     LinearRegression,
     PyMCModel,
     SoftmaxWeightedSumFitter,
@@ -844,6 +848,218 @@ def prior_test_data():
         "treated_units": ["unit_0"],
     }
     return X, y, coords
+
+
+class TestHierarchicalLinearRegression:
+    data: ClassVar[dict[str, Any]]
+    X: ClassVar[xr.DataArray]
+    Z: ClassVar[xr.DataArray]
+    y: ClassVar[xr.DataArray]
+    group_idx: ClassVar[np.ndarray]
+    coords: ClassVar[dict[str, Any]]
+    sample_kwargs: ClassVar[dict[str, Any]]
+    priors: ClassVar[dict[str, Prior]]
+    model_true: ClassVar[dict[str, np.ndarray]]
+    model: ClassVar[HierarchicalLinearRegression]
+    idata: ClassVar[az.InferenceData]
+
+    @staticmethod
+    def _expect_value_error(fn, expected_message: str) -> None:
+        with pytest.raises(ValueError, match=expected_message):
+            fn()
+
+    @staticmethod
+    def _prepare_data(
+        XY: pd.DataFrame,
+        Z_: pd.DataFrame,
+        params: dict[str, np.ndarray],
+        *,
+        seed: int = 42,
+        sample_kwargs: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        """Map HLR data into HierarchicalLinearRegression inputs."""
+        obs_ind = XY.index.to_numpy()
+        group_idx = XY["group_idx"].to_numpy()
+        n_groups = int(XY["group_idx"].nunique())
+
+        _X = XY[["1", "x1"]].to_numpy()
+        _Z = Z_.to_numpy()
+        _y = XY["y"].to_numpy()
+
+        X = xr.DataArray(
+            _X,
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": obs_ind, "coeffs": ["1", "x1"]},
+        )
+        Z = xr.DataArray(
+            _Z,
+            dims=["obs_ind", "random_coeffs"],
+            coords={"obs_ind": obs_ind, "random_coeffs": list(Z_.columns)},
+        )
+        y = xr.DataArray(
+            _y[:, None],
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": obs_ind, "treated_units": ["unit_0"]},
+        )
+
+        coords = {
+            "obs_ind": obs_ind,
+            "coeffs": ["1", "x1"],
+            "random_coeffs": list(Z_.columns),
+            "treated_units": ["unit_0"],
+            "groups": np.arange(n_groups),
+        }
+
+        resolved_sample_kwargs: dict[str, Any] = {
+            "draws": 500,
+            "tune": 500,
+            "chains": 2,
+            "target_accept": 0.90,
+            "progressbar": False,
+            "random_seed": seed,
+        }
+        if sample_kwargs is not None:
+            resolved_sample_kwargs.update(sample_kwargs)
+
+        return {
+            "model_kwargs": {
+                "X": X,
+                "Z": Z,
+                "y": y,
+                "group_idx": group_idx,
+                "coords": coords,
+            },
+            "sample_kwargs": resolved_sample_kwargs,
+            "priors": {
+                "beta_fixed": Prior(
+                    "Normal", mu=0, sigma=10, dims=["treated_units", "coeffs"]
+                ),
+                "sigma_fixed": Prior("HalfNormal", sigma=1, dims=["treated_units"]),
+                "sigma_random": Prior(
+                    "HalfNormal", sigma=1, dims=["treated_units", "random_coeffs"]
+                ),
+                "beta_group": Prior(
+                    "Normal",
+                    mu=0,
+                    sigma=1,
+                    dims=["groups", "treated_units", "random_coeffs"],
+                ),
+            },
+            "model_true": params,
+        }
+
+    @classmethod
+    def _setup_data(
+        cls,
+        *,
+        seed: int = 42,
+        n_groups: int = 12,
+        n_obs_per_group: int = 40,
+        beta_fixed_true: tuple[float, float] = (2.0, 1.4),
+        sigma_random_true: tuple[float, float] = (0.7, 0.5),
+        sigma_noise: float = 0.8,
+        sample_kwargs: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        XY, Z, params = generate_hlr_data(
+            seed=seed,
+            n_groups=n_groups,
+            n_obs_per_group=n_obs_per_group,
+            beta_fixed_true=beta_fixed_true,
+            sigma_random_true=sigma_random_true,
+            sigma_noise=sigma_noise,
+        )
+        return cls._prepare_data(
+            XY,
+            Z,
+            params,
+            seed=seed,
+            sample_kwargs=sample_kwargs,
+        )
+
+    @classmethod
+    def setup_class(cls) -> None:
+        cls.data = cls._setup_data(
+            sample_kwargs={
+                "draws": 120,
+                "tune": 120,
+                "chains": 2,
+                "cores": 1,
+            }
+        )
+        cls.X = cls.data["model_kwargs"]["X"]
+        cls.Z = cls.data["model_kwargs"]["Z"]
+        cls.y = cls.data["model_kwargs"]["y"]
+        cls.group_idx = cls.data["model_kwargs"]["group_idx"]
+        cls.coords = cls.data["model_kwargs"]["coords"]
+        cls.sample_kwargs = cls.data["sample_kwargs"]
+        cls.priors = cls.data["priors"]
+        cls.model_true = cls.data["model_true"]
+
+        cls.model = HierarchicalLinearRegression(
+            sample_kwargs=cls.sample_kwargs, priors=cls.priors
+        )
+        cls.model.build_model(
+            X=cls.X,
+            Z=cls.Z,
+            y=cls.y,
+            group_idx=cls.group_idx,
+            coords=cls.coords,
+        )
+        with cls.model:
+            cls.idata = pm.sampling.mcmc.sample(**cls.sample_kwargs)
+
+    def test_centered_requires_sigma_random_prior(self) -> None:
+        priors = {key: self.model.priors[key] for key in ["beta_fixed", "sigma_fixed"]}
+        self._expect_value_error(
+            lambda: HierarchicalLinearRegression(priors=priors).build_model(
+                X=self.X,
+                Z=self.Z,
+                y=self.y,
+                group_idx=self.group_idx,
+                coords=self.coords,
+                non_centered=False,
+            ),
+            "Missing required priors for centered parameterization: sigma_random.",
+        )
+
+    def test_noncentered_requires_beta_group_prior(self) -> None:
+        priors = {
+            key: self.model.priors[key]
+            for key in ["beta_fixed", "sigma_fixed", "sigma_random"]
+        }
+        self._expect_value_error(
+            lambda: HierarchicalLinearRegression(priors=priors).build_model(
+                X=self.X,
+                Z=self.Z,
+                y=self.y,
+                group_idx=self.group_idx,
+                coords=self.coords,
+                non_centered=True,
+            ),
+            "Missing required priors for non-centered parameterization: beta_group.",
+        )
+
+    def test_fixed_effect_parameter_recovery(self) -> None:
+        beta_fixed_mean = (
+            self.idata.posterior["beta_fixed"].mean(dim=("chain", "draw")).to_numpy()[0]
+        )
+        np.testing.assert_allclose(
+            beta_fixed_mean,
+            self.model_true["beta_fixed_true"],
+            atol=0.50,
+        )
+
+    def test_random_scale_parameter_recovery(self) -> None:
+        sigma_random_mean = (
+            self.idata.posterior["sigma_random"]
+            .mean(dim=("chain", "draw"))
+            .to_numpy()[0]
+        )
+        np.testing.assert_allclose(
+            sigma_random_mean,
+            self.model_true["sigma_random_true"],
+            atol=0.50,
+        )
 
 
 class TestPriorIntegration:

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -1039,6 +1039,46 @@ class TestHierarchicalLinearRegression:
             "Missing required priors for non-centered parameterization: beta_group.",
         )
 
+    def test_centered_build_model_uses_centered_random_effects(self) -> None:
+        priors = {
+            key: self.model.priors[key]
+            for key in ["beta_fixed", "sigma_fixed", "sigma_random"]
+        }
+        model = HierarchicalLinearRegression(priors=priors)
+
+        model.build_model(
+            X=self.X,
+            Z=self.Z,
+            y=self.y,
+            group_idx=self.group_idx,
+            coords=self.coords,
+            non_centered=False,
+        )
+
+        assert "beta_random" in model.named_vars
+        assert "beta_group" not in model.named_vars
+
+    def test_fit_extends_prior_and_posterior_predictive(self, mock_pymc_sample) -> None:
+        model = HierarchicalLinearRegression(
+            sample_kwargs={
+                "draws": 2,
+                "chains": 1,
+                "progressbar": False,
+                "random_seed": self.sample_kwargs["random_seed"],
+            },
+            priors=self.priors,
+        )
+        result = model.fit(**self.data["model_kwargs"])
+
+        assert result is model.idata
+        assert isinstance(result, az.InferenceData)
+        assert {
+            "posterior",
+            "prior",
+            "prior_predictive",
+            "posterior_predictive",
+        } <= set(result.groups())
+
     def test_fixed_effect_parameter_recovery(self) -> None:
         beta_fixed_mean = (
             self.idata.posterior["beta_fixed"].mean(dim=("chain", "draw")).to_numpy()[0]

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -1008,6 +1008,42 @@ class TestHierarchicalLinearRegression:
         with cls.model:
             cls.idata = pm.sampling.mcmc.sample(**cls.sample_kwargs)
 
+    def test_default_priors_build_model(self) -> None:
+        model = HierarchicalLinearRegression()
+
+        model.build_model(
+            X=self.X,
+            Z=self.Z,
+            y=self.y,
+            group_idx=self.group_idx,
+            coords=self.coords,
+        )
+
+        assert "beta_fixed" in model.named_vars
+        assert "sigma_fixed" in model.named_vars
+        assert "sigma_random" in model.named_vars
+        assert "beta_group" in model.named_vars
+        assert "beta_random" in model.named_vars
+
+    def test_partial_custom_priors_do_not_fall_back_to_defaults(self) -> None:
+        priors = {
+            "beta_fixed": self.model.priors["beta_fixed"],
+            "sigma_fixed": self.model.priors["sigma_fixed"],
+            "sigma_random": self.model.priors["sigma_random"],
+        }
+
+        self._expect_value_error(
+            lambda: HierarchicalLinearRegression(priors=priors).build_model(
+                X=self.X,
+                Z=self.Z,
+                y=self.y,
+                group_idx=self.group_idx,
+                coords=self.coords,
+                non_centered=True,
+            ),
+            "Missing required custom priors for non-centered parameterization: beta_group.",
+        )
+
     def test_centered_requires_sigma_random_prior(self) -> None:
         priors = {key: self.model.priors[key] for key in ["beta_fixed", "sigma_fixed"]}
         self._expect_value_error(
@@ -1019,7 +1055,7 @@ class TestHierarchicalLinearRegression:
                 coords=self.coords,
                 non_centered=False,
             ),
-            "Missing required priors for centered parameterization: sigma_random.",
+            "Missing required custom priors for centered parameterization: sigma_random.",
         )
 
     def test_noncentered_requires_beta_group_prior(self) -> None:
@@ -1036,7 +1072,7 @@ class TestHierarchicalLinearRegression:
                 coords=self.coords,
                 non_centered=True,
             ),
-            "Missing required priors for non-centered parameterization: beta_group.",
+            "Missing required custom priors for non-centered parameterization: beta_group.",
         )
 
     def test_centered_build_model_uses_centered_random_effects(self) -> None:

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - python>=3.12
   - arviz<1.0,>=0.14.0
   - codespell
+  - formulaic
   - graphviz
   - interrogate
   - ipython!=8.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "statsmodels",
     "xarray>=v2022.11.0",
     "pymc-extras>=0.3.0",
+    "formulaic",
 ]
 
 # List additional groups of dependencies here (e.g. development dependencies). Users


### PR DESCRIPTION
This PR adds a `MixedModelFormula` and a `MixedModelMatrices` duck typing formulaic `Formula` and `ModelMatrix`.

This PR is part of the issue https://github.com/pymc-labs/CausalPy/issues/656 (Hierarchical DiD experiment) resolution.