### PR TITLE
Enforce single H1 in docs notebooks (#863) + add pr-review skill

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pr-review
+description: Review CausalPy pull requests — fetch context, run a structured pass over code, tests, docs, and process, then produce maintainer-quality comments for human review before posting. Use when the user asks to review a PR, check a PR, evaluate review feedback, or audit PR comments. Complements pr-to-green (which fixes PRs) and pr-workflows (which creates them).
+---
+
+# PR Review
+
+This skill is for **reviewing** a CausalPy pull request — diagnosing what's there, judging it against project conventions, and producing actionable feedback. It is the read/diagnose/write-comment counterpart to `pr-to-green` (fix in-flight PR) and `pr-workflows` (create PR from issue).
+
+## When to use
+
+- The user asks to review, check, or evaluate a PR (e.g. "review #826", "look at PR 826", "what's outstanding on PR 826").
+- The user asks whether a PR is ready to approve, merge, or land.
+- The user asks to evaluate a contributor's response to prior review feedback ("did they address my comments?").
+- The user asks to audit existing comments on a PR for relevance, accuracy, or remaining gaps.
+
+Do **not** use this skill for:
+
+- Fixing a failing PR — use [`pr-to-green`](../pr-to-green/SKILL.md).
+- Turning an issue into a PR — use [`pr-workflows`](../pr-workflows/SKILL.md).
+- Creating new issues that come out of a review — delegate to [`github-issues`](../github-issues/SKILL.md).
+
+## Division of labour with automation
+
+A pre-commit hook never misses; an agent review is judgement-heavy. Don't duplicate the hook's job. Mechanical checks already enforced by `prek` / CI (lint, format, mypy, schema validation, single-H1-per-notebook, etc.) are not part of this skill — assume they pass and focus the human-equivalent attention on what they can't catch.
+
+If during review you notice a *class* of issue that automation could catch but doesn't, file it as a follow-up issue via [`github-issues`](../github-issues/SKILL.md) rather than only flagging the one instance.
+
+## Workflow
+
+The full workflow is in [reference/workflow.md](reference/workflow.md). At a glance:
+
+1. **Establish context** — fetch PR metadata, all commits, all reviews, all comments (review + issue threads), file changes.
+2. **Read the relevant subset** — files changed, plus surrounding context for each change (base class for new subclass, sibling tests for new tests, etc.).
+3. **Pass over the diff with the patterns checklist** — see [reference/what-to-look-for.md](reference/what-to-look-for.md). Group findings by severity.
+4. **Verify claims** — if the contributor says "addressed all feedback", confirm against the actual code; if they say a rebase is clean, confirm against `git log`.
+5. **Draft comments for human review** — never post directly. See [reference/posting-comments.md](reference/posting-comments.md).
+6. **Post on approval** and report URLs back.
+
+For batched PR work (multi-file diffs, parallel exploration), follow `pr-to-green`'s subagent delegation patterns — same `Task` triggers (`generalPurpose` for exploration, `ci-failure-investigator` for noisy CI logs) apply.
+
+## What to look for
+
+Severity-sorted patterns (must-fix → should-fix → nits) live in [reference/what-to-look-for.md](reference/what-to-look-for.md). The two domain-specific deep-dives are:
+
+- [reference/code-patterns.md](reference/code-patterns.md) — `BaseExperiment` contract, `PyMCModel` vs. `RegressorMixin` dispatch, `_clone()` patterns, `Literal` for constrained strings, custom exceptions, `__repr__` style, memory-heavy retainers.
+- [reference/docs-patterns.md](reference/docs-patterns.md) — notebook narrative quality, glossary linking, `:::{note}` admonitions, hide-input/hide-output cell tags, citations, sampler-output noise, helper-promotion judgement.
+
+## Drafting comments
+
+The full template is in [reference/posting-comments.md](reference/posting-comments.md). Two non-negotiable rules:
+
+1. **Always draft for human review before posting.** Read the draft back and offer 2–3 framing variants (stricter / softer / approval-pending).
+2. **Cite specific code locations.** Use line:line:filepath references when calling out code, not vague paraphrases.
+
+## Mandatory pre-flight reads
+
+Before reviewing any PR, the reviewing agent should have read or be able to load:
+
+- `AGENTS.md` (root) — code structure, style, type hints, testing preferences.
+- `CONTRIBUTING.md` — process expectations.
+- `docs/source/notebooks/index.md` — toctree layout, where new notebooks should go.
+- The PR's own description and any prior review iterations.
+
+## How to extend this skill
+
+When a review surfaces a new recurring pattern, add it. The process is in [reference/how-to-extend.md](reference/how-to-extend.md). Skill drift is real — every six months or so, prune patterns that have been formalised into hooks.
+
+## Important behaviour
+
+- Never post review comments without explicit human approval.
+- Never approve, request changes, or merge a PR through `gh pr review --approve` unless explicitly instructed.
+- When evaluating a contributor's response to prior feedback, verify against the code, not their summary. A "fixed all feedback" claim is a hypothesis to test, not a fact to accept.
+- If a reviewer-bot identity has been used in the past on the PR (e.g. `claude-opus-4-7-xhigh`), preserve that attribution in posted comments so the human reviewer's voice and the agent's voice stay distinguishable.
+- Do not duplicate work already covered by hooks/CI. If something is mechanically enforceable and not enforced, file an issue rather than re-flagging the instance.

--- a/.github/skills/pr-review/reference/code-patterns.md
+++ b/.github/skills/pr-review/reference/code-patterns.md
@@ -1,0 +1,108 @@
+# CausalPy Code Patterns
+
+Repo-specific conventions and contracts to check against when reviewing source-code diffs. These are the patterns most likely to be inadvertently broken by a contributor (especially a new one) because they're enforced by convention rather than by the type system.
+
+## `BaseExperiment` contract
+
+All experiment classes in `causalpy/experiments/` inherit from `BaseExperiment`. Required:
+
+- Class attributes `supports_ols: bool` and `supports_bayes: bool` declared.
+- If `supports_bayes`: implement `_bayesian_plot()` and `get_plot_data_bayesian()`.
+- If `supports_ols`: implement `_ols_plot()` and `get_plot_data_ols()`.
+- Model-agnostic dispatch via `isinstance(self.model, PyMCModel)` vs. `isinstance(self.model, RegressorMixin)`.
+- Data index named `"obs_ind"`.
+- Formula parsing via patsy `dmatrices()`.
+- Custom exceptions from `causalpy.custom_exceptions`: `FormulaException`, `DataException`, `BadIndexException`.
+
+Review prompts:
+
+- New `BaseExperiment` subclass? Check both class attributes are declared.
+- Implements only `_bayesian_plot` but `supports_ols=True`? That's a bug.
+- Uses `assert` for input validation? Should be a custom exception.
+
+## `PyMCModel` contract
+
+PyMC models inherit from `PyMCModel` (extends `pm.Model`). Common interface: `fit()`, `predict()`, `score()`, `calculate_impact()`, `print_coefficients()`.
+
+- Data: `xarray.DataArray` with coords (`coeffs`, `obs_ind`, `treated_units`).
+- Stores user-supplied priors on `self._user_priors` for round-trip via `_clone()`.
+
+## `_clone()` pattern
+
+The base `PyMCModel._clone()` forwards `priors=self._user_priors`. Every override **must** do the same, or user customisations are silently dropped on clone.
+
+Spot-check template:
+
+```python
+# In the new subclass:
+def _clone(self):
+    return type(self)(
+        sample_kwargs=self.sample_kwargs,
+        priors=self._user_priors,   # <-- must be present
+        # ... any other config kwargs the subclass adds ...
+    )
+```
+
+If `priors=` is absent, that's a must-fix (MF-1 in [what-to-look-for.md](what-to-look-for.md)).
+
+## `RegressorMixin` (sklearn) compatibility
+
+Scikit-learn models use `RegressorMixin` and are made causalpy-compatible via `create_causalpy_compatible_class()`. Same external interface as `PyMCModel`. Data is numpy arrays, not xarray.
+
+Review prompt: experiment classes should branch with `isinstance(self.model, PyMCModel)` vs. `isinstance(self.model, RegressorMixin)` rather than feature-detect on the model.
+
+## `CheckResult` contract
+
+Lives in `causalpy/checks/base.py`. Has a documented `figures: list[Any]` field — but as of writing, no check populates it. If a new check defines a non-trivial plotting helper in a notebook (see [what-to-look-for.md § N-7](what-to-look-for.md#n-7-helper-used-n-times-in-a-notebook-is-library-material)), promoting it to populate `CheckResult.figures` is the natural integration point.
+
+`passed=None` is the right design for informational-only checks (e.g. `OutcomeFalsification`) — they should inform, not gate.
+
+## Type hints
+
+`AGENTS.md` is explicit. Required style (Python 3.10+):
+
+- `X | None`, not `Optional[X]`.
+- Lowercase `dict`, `list`, `tuple`, not `Dict`, `List`, `Tuple` from `typing`.
+- `Literal` for constrained string parameters (see [what-to-look-for.md § MF-2](what-to-look-for.md#mf-2-constrained-string-parameter-not-typed-as-literal)).
+
+## Custom exceptions
+
+Use, in order of preference:
+
+- `FormulaException` — patsy/formula problems.
+- `DataException` — data-shape, missing-column, dtype problems.
+- `BadIndexException` — index issues.
+
+Plain `ValueError` is acceptable when nothing more specific fits; `assert` is not.
+
+## `__repr__` style
+
+Convention: show non-default values only.
+
+```python
+def __repr__(self) -> str:
+    parts = [f"alpha={self.alpha}"] if self.alpha != 0.05 else []
+    if not self.store_experiments:
+        parts.append("store_experiments=False")
+    return f"OutcomeFalsification({', '.join(parts)})"
+```
+
+A new class with a `__repr__` that shows defaults is inconsistent with sibling classes — flag as N-1.
+
+## Helper promotion
+
+When a docs notebook defines a non-trivial helper (≥50 lines) called ≥3 times, suggest promoting to the library. Standard cleanup checklist before promotion:
+
+1. Drop UI side-effects: no `print()` in library code (use `warnings.warn`); no `plt.show()` (return the `Figure`).
+2. Drop hard-coded constants that limit reuse: e.g. `FOLD_COLORS = [...5 colors...]` should become a module-level constant or use matplotlib's color cycle.
+3. Add `figsize` and `axes` kwargs so the function is composable in user code and unit-testable.
+4. Reduce arg surface: if two args are always paired, fold one into the other (or store the dependency on the producing class so the consumer takes one arg, not two).
+5. Add a tiny test that asserts shape: `assert isinstance(out, Figure)`, `assert len(out.axes) == expected`.
+
+## Memory-heavy retainers
+
+`InferenceData` is large. Any class that retains it by default imposes a hidden cost. Default to summary-only with an opt-in (`store_X=True`) for users who want to inspect.
+
+## Backwards compatibility
+
+`AGENTS.md`: maintain compatibility for previously-released APIs only; APIs introduced in the same PR can be reshaped freely. So new public APIs (added in the PR being reviewed) are legitimate review targets for "I'd rather it look like X" feedback; APIs that already shipped are not.

--- a/.github/skills/pr-review/reference/docs-patterns.md
+++ b/.github/skills/pr-review/reference/docs-patterns.md
@@ -1,0 +1,122 @@
+# CausalPy Docs Patterns
+
+Repo-specific conventions for notebooks (`docs/source/notebooks/`) and knowledgebase pages (`docs/source/knowledgebase/`). The mechanical rules (single H1, schema validation) are enforced by hooks; this file is for the judgement-heavy patterns a hook can't catch.
+
+## Notebook structure
+
+### Single H1 — title only
+
+Every notebook must have exactly one `# ` markdown heading (the page title). All other section headings are `##` or below. (Mechanical check planned, see issue #863.) During review:
+
+- If you see multiple `#` headings, that's a hook job — but flag it on the PR if the hook hasn't landed yet.
+- If you see no `#` heading at all, the notebook will render with the filename as title, which is usually wrong.
+
+### `toctree` placement
+
+A new notebook in `docs/source/notebooks/` must be referenced from somewhere — typically `docs/source/notebooks/index.md`. Cross-link from related prose pages (e.g. `sensitivity_checks.md`) where applicable.
+
+Section assignment is a curation question:
+
+- ITS examples → `Interrupted Time Series` toctree.
+- DiD examples → `Difference in Differences`.
+- New method introduction → its own toctree section.
+- Workflow / cross-cutting → `Workflow` section.
+
+If the placement isn't obvious, ask the contributor to confirm rather than guessing.
+
+## Notebook content
+
+### Pedagogical structure
+
+Good notebooks have a recognisable arc: problem → method → data → analysis → interpretation → caveats. Reviews should call out when the arc is missing or scrambled.
+
+When evaluating pedagogy, useful prompts:
+
+- Can a reader who knows causal inference but not CausalPy follow it?
+- Is the *causal question* stated before the method is introduced?
+- Are caveats and assumptions called out, not buried?
+- Does the conclusion answer the question posed at the top?
+
+### Cell tags
+
+Two tags matter for readability:
+
+- **`hide-input`** on plotting cells — collapses the matplotlib boilerplate so the rendered docs show the plot output prominently.
+- **`hide-output`** on cells with verbose output (sampler progress, large tables, debug prints) — collapses the noise while keeping the cell runnable.
+
+Review prompt: any cell that produces ≥10 lines of sampler/progress output without `hide-output` is a candidate for the tag.
+
+### Sampler warnings
+
+Visible sampler warnings (divergences, low ESS, R̂ > 1.01) in a docs notebook are confusing for readers. Two fixes:
+
+1. Tune the sampler config (more chains, more tuning steps) to make the warnings go away genuinely.
+2. Hide them under `hide-output` if the warnings aren't a core part of the narrative.
+
+(1) is preferred when feasible. (2) is acceptable when the analysis is fundamentally about a borderline case.
+
+### External data
+
+Notebooks should prefer bundled CausalPy example datasets (loaded via `cp.load_data(...)`) over runtime fetches from external URLs. If an external fetch is unavoidable, document it with a comment so readers know what they're depending on.
+
+## MyST and cross-references
+
+### Glossary linking
+
+`AGENTS.md`: link to glossary terms (defined in `glossary.rst`) on first mention in a file.
+
+- Markdown / `.ipynb`: `` {term}`glossary term` ``
+- RST: `` :term:`glossary term` ``
+
+If a notebook introduces concepts like "treatment effect", "potential outcomes", "propensity score", etc., the first mention should be a glossary link. Subsequent mentions don't need to link.
+
+### Cross-references
+
+In Markdown, use MyST role syntax:
+
+- `` {doc}`path/to/doc` `` — link to another docs page.
+- `` {ref}`label-name` `` — link to a labelled section.
+
+Don't use raw markdown links (`[text](path/to/doc.md)`) for cross-doc references — MyST roles get full Sphinx resolution and break-link detection.
+
+### Admonitions
+
+Use MyST `:::{note}`, `:::{warning}`, `:::{important}` for callouts. Plain bold/italic emphasis is not the same — admonitions render as styled boxes.
+
+### Citations
+
+Citations live in `docs/source/references.bib`. Cite sources in example notebooks where possible. Include a reference section at the bottom of notebooks using:
+
+```markdown
+:::{bibliography}
+:filter: docname in docnames
+:::
+```
+
+If a new notebook has prose claims like "as shown in Smith et al. (2020)" without a corresponding `references.bib` entry and `:::{bibliography}` block, flag it.
+
+## Naming and organisation
+
+### Notebook filenames
+
+Pattern: `{method}_{model}.ipynb`.
+
+- `did_pymc.ipynb`, `rd_skl.ipynb`, `iv_pymc.ipynb`, `sc_pymc_brexit.ipynb`.
+- Composite topics: keep the prefix scheme so `:glob:` patterns would still work even though no section uses one today.
+
+### File placement
+
+- How-to examples → `docs/source/notebooks/`.
+- Educational / conceptual content → `docs/source/knowledgebase/`.
+- Scratch / temporary → `.scratch/` (untracked).
+
+A notebook that's mostly explaining a concept (rather than demonstrating CausalPy usage) probably belongs in `knowledgebase/`, not `notebooks/`.
+
+## API docs
+
+Auto-generated from docstrings via Sphinx autodoc. No manual API docs to write — but the docstrings themselves matter:
+
+- NumPy-style sections (`Parameters`, `Returns`, `Examples`).
+- `Examples` blocks should be runnable doctests where feasible (`make doctest` in CI).
+
+If a new public function has no `Examples` block, that's a should-fix, not a nit, because the API docs page will be terse.

--- a/.github/skills/pr-review/reference/how-to-extend.md
+++ b/.github/skills/pr-review/reference/how-to-extend.md
@@ -1,0 +1,91 @@
+# How to Extend This Skill
+
+This skill should grow with the codebase. New patterns get added when they recur; old patterns get pruned when they get formalised into hooks.
+
+## When to add a new pattern
+
+Add a pattern when **either** is true:
+
+- You've seen the same shape of issue in **two or more PRs** (it's not a one-off).
+- The pattern is specific enough to CausalPy that a generic reviewer wouldn't catch it (it's not common-knowledge linting).
+
+Don't add a pattern just because it came up once. The risk of skill bloat is real — a 200-line checklist is worse than a 50-line one because agents start cherry-picking.
+
+## Where to add it
+
+Choose the smallest scope that fits:
+
+| Pattern type | Where to add |
+|---|---|
+| Severity-sorted "look for X" | [what-to-look-for.md](what-to-look-for.md) under the right severity heading |
+| CausalPy source-code convention | [code-patterns.md](code-patterns.md) |
+| Notebook / docs convention | [docs-patterns.md](docs-patterns.md) |
+| Comment-shape template | [posting-comments.md](posting-comments.md) |
+| Workflow / process change | [workflow.md](workflow.md) |
+
+If a new pattern doesn't fit any existing file, that's a signal the skill is growing a new dimension and may need a new reference file. Don't force-fit.
+
+## Required structure for a new pattern
+
+Each pattern needs all four:
+
+1. **A short ID** (e.g. `MF-1`, `SF-3`, `N-7`) for cross-referencing.
+2. **A one-line title** that says what the pattern is.
+3. **A canonical example**: a real PR (e.g. "PR #826") and a specific instance, so future readers can ground the abstraction in a concrete case.
+4. **A "how to spot" prompt**: what does the agent actually look at to decide if this pattern is present? Vague patterns produce vague flags.
+
+Template:
+
+```markdown
+### <ID>: <One-line title>
+
+<2–4 sentences explaining what the pattern is and why it matters.>
+
+- **Canonical example**: <PR ref + specific instance>.
+- **How to spot**: <concrete diagnostic prompt>.
+- <Optional: links to related patterns or code-patterns.md sections>.
+```
+
+## When to prune
+
+Prune a pattern when:
+
+- A hook or CI check now enforces it mechanically. The agent shouldn't waste attention on what tooling already catches.
+- The pattern hasn't recurred in 12 months and the originating context has changed.
+- A new pattern subsumes it. Merge the two; don't leave both.
+
+Pruning is part of maintenance, not vandalism. The skill is more useful at 200 well-curated lines than 600 stale ones.
+
+## When to formalise into a hook
+
+If a pattern in `what-to-look-for.md` has a **mechanical answer** — same input always produces the same correct verdict — it should probably become a hook, not stay an agent task.
+
+Mechanical patterns from past reviews that were (or should be) formalised:
+
+- **Single H1 per notebook** → issue #863 (pre-commit hook).
+- **Notebook orphaned from `toctree`** → under discussion.
+- **Constrained string param not `Literal`** → potential Ruff/mypy rule (deferred).
+
+When you formalise a pattern, **remove it from this skill** at the same time. Don't leave both — divergence is worse than either alone.
+
+## Six-monthly review
+
+On a recurring cadence (every six months or after every ~10 PRs reviewed), do a quick pass:
+
+1. Are any patterns stale or unused?
+2. Are any patterns now hook-enforced and need pruning?
+3. Have new patterns recurred enough to add?
+4. Is `SKILL.md` still under 500 lines / 5000 tokens?
+
+If yes to any of (1) (2) (3), update accordingly. If no to (4), refactor — split a reference file, move detail out of `SKILL.md`.
+
+## Worked example: how this skill itself was created
+
+Initial creation drew on PR #826 review feedback as the canonical seed:
+
+- 2 must-fix items → MF-1 (`_clone()` priors), MF-2 (`Literal` for constrained strings).
+- 6 should-fix items → SF-1 through SF-6.
+- 7 nits → N-1 through N-7 (a few omitted as too one-off).
+- 3 process patterns → P-1 (mega payload), P-2 (superseded commits), P-3 (orphan notebook).
+
+Each pattern was checked against the four-element template (ID, title, example, how-to-spot) before inclusion. Patterns that were just "a single judgement call" without a recognisable shape were kept out — they're the kind of thing agents naturally do well anyway and don't benefit from a checklist entry.

--- a/.github/skills/pr-review/reference/posting-comments.md
+++ b/.github/skills/pr-review/reference/posting-comments.md
@@ -1,0 +1,180 @@
+# Posting Review Comments
+
+How to draft, present, and post review comments. Two non-negotiable rules:
+
+1. **Never post without explicit human approval.** Always draft first, present in chat, wait.
+2. **Cite specific code locations.** Use `line:line:filepath` references when calling out code, not vague paraphrases.
+
+## Comment shapes
+
+### Issue-thread comment (general PR conversation)
+
+For multi-item review summaries, scope/process feedback, or replies to other comments. Posted via `gh pr comment`.
+
+```bash
+gh pr comment <num> --body "$(cat <<'EOF'
+<text>
+EOF
+)"
+```
+
+### Inline review comment (line-anchored)
+
+For specific code-level suggestions tied to a line range. Posted via `gh api repos/:owner/:repo/pulls/<num>/comments` with JSON body.
+
+Use inline comments for:
+
+- Suggestions that point at a specific line.
+- Bug call-outs where the location is the whole point.
+
+Use issue-thread comments for:
+
+- Multi-section review summaries.
+- Replies to other comments.
+- Process / scope feedback.
+- Status updates ("rebase looks clean", "verified all feedback addressed").
+
+### Formal review (`gh pr review`)
+
+For `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` events. **Never** use `--approve` or `--request-changes` without explicit user instruction. `--comment` is fine for grouping multiple inline comments under a single review.
+
+## Templates
+
+### Multi-item review summary
+
+```markdown
+Thanks for the PR! [One sentence positive framing if warranted.]
+
+I have comments grouped by severity below.
+
+---
+
+## Must-fix
+
+### 1. [Concise title] (`path/to/file.py`)
+
+[2–4 sentence description. Include why it's a problem, not just what.]
+
+### 2. [Concise title] (`path/to/file.py`)
+
+[Description]
+
+---
+
+## Should-fix
+
+### 3. [Concise title]
+
+[Description, optionally with a code reference:]
+
+` ` `123:128:path/to/file.py
+def foo():
+    return self.x
+` ` `
+
+---
+
+## Nits
+
+### 4. [Concise title]
+
+[Description]
+
+---
+
+## Things I liked
+
+- [Specific positive — generic praise is unhelpful]
+- [Another specific positive]
+```
+
+The "Things I liked" section is not optional. Reviews that only criticise lose signal and demoralise. Find at least 2 specific things to call out, even on PRs with serious issues.
+
+### Status update on a contributor's response
+
+```markdown
+Thanks @<contributor> — confirmed [the rebase / the fix / etc.] (PR is now <state>, [verification details]).
+
+I've gone through round-1 and round-2 review items against the current branch and the code is basically in good shape. Everything is addressed, with tests for the substantive changes ([list 2-3 specifics]). Docs items are also done: [specifics].
+
+One judgement call worth flagging:
+
+- [Item still in question]: [their decision] vs. [your original ask]. [Ask for confirmation that the current shape is intentional.]
+
+[Optional: anything correctly deferred to follow-up]
+
+I'll do a manual pass over [the notebook / the API surface] before approving, but everything is looking good so far.
+```
+
+### Inline code-shape suggestion
+
+```markdown
+## Suggestion: [concise title]
+
+[Brief context — what does the code do today, and why is the suggestion worth considering?]
+
+### Why it [belongs in / should change]
+
+[Substantive reasoning, with bullet points if there are several supporting facts.]
+
+### Suggested shape
+
+[Concrete proposal, often with two options:]
+
+1. **[Option A]** — [description]
+2. **[Option B]** — [description]
+
+I'd lean toward **(1) [or whichever]** because [reason].
+
+### Cleanups before [doing the change]
+
+- [Specific cleanup 1]
+- [Specific cleanup 2]
+
+### Scope
+
+[Make explicit whether this is in-scope for the current PR or a follow-up. Defaulting to "happy for follow-up PR" reduces friction unless the change is small.]
+```
+
+### Correction
+
+If you posted something incorrect, post a follow-up correction promptly. Don't try to edit silently.
+
+```markdown
+Correction to my previous comment: [the wrong claim] was wrong because [what tripped you up]. [The correct statement.] [Anything that does still hold from the previous comment.]
+```
+
+## Tone calibration
+
+For each draft, offer the user 2–3 framing variants so they pick:
+
+1. **As-written** — the default tone you drafted.
+2. **Stricter** — convert a soft ask to a block, or flip a default to required.
+3. **Looser** — accept the contributor's choice with a note, defer the change to a follow-up issue.
+
+Example presentation in chat:
+
+> Three framing options:
+> 1. As-written — single soft question, otherwise approval-pending.
+> 2. Stricter — request the default flip in this PR (saves a deprecation cycle later).
+> 3. Looser — accept everything as-is and approve, file a follow-up issue.
+
+## Attribution
+
+If past comments on the PR have used a reviewer-bot identity (e.g. `claude-opus-4-7-xhigh`), preserve that voice when posting agent-authored comments. The human reviewer's voice and the agent's voice should be distinguishable in the thread.
+
+When in doubt, use a header like:
+
+```markdown
+`<model-slug>` here. [Bot disclaimer / scope.]
+```
+
+## After posting
+
+Always return the URL to the user:
+
+```bash
+# gh pr comment / gh api comment will print the URL on success
+```
+
+Echo it back: `Posted: [#826 (comment)](URL).`

--- a/.github/skills/pr-review/reference/what-to-look-for.md
+++ b/.github/skills/pr-review/reference/what-to-look-for.md
@@ -1,0 +1,147 @@
+# What to Look For
+
+Severity-sorted patterns. This is the diagnostic checklist — walk it explicitly during step 3 of the workflow.
+
+The patterns below are organised by severity, then by recurring **shape**. Each shape has a short rationale and a concrete example drawn from past reviews where possible. When a pattern requires deep CausalPy knowledge, it's been split into [code-patterns.md](code-patterns.md) (Python source) or [docs-patterns.md](docs-patterns.md) (notebooks + docs).
+
+## Must-fix patterns
+
+These are bugs or contract violations. Posting as `must-fix` should mean "I will block approval until this is addressed."
+
+### MF-1: Subclass override drops base-class behaviour
+
+A subclass overrides a method but doesn't forward all the kwargs the base class forwards.
+
+- **Canonical example**: `BayesianBasisExpansionTimeSeries._clone()` and `StateSpaceTimeSeries._clone()` in PR #826 omitted `priors=self._user_priors`. Consequence: user priors silently dropped on clone.
+- **How to spot**: when a diff adds a method override, read the base-class version side-by-side. Diff their kwargs.
+- See [code-patterns.md § _clone() pattern](code-patterns.md#clone-pattern) for the canonical CausalPy `_clone()` shape.
+
+### MF-2: Constrained string parameter not typed as `Literal`
+
+`AGENTS.md` is explicit: "use `Literal` for constrained string parameters."
+
+- **Canonical example**: `selection_method: str` accepting `"sequential"` or `"random"` should be `Literal["sequential", "random"]`.
+- **How to spot**: any new function/method parameter with a type of `str` whose docstring or implementation enumerates a fixed set of accepted values.
+- This is also a candidate for a Ruff/mypy custom rule eventually — file an issue if the same instance appears across multiple PRs.
+
+### MF-3: Behavioural change to existing function with no test that pins the new behaviour
+
+Common after bug fixes. The fix changes math/logic, but the only tests are pre-existing tests that happen to still pass — they don't *require* the new behaviour.
+
+- **Canonical example**: PR #826 changed the assurance simulation formula. Round-1 review flagged the missing test; round-2 confirmed two new tests now pin the corrected math.
+- **How to spot**: look for diff hunks that change a constant, formula, or branch condition in non-test code with no corresponding new assertion in tests.
+- The verification ask is specific: a test that would fail under the old code and pass under the new.
+
+### MF-4: New public API not consistent with sibling implementations
+
+If `BaseExperiment` subclasses all expose `supports_ols` and `supports_bayes`, a new subclass missing them is a bug. Same for `PyMCModel` subclasses, `CheckResult`-producing checks, etc.
+
+- See [code-patterns.md § BaseExperiment contract](code-patterns.md#baseexperiment-contract) and [§ PyMCModel contract](code-patterns.md#pymcmodel-contract).
+
+## Should-fix patterns
+
+Design judgement, not bugs. Block on these only if the contributor pushes back without good reason.
+
+### SF-1: Default value of a memory-heavy retainer is "on"
+
+Result/check classes that retain the full fitted model (including `InferenceData`) by default impose a hidden cost on every user, even those who only need summary stats.
+
+- **Canonical example**: PR #826 `FalsificationResult` retains the full `BaseExperiment`. Should default to summary-only with `store_experiments=True` as opt-in.
+- **How to spot**: any new dataclass/class with a field that holds a fitted experiment, posterior, or large array, instantiated by default during `run()`/`fit()`.
+- If the contributor pushes back: ask whether common-case users will pay for the inspection feature they don't use.
+
+### SF-2: Bare `except Exception` (or `except:`) in library code
+
+Hides unexpected bugs as well as expected failures. Acceptable when the goal is "best effort and log everything", but the contributor should be explicit.
+
+- **Canonical example**: `outcome_falsification.py` `run()` loop catches `Exception` to keep going on individual formula failures. A targeted tuple `(ValueError, PatsyError, RuntimeError)` would still keep the loop going while letting unexpected `AttributeError`s surface.
+- This is partly enforceable by Ruff `BLE001` — if the rule isn't enabled and the same pattern keeps appearing, file an issue to enable it with allowlist.
+
+### SF-3: Docstring describes one quantity, code/test asserts another
+
+Subtle bug-source. The docstring becomes the spec; if it's wrong, future contributors will write code matching the wrong spec.
+
+- **Canonical example**: PR #826 `min_gap` docstring described "candidate-list distance" but the test asserted "actual time distance". These are different. Either the docstring or the test is wrong.
+- **How to spot**: read the docstring of any new parameter, then read the test that exercises it. Confirm they describe the same quantity.
+
+### SF-4: Default value is silently a no-op
+
+A default that doesn't actually constrain anything is misleading. Either the default should impose a useful constraint, or the docstring should be honest about the no-op.
+
+- **Canonical example**: `min_gap=1` with sampling-without-replacement is trivially true for any two distinct integer positions. Either change the default to `intervention_length` or document the no-op.
+- **How to spot**: read default values; ask "what does this default actually do?" If the answer is "nothing", flag.
+
+### SF-5: Algorithmic invariant not enforced where the rest of the code assumes it
+
+When downstream code assumes invariant X (independence, non-overlap, sortedness) but upstream selection doesn't enforce X, X gets violated silently.
+
+- **Canonical example**: `PlaceboInTime` random folds didn't enforce non-overlap of pseudo-windows; downstream hierarchical model assumes folds are exchangeable. Need either an `allow_overlap=False` default or an explicit docstring warning.
+- **How to spot**: read the assumptions of downstream consumers, then read the upstream selector. Mismatch = flag.
+
+### SF-6: Function ignores a parameter for a subset of input types
+
+Polymorphic input handling that silently drops requested behaviour for one branch.
+
+- **Canonical example**: `_draw_expected_effect_samples(n)` returned the user's numpy array verbatim, ignoring `n` entirely. Downstream code cycled with `i % len(prior)`, masking the silent drop.
+- **How to spot**: any function that takes both a "size" parameter and a polymorphic input. Read each branch and confirm `n` is honoured (or explicitly documented as a no-op for that branch).
+
+## Nits
+
+Cosmetic / quality-of-life. Cluster these at the end of a review so they don't dilute attention from the must-fix items.
+
+### N-1: `__repr__` shows defaults
+
+`__repr__` should show non-default values only, mirroring `dataclass`-style brevity. If a sibling class in the same module already does this, inconsistency is the flag.
+
+### N-2: Defensive code that doesn't actually defend
+
+`except (KeyError, IndexError, np.linalg.LinAlgError)` where `LinAlgError` is never actually raised by the code under the try block. Harmless but adds noise.
+
+- **How to spot**: for each exception in a multi-exception except clause, ask "what code path raises this?" If unclear, drop it.
+
+### N-3: Test uses an unrealistic failure mode
+
+Tests should exercise the failure modes users will actually hit, not synthetic ones. A test that uses a syntactically-invalid formula instead of a missing-column formula is testing the wrong thing.
+
+### N-4: Docstring missing a non-obvious behaviour note
+
+Behaviour that isn't bug-level but isn't intuitive — e.g. "this default halves the eligible window when X is unset." A one-line docstring note prevents future surprise.
+
+### N-5: External data dependency in docs notebook
+
+Notebook fetches from `https://...` at runtime. Brittle to URL changes / outages. Either bundle as a CausalPy example dataset or add a note.
+
+### N-6: Test setup duplication ≥ 60 lines across ≥ 3 tests
+
+A pytest fixture would consolidate. Not a bug, but an ongoing maintenance tax.
+
+### N-7: Helper used N times in a notebook is library material
+
+If a docs notebook defines a non-trivial helper (≥50 lines) and uses it ≥3 times, the helper is general, not example-specific. Suggest promotion to the library — usually as a follow-up PR rather than expanding the current one.
+
+- **Canonical example**: `plot_placebo_calibration` in PR #826's notebook (~130 lines, called 3x). Inline review left the suggestion with a "happy for follow-up PR" disposition.
+- See [code-patterns.md § Helper promotion](code-patterns.md#helper-promotion) for the cleanup checklist before promoting.
+
+## Process patterns
+
+Not code-level, but worth flagging on the PR.
+
+### P-1: Mega-payload PR
+
+Multiple logically-independent themes in one PR (interrogate config + new model `_clone()` + new check + plot bug fix). Slows review and complicates revert.
+
+- **How to handle**: don't block on this for the current PR (sunk cost), but flag it once for future PRs.
+- **Canonical example**: PR #826 issue-thread comment.
+
+### P-2: Branch contains commits superseded by recently-merged work on `main`
+
+Contributor's branch has commits that overlap with — and are slightly worse than — a fix that just landed on `main`. Need to identify the colliding commits, recommend rebase + drop, and confirm the canonical fix is picked up.
+
+- **Canonical example**: PR #826 had two `panel_regression.py` commits superseded by #853.
+- **How to spot**: when a PR is in `CONFLICTING` state, scan its file list against the most recent N commits to `main` for overlap.
+
+### P-3: Notebook orphaned from `toctree`
+
+A new notebook in `docs/source/notebooks/` not referenced anywhere in the docs tree. Sphinx renders it but there's no path for users to reach it.
+
+- This is a hook candidate (under discussion); until the hook lands, look for it manually on every PR that adds a notebook.

--- a/.github/skills/pr-review/reference/workflow.md
+++ b/.github/skills/pr-review/reference/workflow.md
@@ -1,0 +1,101 @@
+# PR Review Workflow
+
+Six steps. Steps 1–4 are read-only context-gathering and analysis. Step 5 is drafting. Step 6 only happens with explicit human approval.
+
+## Step 1 — Establish full context
+
+Run these in parallel where possible:
+
+```bash
+# PR metadata
+gh pr view <num> --json title,url,state,author,number,mergeable,mergeStateStatus,headRefName,baseRefName,commits,files
+
+# All commits
+gh api repos/:owner/:repo/pulls/<num>/commits --paginate --jq '.[] | {sha: .sha[0:8], msg: .commit.message | split("\n")[0]}'
+
+# All formal reviews (CHANGES_REQUESTED, COMMENTED, APPROVED)
+gh api repos/:owner/:repo/pulls/<num>/reviews --jq '.[] | {user: .user.login, state, submitted_at, body}'
+
+# All inline review comments (line-anchored)
+gh api repos/:owner/:repo/pulls/<num>/comments --paginate
+
+# All issue-thread comments (general PR conversation)
+gh api repos/:owner/:repo/issues/<num>/comments --paginate
+
+# Files changed
+gh pr diff <num> --name-only
+```
+
+If the user has already provided partial context (e.g. "check the last comment"), narrow the fetch — don't re-pull everything.
+
+## Step 2 — Read the relevant subset
+
+Read every file in the diff. For each, also pull surrounding context:
+
+- Subclass added → read the base class.
+- New test → read sibling tests in the same file.
+- New experiment class → read `BaseExperiment` and at least one existing experiment.
+- New check → read `causalpy/checks/base.py` and an existing check.
+- Notebook added → read at least one sibling notebook in the same docs section.
+
+This is what catches "this `_clone()` doesn't forward `priors=self._user_priors` like the base class does" — you can't notice the omission without reading the base class.
+
+## Step 3 — Pass over the diff
+
+Walk the patterns checklist in [what-to-look-for.md](what-to-look-for.md) explicitly. Don't trust unaided memory; the checklist exists because reviews otherwise drift toward whatever's most recently in mind.
+
+Group findings by severity:
+
+- **Must-fix** — bugs, contract violations, dropped behaviour, missing required forwarding (e.g. base-class kwargs).
+- **Should-fix** — design judgement (default values, API ergonomics, memory footprint), missing tests for behavioural changes, broad except clauses.
+- **Nits** — style, docstring polish, naming, defensive code that isn't actually defending anything.
+- **Things you liked** — actually include this. Reviews that only criticise are demoralising and lose signal.
+
+## Step 4 — Verify claims
+
+If the contributor (or a previous review iteration) claimed something is done, verify against current code. Common claim shapes and their tests:
+
+| Claim | Verification |
+|---|---|
+| "Rebased onto main" | `git log --oneline base..head` shows merge commits / no problematic commits |
+| "Addressed all feedback" | Walk each review item against current files |
+| "Tests added for the new behaviour" | Read the test, confirm it would fail without the fix |
+| "Fixed the conflict" | `gh pr view --json mergeable` shows `MERGEABLE` |
+| "PR is small" | `gh pr view --json files` line-count |
+
+Any claim that turns out to be wrong should be flagged respectfully but specifically — vague disagreement is unhelpful.
+
+## Step 5 — Draft comments for human review
+
+Never post directly. Always:
+
+1. Lay out findings in chat for the user.
+2. Show the draft comment text in a code block.
+3. Offer 2–3 framing variants (stricter, softer, approval-pending) so the user picks the tone.
+4. Wait for explicit approval.
+
+See [posting-comments.md](posting-comments.md) for full templates.
+
+## Step 6 — Post on approval
+
+Only after the user explicitly approves:
+
+```bash
+gh pr comment <num> --body "$(cat <<'EOF'
+<text>
+EOF
+)"
+```
+
+For inline review comments anchored to a line, use `gh api repos/:owner/:repo/pulls/<num>/comments` with the appropriate JSON body. For a formal review (with `event: COMMENT`/`APPROVE`/`REQUEST_CHANGES`), use `gh pr review` — but never `--approve` or `--request-changes` without an explicit user instruction.
+
+After posting, return the URL.
+
+## Loops and follow-up
+
+If the review surfaces:
+
+- **A formalisable pattern** (could be a hook) → file a follow-up issue via [`github-issues`](../../github-issues/SKILL.md).
+- **A code-level fix the contributor should make** → leave a PR comment with the fix sketched.
+- **A scope concern** (PR too big, mixes themes) → flag in the review summary and reference past examples (`#826` "mega payload" comment is the canonical example here).
+- **A merge blocker** (conflicts with a recently-merged PR) → identify the colliding commits and propose the rebase.

--- a/causalpy/tests/test_notebook_validation.py
+++ b/causalpy/tests/test_notebook_validation.py
@@ -21,10 +21,12 @@ import sys
 from pathlib import Path
 
 import nbformat
-from nbformat.v4 import new_code_cell, new_notebook, new_output
+import pytest
+from nbformat.v4 import new_code_cell, new_markdown_cell, new_notebook, new_output
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 VALIDATOR_SCRIPT = REPO_ROOT / "scripts" / "validate_notebooks.py"
+DOCS_NOTEBOOKS_DIR = REPO_ROOT / "docs" / "source" / "notebooks"
 
 
 def _run_validator(notebook_path: Path) -> subprocess.CompletedProcess[str]:
@@ -49,10 +51,22 @@ def _build_notebook() -> dict:
     )
 
 
+def _write_notebook(notebook_path: Path, notebook: dict) -> None:
+    notebook_path.parent.mkdir(parents=True, exist_ok=True)
+    with notebook_path.open("w", encoding="utf-8") as notebook_file:
+        nbformat.write(notebook, notebook_file)
+
+
+def _write_docs_notebook(tmp_path: Path, name: str, cells: list) -> Path:
+    notebook = new_notebook(cells=cells)
+    notebook_path = tmp_path / "docs" / "source" / "notebooks" / name
+    _write_notebook(notebook_path, notebook)
+    return notebook_path
+
+
 def test_validate_notebooks_accepts_valid_notebook(tmp_path: Path) -> None:
     notebook_path = tmp_path / "valid.ipynb"
-    with notebook_path.open("w", encoding="utf-8") as notebook_file:
-        nbformat.write(_build_notebook(), notebook_file)
+    _write_notebook(notebook_path, _build_notebook())
 
     result = _run_validator(notebook_path)
 
@@ -77,3 +91,166 @@ def test_validate_notebooks_reports_schema_details_for_invalid_output(
     assert "cell[0]" in result.stderr
     assert "output[0]" in result.stderr
     assert "required property" in result.stderr
+
+
+def test_docs_notebook_with_single_h1_passes(tmp_path: Path) -> None:
+    notebook_path = _write_docs_notebook(
+        tmp_path,
+        "single_h1.ipynb",
+        cells=[
+            new_markdown_cell(source="# Lone Title\n\nSome intro text."),
+            new_markdown_cell(source="## Subsection"),
+            new_code_cell(source="x = 1"),
+        ],
+    )
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+@pytest.mark.parametrize(
+    ("description", "cells", "expected_count"),
+    [
+        (
+            "no_h1",
+            [
+                new_markdown_cell(source="## Only a subsection\n\nNo top-level."),
+                new_code_cell(source="x = 1"),
+            ],
+            0,
+        ),
+        (
+            "multiple_h1_in_one_cell",
+            [
+                new_markdown_cell(source="# First\n\nIntro\n\n# Second\n\nMore."),
+            ],
+            2,
+        ),
+        (
+            "multiple_h1_across_cells",
+            [
+                new_markdown_cell(source="# First"),
+                new_markdown_cell(source="# Second"),
+                new_markdown_cell(source="# Third"),
+            ],
+            3,
+        ),
+    ],
+)
+def test_docs_notebook_with_wrong_h1_count_fails(
+    tmp_path: Path,
+    description: str,
+    cells: list,
+    expected_count: int,
+) -> None:
+    notebook_path = _write_docs_notebook(tmp_path, f"{description}.ipynb", cells=cells)
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 1
+    assert str(notebook_path) in result.stderr
+    assert f"found {expected_count}" in result.stderr
+    assert "exactly one top-level (#) markdown heading" in result.stderr
+
+
+def test_python_comments_in_code_cells_do_not_count_as_h1(tmp_path: Path) -> None:
+    notebook_path = _write_docs_notebook(
+        tmp_path,
+        "code_comments.ipynb",
+        cells=[
+            new_markdown_cell(source="# The Real Title"),
+            new_code_cell(
+                source=("# Calculate average weekly spend\n# Another comment\nx = 1")
+            ),
+        ],
+    )
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_fenced_code_block_in_markdown_does_not_count_as_h1(
+    tmp_path: Path,
+) -> None:
+    """Replicates the its_lift_test.ipynb pattern: ```python``` block with
+    `# comment` inside a markdown cell must not register as additional H1s."""
+    markdown_with_fenced_python = (
+        "## Key outputs\n"
+        "\n"
+        "```python\n"
+        "# Calculate average weekly spend during the promo period\n"
+        "# Extract mean lift statistics from the ITS analysis\n"
+        "spend = 100\n"
+        "```\n"
+        "\n"
+        "Some closing text."
+    )
+    notebook_path = _write_docs_notebook(
+        tmp_path,
+        "fenced_python_in_markdown.ipynb",
+        cells=[
+            new_markdown_cell(source="# Real Title"),
+            new_markdown_cell(source=markdown_with_fenced_python),
+        ],
+    )
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_tilde_fenced_block_in_markdown_does_not_count_as_h1(
+    tmp_path: Path,
+) -> None:
+    markdown_with_tilde_fence = "Example:\n\n~~~python\n# Not a heading\ny = 2\n~~~\n"
+    notebook_path = _write_docs_notebook(
+        tmp_path,
+        "tilde_fenced.ipynb",
+        cells=[
+            new_markdown_cell(source="# Real Title"),
+            new_markdown_cell(source=markdown_with_tilde_fence),
+        ],
+    )
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_h1_check_only_applies_to_docs_notebooks(tmp_path: Path) -> None:
+    """Notebooks outside docs/source/notebooks/ are exempt from the H1 rule."""
+    notebook = new_notebook(
+        cells=[
+            new_markdown_cell(source="# First"),
+            new_markdown_cell(source="# Second"),
+            new_markdown_cell(source="# Third"),
+        ]
+    )
+    notebook_path = tmp_path / "scratch_notebook.ipynb"
+    _write_notebook(notebook_path, notebook)
+
+    result = _run_validator(notebook_path)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stderr == ""
+
+
+def test_all_docs_notebooks_pass_h1_check() -> None:
+    """Regression test: every checked-in docs notebook must satisfy the rule."""
+    if not DOCS_NOTEBOOKS_DIR.is_dir():
+        pytest.skip("docs/source/notebooks directory not present in this checkout")
+
+    notebooks = sorted(DOCS_NOTEBOOKS_DIR.glob("*.ipynb"))
+    if not notebooks:
+        pytest.skip("no notebooks found under docs/source/notebooks")
+
+    result = subprocess.run(
+        [sys.executable, str(VALIDATOR_SCRIPT), *map(str, notebooks)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr

--- a/scripts/validate_notebooks.py
+++ b/scripts/validate_notebooks.py
@@ -11,6 +11,13 @@ import nbformat
 from nbformat import NotebookNode
 from nbformat.validator import NotebookValidationError
 
+# Notebooks under this directory are rendered into the Sphinx docs index. Each
+# top-level (`#`) markdown heading inside such a notebook becomes a separate
+# `toctree` entry, so we enforce exactly one per notebook to keep the sidebar
+# clean. The check is intentionally not applied to scratch / dev notebooks
+# elsewhere in the repo.
+DOCS_NOTEBOOKS_DIR = Path("docs/source/notebooks")
+
 
 def _extract_path_index(path_segments: list[Any], segment_name: str) -> int | None:
     """Return the integer index that follows a path segment name."""
@@ -69,6 +76,69 @@ def _format_validation_error(
     return "\n".join(details)
 
 
+def _count_h1_headings(notebook: NotebookNode) -> list[tuple[int, str]]:
+    """Return ``(cell_index, heading_text)`` for every level-1 markdown heading.
+
+    Only markdown cells are inspected. Within markdown cells, lines inside
+    fenced code blocks (``` ``` ``` or ``` ~~~ ```) are skipped so that Python
+    comments embedded in code samples do not register as headings.
+    """
+    h1s: list[tuple[int, str]] = []
+    for cell_index, cell in enumerate(notebook.get("cells", [])):
+        if cell.get("cell_type") != "markdown":
+            continue
+        source = cell.get("source", "")
+        if isinstance(source, list):
+            source = "".join(source)
+        in_fence = False
+        for line in source.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith(("```", "~~~")):
+                in_fence = not in_fence
+                continue
+            if in_fence:
+                continue
+            if line.startswith("# ") and not line.startswith("## "):
+                h1s.append((cell_index, line[2:].strip()))
+    return h1s
+
+
+def _is_docs_notebook(notebook_path: Path) -> bool:
+    """Return True if the notebook lives under ``docs/source/notebooks/``."""
+    try:
+        resolved = notebook_path.resolve()
+    except OSError:
+        resolved = notebook_path
+    parts = resolved.parts
+    target = DOCS_NOTEBOOKS_DIR.parts
+    if len(parts) < len(target):
+        return False
+    for window_start in range(len(parts) - len(target) + 1):
+        if parts[window_start : window_start + len(target)] == target:
+            return True
+    return False
+
+
+def _format_h1_violation(
+    notebook_path: Path,
+    h1s: list[tuple[int, str]],
+) -> str:
+    """Format a human-readable error for a single-H1 violation."""
+    if h1s:
+        locations = "\n".join(
+            f"  cell {cell_index}: {text}" for cell_index, text in h1s
+        )
+    else:
+        locations = "  (no top-level # headings found)"
+    return (
+        f"{notebook_path}: expected exactly one top-level (#) markdown "
+        f"heading, found {len(h1s)}.\n"
+        f"{locations}\n"
+        f"  Each docs notebook must have exactly one top-level (#) heading. "
+        f"Demote the others to ## (or below) so the docs sidebar stays clean."
+    )
+
+
 def validate_notebook(notebook_path: Path) -> tuple[bool, str | None]:
     """Validate a single notebook and return (is_valid, error_message)."""
     try:
@@ -81,6 +151,11 @@ def validate_notebook(notebook_path: Path) -> tuple[bool, str | None]:
         nbformat.validate(notebook)
     except NotebookValidationError as error:
         return False, _format_validation_error(notebook_path, notebook, error)
+
+    if _is_docs_notebook(notebook_path):
+        h1s = _count_h1_headings(notebook)
+        if len(h1s) != 1:
+            return False, _format_h1_violation(notebook_path, h1s)
 
     return True, None
 


### PR DESCRIPTION
## Summary

Two related-but-distinct changes bundled in one PR.

### 1. Single-H1 hook for docs notebooks (closes #863)

Extends the existing `validate-notebooks` pre-commit hook (`scripts/validate_notebooks.py`) with a single-H1 check, scoped to `docs/source/notebooks/` so dev/scratch notebooks elsewhere are unaffected.

The check is robust against the two false-positive sources that were called out in #863:

- **Code cells are skipped entirely** — Python comments cannot trigger a violation.
- **Within markdown cells, fenced code blocks (```` ``` ```` and `~~~`) are skipped** — Python comments embedded in markdown code samples (the `its_lift_test.ipynb` pattern) cannot trigger a violation.

Failure messages name each offending cell index and heading text, plus a short remediation hint.

Test coverage in `causalpy/tests/test_notebook_validation.py`:

- Single-H1 valid case.
- Multi-H1 / no-H1 violations (three parametrised variants).
- Code-cell comment false-positive guard.
- Fenced-code-block (```` ```python ```` and `~~~python`) false-positive guards.
- Out-of-scope exemption (notebooks outside `docs/source/notebooks/` ignored).
- Regression test that walks every shipped docs notebook and asserts the check passes — currently green now that #826's notebook fix has landed (see audit below).

### 2. New `pr-review` agent skill

`.github/skills/pr-review/` — orchestrator `SKILL.md` plus six focused reference files (`workflow.md`, `what-to-look-for.md`, `code-patterns.md`, `docs-patterns.md`, `posting-comments.md`, `how-to-extend.md`).

Captures the review patterns surfaced during the #826 review iteration into a reusable skill: how to fetch PR context, severity-sorted patterns to look for, CausalPy-specific code conventions (`BaseExperiment`, `_clone()`, `Literal` for constrained strings, helper-promotion checklist), notebook/docs conventions, comment-drafting templates, and a built-in extension/pruning protocol so the skill stays sharp as patterns get formalised into hooks.

Designed to complement (not duplicate) the existing `pr-to-green` and `pr-workflows` skills; explicitly defers mechanical checks to hooks/CI.

## Why these are bundled

The branch was originally scoped to #863, but the skill captures (among other things) "single-H1 enforcement should be a hook, not an agent task" as an explicit pattern. Bundling them keeps the skill's canonical examples accurate from day one. Happy to split into two PRs if a maintainer prefers — they're cleanly separable (no shared files, no shared test surface).

## Audit — current docs notebook corpus

```
Scanned 32 notebooks
Violations: 0
```

(Was 1 prior to #826 landing; the H1 fix in that PR cleared the only outstanding violation.)

## Test plan

- [ ] `prek run --all-files` passes locally.
- [ ] `$CONDA_EXE run -n CausalPy python -m pytest causalpy/tests/test_notebook_validation.py -v` passes.
- [ ] CI `prek` job picks up the new check via the existing `validate-notebooks` hook.
- [ ] Manual smoke: introducing a deliberate second `#` heading in any `docs/source/notebooks/*.ipynb` causes the hook to fail with the expected message.

## Out of scope

- Pre-commit / CI check for orphan notebooks (notebooks not referenced from any toctree). Discussed in chat, not yet filed as an issue.
- Setting `-W` on the docs build so Sphinx orphan warnings become errors. Tracked separately from this PR.

## Related

- Closes #863
- Surfaced by review iteration on #826

Made with [Cursor](https://cursor.com)