### PR TITLE
Add pr-review agent skill

### DIFF
--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -22,7 +22,7 @@ Do **not** use this skill for:
 
 ## Division of labour with automation
 
-A pre-commit hook never misses; an agent review is judgement-heavy. Don't duplicate the hook's job. Mechanical checks already enforced by `prek` / CI (lint, format, mypy, schema validation, single-H1-per-notebook, etc.) are not part of this skill — assume they pass and focus the human-equivalent attention on what they can't catch.
+A pre-commit hook never misses; an agent review is judgement-heavy. Don't duplicate the hook's job. Mechanical checks already enforced by `prek` / CI (lint, format, mypy, schema validation, etc.) are not part of this skill — assume they pass and focus the human-equivalent attention on what they can't catch.
 
 If during review you notice a *class* of issue that automation could catch but doesn't, file it as a follow-up issue via [`github-issues`](../github-issues/SKILL.md) rather than only flagging the one instance.
 

--- a/.github/skills/pr-review/SKILL.md
+++ b/.github/skills/pr-review/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: pr-review
+description: Review CausalPy pull requests — fetch context, run a structured pass over code, tests, docs, and process, then produce maintainer-quality comments for human review before posting. Use when the user asks to review a PR, check a PR, evaluate review feedback, or audit PR comments. Complements pr-to-green (which fixes PRs) and pr-workflows (which creates them).
+---
+
+# PR Review
+
+This skill is for **reviewing** a CausalPy pull request — diagnosing what's there, judging it against project conventions, and producing actionable feedback. It is the read/diagnose/write-comment counterpart to `pr-to-green` (fix in-flight PR) and `pr-workflows` (create PR from issue).
+
+## When to use
+
+- The user asks to review, check, or evaluate a PR (e.g. "review #826", "look at PR 826", "what's outstanding on PR 826").
+- The user asks whether a PR is ready to approve, merge, or land.
+- The user asks to evaluate a contributor's response to prior review feedback ("did they address my comments?").
+- The user asks to audit existing comments on a PR for relevance, accuracy, or remaining gaps.
+
+Do **not** use this skill for:
+
+- Fixing a failing PR — use [`pr-to-green`](../pr-to-green/SKILL.md).
+- Turning an issue into a PR — use [`pr-workflows`](../pr-workflows/SKILL.md).
+- Creating new issues that come out of a review — delegate to [`github-issues`](../github-issues/SKILL.md).
+
+## Division of labour with automation
+
+A pre-commit hook never misses; an agent review is judgement-heavy. Don't duplicate the hook's job. Mechanical checks already enforced by `prek` / CI (lint, format, mypy, schema validation, single-H1-per-notebook, etc.) are not part of this skill — assume they pass and focus the human-equivalent attention on what they can't catch.
+
+If during review you notice a *class* of issue that automation could catch but doesn't, file it as a follow-up issue via [`github-issues`](../github-issues/SKILL.md) rather than only flagging the one instance.
+
+## Workflow
+
+The full workflow is in [reference/workflow.md](reference/workflow.md). At a glance:
+
+1. **Establish context** — fetch PR metadata, all commits, all reviews, all comments (review + issue threads), file changes.
+2. **Read the relevant subset** — files changed, plus surrounding context for each change (base class for new subclass, sibling tests for new tests, etc.).
+3. **Pass over the diff with the patterns checklist** — see [reference/what-to-look-for.md](reference/what-to-look-for.md). Group findings by severity.
+4. **Verify claims** — if the contributor says "addressed all feedback", confirm against the actual code; if they say a rebase is clean, confirm against `git log`.
+5. **Draft comments for human review** — never post directly. See [reference/posting-comments.md](reference/posting-comments.md).
+6. **Post on approval** and report URLs back.
+
+For batched PR work (multi-file diffs, parallel exploration), follow `pr-to-green`'s subagent delegation patterns — same `Task` triggers (`generalPurpose` for exploration, `ci-failure-investigator` for noisy CI logs) apply.
+
+## What to look for
+
+Severity-sorted patterns (must-fix → should-fix → nits) live in [reference/what-to-look-for.md](reference/what-to-look-for.md). The two domain-specific deep-dives are:
+
+- [reference/code-patterns.md](reference/code-patterns.md) — `BaseExperiment` contract, `PyMCModel` vs. `RegressorMixin` dispatch, `_clone()` patterns, `Literal` for constrained strings, custom exceptions, `__repr__` style, memory-heavy retainers.
+- [reference/docs-patterns.md](reference/docs-patterns.md) — notebook narrative quality, glossary linking, `:::{note}` admonitions, hide-input/hide-output cell tags, citations, sampler-output noise, helper-promotion judgement.
+
+## Drafting comments
+
+The full template is in [reference/posting-comments.md](reference/posting-comments.md). Two non-negotiable rules:
+
+1. **Always draft for human review before posting.** Read the draft back and offer 2–3 framing variants (stricter / softer / approval-pending).
+2. **Cite specific code locations.** Use line:line:filepath references when calling out code, not vague paraphrases.
+
+## Mandatory pre-flight reads
+
+Before reviewing any PR, the reviewing agent should have read or be able to load:
+
+- `AGENTS.md` (root) — code structure, style, type hints, testing preferences.
+- `CONTRIBUTING.md` — process expectations.
+- `docs/source/notebooks/index.md` — toctree layout, where new notebooks should go.
+- The PR's own description and any prior review iterations.
+
+## How to extend this skill
+
+When a review surfaces a new recurring pattern, add it. The process is in [reference/how-to-extend.md](reference/how-to-extend.md). Skill drift is real — every six months or so, prune patterns that have been formalised into hooks.
+
+## Important behaviour
+
+- Never post review comments without explicit human approval.
+- Never approve, request changes, or merge a PR through `gh pr review --approve` unless explicitly instructed.
+- When evaluating a contributor's response to prior feedback, verify against the code, not their summary. A "fixed all feedback" claim is a hypothesis to test, not a fact to accept.
+- If a reviewer-bot identity has been used in the past on the PR (e.g. `claude-opus-4-7-xhigh`), preserve that attribution in posted comments so the human reviewer's voice and the agent's voice stay distinguishable.
+- Do not duplicate work already covered by hooks/CI. If something is mechanically enforceable and not enforced, file an issue rather than re-flagging the instance.

--- a/.github/skills/pr-review/reference/code-patterns.md
+++ b/.github/skills/pr-review/reference/code-patterns.md
@@ -1,0 +1,108 @@
+# CausalPy Code Patterns
+
+Repo-specific conventions and contracts to check against when reviewing source-code diffs. These are the patterns most likely to be inadvertently broken by a contributor (especially a new one) because they're enforced by convention rather than by the type system.
+
+## `BaseExperiment` contract
+
+All experiment classes in `causalpy/experiments/` inherit from `BaseExperiment`. Required:
+
+- Class attributes `supports_ols: bool` and `supports_bayes: bool` declared.
+- If `supports_bayes`: implement `_bayesian_plot()` and `get_plot_data_bayesian()`.
+- If `supports_ols`: implement `_ols_plot()` and `get_plot_data_ols()`.
+- Model-agnostic dispatch via `isinstance(self.model, PyMCModel)` vs. `isinstance(self.model, RegressorMixin)`.
+- Data index named `"obs_ind"`.
+- Formula parsing via patsy `dmatrices()`.
+- Custom exceptions from `causalpy.custom_exceptions`: `FormulaException`, `DataException`, `BadIndexException`.
+
+Review prompts:
+
+- New `BaseExperiment` subclass? Check both class attributes are declared.
+- Implements only `_bayesian_plot` but `supports_ols=True`? That's a bug.
+- Uses `assert` for input validation? Should be a custom exception.
+
+## `PyMCModel` contract
+
+PyMC models inherit from `PyMCModel` (extends `pm.Model`). Common interface: `fit()`, `predict()`, `score()`, `calculate_impact()`, `print_coefficients()`.
+
+- Data: `xarray.DataArray` with coords (`coeffs`, `obs_ind`, `treated_units`).
+- Stores user-supplied priors on `self._user_priors` for round-trip via `_clone()`.
+
+## `_clone()` pattern
+
+The base `PyMCModel._clone()` forwards `priors=self._user_priors`. Every override **must** do the same, or user customisations are silently dropped on clone.
+
+Spot-check template:
+
+```python
+# In the new subclass:
+def _clone(self):
+    return type(self)(
+        sample_kwargs=self.sample_kwargs,
+        priors=self._user_priors,   # <-- must be present
+        # ... any other config kwargs the subclass adds ...
+    )
+```
+
+If `priors=` is absent, that's a must-fix (MF-1 in [what-to-look-for.md](what-to-look-for.md)).
+
+## `RegressorMixin` (sklearn) compatibility
+
+Scikit-learn models use `RegressorMixin` and are made causalpy-compatible via `create_causalpy_compatible_class()`. Same external interface as `PyMCModel`. Data is numpy arrays, not xarray.
+
+Review prompt: experiment classes should branch with `isinstance(self.model, PyMCModel)` vs. `isinstance(self.model, RegressorMixin)` rather than feature-detect on the model.
+
+## `CheckResult` contract
+
+Lives in `causalpy/checks/base.py`. Has a documented `figures: list[Any]` field — but as of writing, no check populates it. If a new check defines a non-trivial plotting helper in a notebook (see [what-to-look-for.md § N-7](what-to-look-for.md#n-7-helper-used-n-times-in-a-notebook-is-library-material)), promoting it to populate `CheckResult.figures` is the natural integration point.
+
+`passed=None` is the right design for informational-only checks (e.g. `OutcomeFalsification`) — they should inform, not gate.
+
+## Type hints
+
+`AGENTS.md` is explicit. Required style (Python 3.10+):
+
+- `X | None`, not `Optional[X]`.
+- Lowercase `dict`, `list`, `tuple`, not `Dict`, `List`, `Tuple` from `typing`.
+- `Literal` for constrained string parameters (see [what-to-look-for.md § MF-2](what-to-look-for.md#mf-2-constrained-string-parameter-not-typed-as-literal)).
+
+## Custom exceptions
+
+Use, in order of preference:
+
+- `FormulaException` — patsy/formula problems.
+- `DataException` — data-shape, missing-column, dtype problems.
+- `BadIndexException` — index issues.
+
+Plain `ValueError` is acceptable when nothing more specific fits; `assert` is not.
+
+## `__repr__` style
+
+Convention: show non-default values only.
+
+```python
+def __repr__(self) -> str:
+    parts = [f"alpha={self.alpha}"] if self.alpha != 0.05 else []
+    if not self.store_experiments:
+        parts.append("store_experiments=False")
+    return f"OutcomeFalsification({', '.join(parts)})"
+```
+
+A new class with a `__repr__` that shows defaults is inconsistent with sibling classes — flag as N-1.
+
+## Helper promotion
+
+When a docs notebook defines a non-trivial helper (≥50 lines) called ≥3 times, suggest promoting to the library. Standard cleanup checklist before promotion:
+
+1. Drop UI side-effects: no `print()` in library code (use `warnings.warn`); no `plt.show()` (return the `Figure`).
+2. Drop hard-coded constants that limit reuse: e.g. `FOLD_COLORS = [...5 colors...]` should become a module-level constant or use matplotlib's color cycle.
+3. Add `figsize` and `axes` kwargs so the function is composable in user code and unit-testable.
+4. Reduce arg surface: if two args are always paired, fold one into the other (or store the dependency on the producing class so the consumer takes one arg, not two).
+5. Add a tiny test that asserts shape: `assert isinstance(out, Figure)`, `assert len(out.axes) == expected`.
+
+## Memory-heavy retainers
+
+`InferenceData` is large. Any class that retains it by default imposes a hidden cost. Default to summary-only with an opt-in (`store_X=True`) for users who want to inspect.
+
+## Backwards compatibility
+
+`AGENTS.md`: maintain compatibility for previously-released APIs only; APIs introduced in the same PR can be reshaped freely. So new public APIs (added in the PR being reviewed) are legitimate review targets for "I'd rather it look like X" feedback; APIs that already shipped are not.

--- a/.github/skills/pr-review/reference/docs-patterns.md
+++ b/.github/skills/pr-review/reference/docs-patterns.md
@@ -1,0 +1,122 @@
+# CausalPy Docs Patterns
+
+Repo-specific conventions for notebooks (`docs/source/notebooks/`) and knowledgebase pages (`docs/source/knowledgebase/`). The mechanical rules (single H1, schema validation) are enforced by hooks; this file is for the judgement-heavy patterns a hook can't catch.
+
+## Notebook structure
+
+### Single H1 — title only
+
+Every notebook must have exactly one `# ` markdown heading (the page title). All other section headings are `##` or below. (Mechanical check planned, see issue #863.) During review:
+
+- If you see multiple `#` headings, that's a hook job — but flag it on the PR if the hook hasn't landed yet.
+- If you see no `#` heading at all, the notebook will render with the filename as title, which is usually wrong.
+
+### `toctree` placement
+
+A new notebook in `docs/source/notebooks/` must be referenced from somewhere — typically `docs/source/notebooks/index.md`. Cross-link from related prose pages (e.g. `sensitivity_checks.md`) where applicable.
+
+Section assignment is a curation question:
+
+- ITS examples → `Interrupted Time Series` toctree.
+- DiD examples → `Difference in Differences`.
+- New method introduction → its own toctree section.
+- Workflow / cross-cutting → `Workflow` section.
+
+If the placement isn't obvious, ask the contributor to confirm rather than guessing.
+
+## Notebook content
+
+### Pedagogical structure
+
+Good notebooks have a recognisable arc: problem → method → data → analysis → interpretation → caveats. Reviews should call out when the arc is missing or scrambled.
+
+When evaluating pedagogy, useful prompts:
+
+- Can a reader who knows causal inference but not CausalPy follow it?
+- Is the *causal question* stated before the method is introduced?
+- Are caveats and assumptions called out, not buried?
+- Does the conclusion answer the question posed at the top?
+
+### Cell tags
+
+Two tags matter for readability:
+
+- **`hide-input`** on plotting cells — collapses the matplotlib boilerplate so the rendered docs show the plot output prominently.
+- **`hide-output`** on cells with verbose output (sampler progress, large tables, debug prints) — collapses the noise while keeping the cell runnable.
+
+Review prompt: any cell that produces ≥10 lines of sampler/progress output without `hide-output` is a candidate for the tag.
+
+### Sampler warnings
+
+Visible sampler warnings (divergences, low ESS, R̂ > 1.01) in a docs notebook are confusing for readers. Two fixes:
+
+1. Tune the sampler config (more chains, more tuning steps) to make the warnings go away genuinely.
+2. Hide them under `hide-output` if the warnings aren't a core part of the narrative.
+
+(1) is preferred when feasible. (2) is acceptable when the analysis is fundamentally about a borderline case.
+
+### External data
+
+Notebooks should prefer bundled CausalPy example datasets (loaded via `cp.load_data(...)`) over runtime fetches from external URLs. If an external fetch is unavoidable, document it with a comment so readers know what they're depending on.
+
+## MyST and cross-references
+
+### Glossary linking
+
+`AGENTS.md`: link to glossary terms (defined in `glossary.rst`) on first mention in a file.
+
+- Markdown / `.ipynb`: `` {term}`glossary term` ``
+- RST: `` :term:`glossary term` ``
+
+If a notebook introduces concepts like "treatment effect", "potential outcomes", "propensity score", etc., the first mention should be a glossary link. Subsequent mentions don't need to link.
+
+### Cross-references
+
+In Markdown, use MyST role syntax:
+
+- `` {doc}`path/to/doc` `` — link to another docs page.
+- `` {ref}`label-name` `` — link to a labelled section.
+
+Don't use raw markdown links (`[text](path/to/doc.md)`) for cross-doc references — MyST roles get full Sphinx resolution and break-link detection.
+
+### Admonitions
+
+Use MyST `:::{note}`, `:::{warning}`, `:::{important}` for callouts. Plain bold/italic emphasis is not the same — admonitions render as styled boxes.
+
+### Citations
+
+Citations live in `docs/source/references.bib`. Cite sources in example notebooks where possible. Include a reference section at the bottom of notebooks using:
+
+```markdown
+:::{bibliography}
+:filter: docname in docnames
+:::
+```
+
+If a new notebook has prose claims like "as shown in Smith et al. (2020)" without a corresponding `references.bib` entry and `:::{bibliography}` block, flag it.
+
+## Naming and organisation
+
+### Notebook filenames
+
+Pattern: `{method}_{model}.ipynb`.
+
+- `did_pymc.ipynb`, `rd_skl.ipynb`, `iv_pymc.ipynb`, `sc_pymc_brexit.ipynb`.
+- Composite topics: keep the prefix scheme so `:glob:` patterns would still work even though no section uses one today.
+
+### File placement
+
+- How-to examples → `docs/source/notebooks/`.
+- Educational / conceptual content → `docs/source/knowledgebase/`.
+- Scratch / temporary → `.scratch/` (untracked).
+
+A notebook that's mostly explaining a concept (rather than demonstrating CausalPy usage) probably belongs in `knowledgebase/`, not `notebooks/`.
+
+## API docs
+
+Auto-generated from docstrings via Sphinx autodoc. No manual API docs to write — but the docstrings themselves matter:
+
+- NumPy-style sections (`Parameters`, `Returns`, `Examples`).
+- `Examples` blocks should be runnable doctests where feasible (`make doctest` in CI).
+
+If a new public function has no `Examples` block, that's a should-fix, not a nit, because the API docs page will be terse.

--- a/.github/skills/pr-review/reference/docs-patterns.md
+++ b/.github/skills/pr-review/reference/docs-patterns.md
@@ -1,15 +1,8 @@
 # CausalPy Docs Patterns
 
-Repo-specific conventions for notebooks (`docs/source/notebooks/`) and knowledgebase pages (`docs/source/knowledgebase/`). The mechanical rules (single H1, schema validation) are enforced by hooks; this file is for the judgement-heavy patterns a hook can't catch.
+Repo-specific conventions for notebooks (`docs/source/notebooks/`) and knowledgebase pages (`docs/source/knowledgebase/`). Mechanical rules are enforced by `prek` / CI hooks; this file is for the judgement-heavy patterns a hook can't catch.
 
 ## Notebook structure
-
-### Single H1 — title only
-
-Every notebook must have exactly one `# ` markdown heading (the page title). All other section headings are `##` or below. (Mechanical check planned, see issue #863.) During review:
-
-- If you see multiple `#` headings, that's a hook job — but flag it on the PR if the hook hasn't landed yet.
-- If you see no `#` heading at all, the notebook will render with the filename as title, which is usually wrong.
 
 ### `toctree` placement
 

--- a/.github/skills/pr-review/reference/how-to-extend.md
+++ b/.github/skills/pr-review/reference/how-to-extend.md
@@ -1,0 +1,91 @@
+# How to Extend This Skill
+
+This skill should grow with the codebase. New patterns get added when they recur; old patterns get pruned when they get formalised into hooks.
+
+## When to add a new pattern
+
+Add a pattern when **either** is true:
+
+- You've seen the same shape of issue in **two or more PRs** (it's not a one-off).
+- The pattern is specific enough to CausalPy that a generic reviewer wouldn't catch it (it's not common-knowledge linting).
+
+Don't add a pattern just because it came up once. The risk of skill bloat is real — a 200-line checklist is worse than a 50-line one because agents start cherry-picking.
+
+## Where to add it
+
+Choose the smallest scope that fits:
+
+| Pattern type | Where to add |
+|---|---|
+| Severity-sorted "look for X" | [what-to-look-for.md](what-to-look-for.md) under the right severity heading |
+| CausalPy source-code convention | [code-patterns.md](code-patterns.md) |
+| Notebook / docs convention | [docs-patterns.md](docs-patterns.md) |
+| Comment-shape template | [posting-comments.md](posting-comments.md) |
+| Workflow / process change | [workflow.md](workflow.md) |
+
+If a new pattern doesn't fit any existing file, that's a signal the skill is growing a new dimension and may need a new reference file. Don't force-fit.
+
+## Required structure for a new pattern
+
+Each pattern needs all four:
+
+1. **A short ID** (e.g. `MF-1`, `SF-3`, `N-7`) for cross-referencing.
+2. **A one-line title** that says what the pattern is.
+3. **A canonical example**: a real PR (e.g. "PR #826") and a specific instance, so future readers can ground the abstraction in a concrete case.
+4. **A "how to spot" prompt**: what does the agent actually look at to decide if this pattern is present? Vague patterns produce vague flags.
+
+Template:
+
+```markdown
+### <ID>: <One-line title>
+
+<2–4 sentences explaining what the pattern is and why it matters.>
+
+- **Canonical example**: <PR ref + specific instance>.
+- **How to spot**: <concrete diagnostic prompt>.
+- <Optional: links to related patterns or code-patterns.md sections>.
+```
+
+## When to prune
+
+Prune a pattern when:
+
+- A hook or CI check now enforces it mechanically. The agent shouldn't waste attention on what tooling already catches.
+- The pattern hasn't recurred in 12 months and the originating context has changed.
+- A new pattern subsumes it. Merge the two; don't leave both.
+
+Pruning is part of maintenance, not vandalism. The skill is more useful at 200 well-curated lines than 600 stale ones.
+
+## When to formalise into a hook
+
+If a pattern in `what-to-look-for.md` has a **mechanical answer** — same input always produces the same correct verdict — it should probably become a hook, not stay an agent task.
+
+Mechanical patterns from past reviews that were (or should be) formalised:
+
+- **Single H1 per notebook** → issue #863 (pre-commit hook).
+- **Notebook orphaned from `toctree`** → under discussion.
+- **Constrained string param not `Literal`** → potential Ruff/mypy rule (deferred).
+
+When you formalise a pattern, **remove it from this skill** at the same time. Don't leave both — divergence is worse than either alone.
+
+## Six-monthly review
+
+On a recurring cadence (every six months or after every ~10 PRs reviewed), do a quick pass:
+
+1. Are any patterns stale or unused?
+2. Are any patterns now hook-enforced and need pruning?
+3. Have new patterns recurred enough to add?
+4. Is `SKILL.md` still under 500 lines / 5000 tokens?
+
+If yes to any of (1) (2) (3), update accordingly. If no to (4), refactor — split a reference file, move detail out of `SKILL.md`.
+
+## Worked example: how this skill itself was created
+
+Initial creation drew on PR #826 review feedback as the canonical seed:
+
+- 2 must-fix items → MF-1 (`_clone()` priors), MF-2 (`Literal` for constrained strings).
+- 6 should-fix items → SF-1 through SF-6.
+- 7 nits → N-1 through N-7 (a few omitted as too one-off).
+- 3 process patterns → P-1 (mega payload), P-2 (superseded commits), P-3 (orphan notebook).
+
+Each pattern was checked against the four-element template (ID, title, example, how-to-spot) before inclusion. Patterns that were just "a single judgement call" without a recognisable shape were kept out — they're the kind of thing agents naturally do well anyway and don't benefit from a checklist entry.

--- a/.github/skills/pr-review/reference/how-to-extend.md
+++ b/.github/skills/pr-review/reference/how-to-extend.md
@@ -62,7 +62,7 @@ If a pattern in `what-to-look-for.md` has a **mechanical answer** — same input
 
 Mechanical patterns from past reviews that were (or should be) formalised:
 
-- **Single H1 per notebook** → issue #863 (pre-commit hook).
+- **Single H1 per notebook** → issue #863, formalised in #866 (`validate-notebooks` pre-commit hook); pattern pruned from `docs-patterns.md` at the same time.
 - **Notebook orphaned from `toctree`** → under discussion.
 - **Constrained string param not `Literal`** → potential Ruff/mypy rule (deferred).
 

--- a/.github/skills/pr-review/reference/posting-comments.md
+++ b/.github/skills/pr-review/reference/posting-comments.md
@@ -1,0 +1,180 @@
+# Posting Review Comments
+
+How to draft, present, and post review comments. Two non-negotiable rules:
+
+1. **Never post without explicit human approval.** Always draft first, present in chat, wait.
+2. **Cite specific code locations.** Use `line:line:filepath` references when calling out code, not vague paraphrases.
+
+## Comment shapes
+
+### Issue-thread comment (general PR conversation)
+
+For multi-item review summaries, scope/process feedback, or replies to other comments. Posted via `gh pr comment`.
+
+```bash
+gh pr comment <num> --body "$(cat <<'EOF'
+<text>
+EOF
+)"
+```
+
+### Inline review comment (line-anchored)
+
+For specific code-level suggestions tied to a line range. Posted via `gh api repos/:owner/:repo/pulls/<num>/comments` with JSON body.
+
+Use inline comments for:
+
+- Suggestions that point at a specific line.
+- Bug call-outs where the location is the whole point.
+
+Use issue-thread comments for:
+
+- Multi-section review summaries.
+- Replies to other comments.
+- Process / scope feedback.
+- Status updates ("rebase looks clean", "verified all feedback addressed").
+
+### Formal review (`gh pr review`)
+
+For `APPROVE`, `REQUEST_CHANGES`, or `COMMENT` events. **Never** use `--approve` or `--request-changes` without explicit user instruction. `--comment` is fine for grouping multiple inline comments under a single review.
+
+## Templates
+
+### Multi-item review summary
+
+```markdown
+Thanks for the PR! [One sentence positive framing if warranted.]
+
+I have comments grouped by severity below.
+
+---
+
+## Must-fix
+
+### 1. [Concise title] (`path/to/file.py`)
+
+[2–4 sentence description. Include why it's a problem, not just what.]
+
+### 2. [Concise title] (`path/to/file.py`)
+
+[Description]
+
+---
+
+## Should-fix
+
+### 3. [Concise title]
+
+[Description, optionally with a code reference:]
+
+` ` `123:128:path/to/file.py
+def foo():
+    return self.x
+` ` `
+
+---
+
+## Nits
+
+### 4. [Concise title]
+
+[Description]
+
+---
+
+## Things I liked
+
+- [Specific positive — generic praise is unhelpful]
+- [Another specific positive]
+```
+
+The "Things I liked" section is not optional. Reviews that only criticise lose signal and demoralise. Find at least 2 specific things to call out, even on PRs with serious issues.
+
+### Status update on a contributor's response
+
+```markdown
+Thanks @<contributor> — confirmed [the rebase / the fix / etc.] (PR is now <state>, [verification details]).
+
+I've gone through round-1 and round-2 review items against the current branch and the code is basically in good shape. Everything is addressed, with tests for the substantive changes ([list 2-3 specifics]). Docs items are also done: [specifics].
+
+One judgement call worth flagging:
+
+- [Item still in question]: [their decision] vs. [your original ask]. [Ask for confirmation that the current shape is intentional.]
+
+[Optional: anything correctly deferred to follow-up]
+
+I'll do a manual pass over [the notebook / the API surface] before approving, but everything is looking good so far.
+```
+
+### Inline code-shape suggestion
+
+```markdown
+## Suggestion: [concise title]
+
+[Brief context — what does the code do today, and why is the suggestion worth considering?]
+
+### Why it [belongs in / should change]
+
+[Substantive reasoning, with bullet points if there are several supporting facts.]
+
+### Suggested shape
+
+[Concrete proposal, often with two options:]
+
+1. **[Option A]** — [description]
+2. **[Option B]** — [description]
+
+I'd lean toward **(1) [or whichever]** because [reason].
+
+### Cleanups before [doing the change]
+
+- [Specific cleanup 1]
+- [Specific cleanup 2]
+
+### Scope
+
+[Make explicit whether this is in-scope for the current PR or a follow-up. Defaulting to "happy for follow-up PR" reduces friction unless the change is small.]
+```
+
+### Correction
+
+If you posted something incorrect, post a follow-up correction promptly. Don't try to edit silently.
+
+```markdown
+Correction to my previous comment: [the wrong claim] was wrong because [what tripped you up]. [The correct statement.] [Anything that does still hold from the previous comment.]
+```
+
+## Tone calibration
+
+For each draft, offer the user 2–3 framing variants so they pick:
+
+1. **As-written** — the default tone you drafted.
+2. **Stricter** — convert a soft ask to a block, or flip a default to required.
+3. **Looser** — accept the contributor's choice with a note, defer the change to a follow-up issue.
+
+Example presentation in chat:
+
+> Three framing options:
+> 1. As-written — single soft question, otherwise approval-pending.
+> 2. Stricter — request the default flip in this PR (saves a deprecation cycle later).
+> 3. Looser — accept everything as-is and approve, file a follow-up issue.
+
+## Attribution
+
+If past comments on the PR have used a reviewer-bot identity (e.g. `claude-opus-4-7-xhigh`), preserve that voice when posting agent-authored comments. The human reviewer's voice and the agent's voice should be distinguishable in the thread.
+
+When in doubt, use a header like:
+
+```markdown
+`<model-slug>` here. [Bot disclaimer / scope.]
+```
+
+## After posting
+
+Always return the URL to the user:
+
+```bash
+# gh pr comment / gh api comment will print the URL on success
+```
+
+Echo it back: `Posted: [#826 (comment)](URL).`

--- a/.github/skills/pr-review/reference/what-to-look-for.md
+++ b/.github/skills/pr-review/reference/what-to-look-for.md
@@ -1,0 +1,147 @@
+# What to Look For
+
+Severity-sorted patterns. This is the diagnostic checklist — walk it explicitly during step 3 of the workflow.
+
+The patterns below are organised by severity, then by recurring **shape**. Each shape has a short rationale and a concrete example drawn from past reviews where possible. When a pattern requires deep CausalPy knowledge, it's been split into [code-patterns.md](code-patterns.md) (Python source) or [docs-patterns.md](docs-patterns.md) (notebooks + docs).
+
+## Must-fix patterns
+
+These are bugs or contract violations. Posting as `must-fix` should mean "I will block approval until this is addressed."
+
+### MF-1: Subclass override drops base-class behaviour
+
+A subclass overrides a method but doesn't forward all the kwargs the base class forwards.
+
+- **Canonical example**: `BayesianBasisExpansionTimeSeries._clone()` and `StateSpaceTimeSeries._clone()` in PR #826 omitted `priors=self._user_priors`. Consequence: user priors silently dropped on clone.
+- **How to spot**: when a diff adds a method override, read the base-class version side-by-side. Diff their kwargs.
+- See [code-patterns.md § _clone() pattern](code-patterns.md#clone-pattern) for the canonical CausalPy `_clone()` shape.
+
+### MF-2: Constrained string parameter not typed as `Literal`
+
+`AGENTS.md` is explicit: "use `Literal` for constrained string parameters."
+
+- **Canonical example**: `selection_method: str` accepting `"sequential"` or `"random"` should be `Literal["sequential", "random"]`.
+- **How to spot**: any new function/method parameter with a type of `str` whose docstring or implementation enumerates a fixed set of accepted values.
+- This is also a candidate for a Ruff/mypy custom rule eventually — file an issue if the same instance appears across multiple PRs.
+
+### MF-3: Behavioural change to existing function with no test that pins the new behaviour
+
+Common after bug fixes. The fix changes math/logic, but the only tests are pre-existing tests that happen to still pass — they don't *require* the new behaviour.
+
+- **Canonical example**: PR #826 changed the assurance simulation formula. Round-1 review flagged the missing test; round-2 confirmed two new tests now pin the corrected math.
+- **How to spot**: look for diff hunks that change a constant, formula, or branch condition in non-test code with no corresponding new assertion in tests.
+- The verification ask is specific: a test that would fail under the old code and pass under the new.
+
+### MF-4: New public API not consistent with sibling implementations
+
+If `BaseExperiment` subclasses all expose `supports_ols` and `supports_bayes`, a new subclass missing them is a bug. Same for `PyMCModel` subclasses, `CheckResult`-producing checks, etc.
+
+- See [code-patterns.md § BaseExperiment contract](code-patterns.md#baseexperiment-contract) and [§ PyMCModel contract](code-patterns.md#pymcmodel-contract).
+
+## Should-fix patterns
+
+Design judgement, not bugs. Block on these only if the contributor pushes back without good reason.
+
+### SF-1: Default value of a memory-heavy retainer is "on"
+
+Result/check classes that retain the full fitted model (including `InferenceData`) by default impose a hidden cost on every user, even those who only need summary stats.
+
+- **Canonical example**: PR #826 `FalsificationResult` retains the full `BaseExperiment`. Should default to summary-only with `store_experiments=True` as opt-in.
+- **How to spot**: any new dataclass/class with a field that holds a fitted experiment, posterior, or large array, instantiated by default during `run()`/`fit()`.
+- If the contributor pushes back: ask whether common-case users will pay for the inspection feature they don't use.
+
+### SF-2: Bare `except Exception` (or `except:`) in library code
+
+Hides unexpected bugs as well as expected failures. Acceptable when the goal is "best effort and log everything", but the contributor should be explicit.
+
+- **Canonical example**: `outcome_falsification.py` `run()` loop catches `Exception` to keep going on individual formula failures. A targeted tuple `(ValueError, PatsyError, RuntimeError)` would still keep the loop going while letting unexpected `AttributeError`s surface.
+- This is partly enforceable by Ruff `BLE001` — if the rule isn't enabled and the same pattern keeps appearing, file an issue to enable it with allowlist.
+
+### SF-3: Docstring describes one quantity, code/test asserts another
+
+Subtle bug-source. The docstring becomes the spec; if it's wrong, future contributors will write code matching the wrong spec.
+
+- **Canonical example**: PR #826 `min_gap` docstring described "candidate-list distance" but the test asserted "actual time distance". These are different. Either the docstring or the test is wrong.
+- **How to spot**: read the docstring of any new parameter, then read the test that exercises it. Confirm they describe the same quantity.
+
+### SF-4: Default value is silently a no-op
+
+A default that doesn't actually constrain anything is misleading. Either the default should impose a useful constraint, or the docstring should be honest about the no-op.
+
+- **Canonical example**: `min_gap=1` with sampling-without-replacement is trivially true for any two distinct integer positions. Either change the default to `intervention_length` or document the no-op.
+- **How to spot**: read default values; ask "what does this default actually do?" If the answer is "nothing", flag.
+
+### SF-5: Algorithmic invariant not enforced where the rest of the code assumes it
+
+When downstream code assumes invariant X (independence, non-overlap, sortedness) but upstream selection doesn't enforce X, X gets violated silently.
+
+- **Canonical example**: `PlaceboInTime` random folds didn't enforce non-overlap of pseudo-windows; downstream hierarchical model assumes folds are exchangeable. Need either an `allow_overlap=False` default or an explicit docstring warning.
+- **How to spot**: read the assumptions of downstream consumers, then read the upstream selector. Mismatch = flag.
+
+### SF-6: Function ignores a parameter for a subset of input types
+
+Polymorphic input handling that silently drops requested behaviour for one branch.
+
+- **Canonical example**: `_draw_expected_effect_samples(n)` returned the user's numpy array verbatim, ignoring `n` entirely. Downstream code cycled with `i % len(prior)`, masking the silent drop.
+- **How to spot**: any function that takes both a "size" parameter and a polymorphic input. Read each branch and confirm `n` is honoured (or explicitly documented as a no-op for that branch).
+
+## Nits
+
+Cosmetic / quality-of-life. Cluster these at the end of a review so they don't dilute attention from the must-fix items.
+
+### N-1: `__repr__` shows defaults
+
+`__repr__` should show non-default values only, mirroring `dataclass`-style brevity. If a sibling class in the same module already does this, inconsistency is the flag.
+
+### N-2: Defensive code that doesn't actually defend
+
+`except (KeyError, IndexError, np.linalg.LinAlgError)` where `LinAlgError` is never actually raised by the code under the try block. Harmless but adds noise.
+
+- **How to spot**: for each exception in a multi-exception except clause, ask "what code path raises this?" If unclear, drop it.
+
+### N-3: Test uses an unrealistic failure mode
+
+Tests should exercise the failure modes users will actually hit, not synthetic ones. A test that uses a syntactically-invalid formula instead of a missing-column formula is testing the wrong thing.
+
+### N-4: Docstring missing a non-obvious behaviour note
+
+Behaviour that isn't bug-level but isn't intuitive — e.g. "this default halves the eligible window when X is unset." A one-line docstring note prevents future surprise.
+
+### N-5: External data dependency in docs notebook
+
+Notebook fetches from `https://...` at runtime. Brittle to URL changes / outages. Either bundle as a CausalPy example dataset or add a note.
+
+### N-6: Test setup duplication ≥ 60 lines across ≥ 3 tests
+
+A pytest fixture would consolidate. Not a bug, but an ongoing maintenance tax.
+
+### N-7: Helper used N times in a notebook is library material
+
+If a docs notebook defines a non-trivial helper (≥50 lines) and uses it ≥3 times, the helper is general, not example-specific. Suggest promotion to the library — usually as a follow-up PR rather than expanding the current one.
+
+- **Canonical example**: `plot_placebo_calibration` in PR #826's notebook (~130 lines, called 3x). Inline review left the suggestion with a "happy for follow-up PR" disposition.
+- See [code-patterns.md § Helper promotion](code-patterns.md#helper-promotion) for the cleanup checklist before promoting.
+
+## Process patterns
+
+Not code-level, but worth flagging on the PR.
+
+### P-1: Mega-payload PR
+
+Multiple logically-independent themes in one PR (interrogate config + new model `_clone()` + new check + plot bug fix). Slows review and complicates revert.
+
+- **How to handle**: don't block on this for the current PR (sunk cost), but flag it once for future PRs.
+- **Canonical example**: PR #826 issue-thread comment.
+
+### P-2: Branch contains commits superseded by recently-merged work on `main`
+
+Contributor's branch has commits that overlap with — and are slightly worse than — a fix that just landed on `main`. Need to identify the colliding commits, recommend rebase + drop, and confirm the canonical fix is picked up.
+
+- **Canonical example**: PR #826 had two `panel_regression.py` commits superseded by #853.
+- **How to spot**: when a PR is in `CONFLICTING` state, scan its file list against the most recent N commits to `main` for overlap.
+
+### P-3: Notebook orphaned from `toctree`
+
+A new notebook in `docs/source/notebooks/` not referenced anywhere in the docs tree. Sphinx renders it but there's no path for users to reach it.
+
+- This is a hook candidate (under discussion); until the hook lands, look for it manually on every PR that adds a notebook.

--- a/.github/skills/pr-review/reference/workflow.md
+++ b/.github/skills/pr-review/reference/workflow.md
@@ -1,0 +1,101 @@
+# PR Review Workflow
+
+Six steps. Steps 1–4 are read-only context-gathering and analysis. Step 5 is drafting. Step 6 only happens with explicit human approval.
+
+## Step 1 — Establish full context
+
+Run these in parallel where possible:
+
+```bash
+# PR metadata
+gh pr view <num> --json title,url,state,author,number,mergeable,mergeStateStatus,headRefName,baseRefName,commits,files
+
+# All commits
+gh api repos/:owner/:repo/pulls/<num>/commits --paginate --jq '.[] | {sha: .sha[0:8], msg: .commit.message | split("\n")[0]}'
+
+# All formal reviews (CHANGES_REQUESTED, COMMENTED, APPROVED)
+gh api repos/:owner/:repo/pulls/<num>/reviews --jq '.[] | {user: .user.login, state, submitted_at, body}'
+
+# All inline review comments (line-anchored)
+gh api repos/:owner/:repo/pulls/<num>/comments --paginate
+
+# All issue-thread comments (general PR conversation)
+gh api repos/:owner/:repo/issues/<num>/comments --paginate
+
+# Files changed
+gh pr diff <num> --name-only
+```
+
+If the user has already provided partial context (e.g. "check the last comment"), narrow the fetch — don't re-pull everything.
+
+## Step 2 — Read the relevant subset
+
+Read every file in the diff. For each, also pull surrounding context:
+
+- Subclass added → read the base class.
+- New test → read sibling tests in the same file.
+- New experiment class → read `BaseExperiment` and at least one existing experiment.
+- New check → read `causalpy/checks/base.py` and an existing check.
+- Notebook added → read at least one sibling notebook in the same docs section.
+
+This is what catches "this `_clone()` doesn't forward `priors=self._user_priors` like the base class does" — you can't notice the omission without reading the base class.
+
+## Step 3 — Pass over the diff
+
+Walk the patterns checklist in [what-to-look-for.md](what-to-look-for.md) explicitly. Don't trust unaided memory; the checklist exists because reviews otherwise drift toward whatever's most recently in mind.
+
+Group findings by severity:
+
+- **Must-fix** — bugs, contract violations, dropped behaviour, missing required forwarding (e.g. base-class kwargs).
+- **Should-fix** — design judgement (default values, API ergonomics, memory footprint), missing tests for behavioural changes, broad except clauses.
+- **Nits** — style, docstring polish, naming, defensive code that isn't actually defending anything.
+- **Things you liked** — actually include this. Reviews that only criticise are demoralising and lose signal.
+
+## Step 4 — Verify claims
+
+If the contributor (or a previous review iteration) claimed something is done, verify against current code. Common claim shapes and their tests:
+
+| Claim | Verification |
+|---|---|
+| "Rebased onto main" | `git log --oneline base..head` shows merge commits / no problematic commits |
+| "Addressed all feedback" | Walk each review item against current files |
+| "Tests added for the new behaviour" | Read the test, confirm it would fail without the fix |
+| "Fixed the conflict" | `gh pr view --json mergeable` shows `MERGEABLE` |
+| "PR is small" | `gh pr view --json files` line-count |
+
+Any claim that turns out to be wrong should be flagged respectfully but specifically — vague disagreement is unhelpful.
+
+## Step 5 — Draft comments for human review
+
+Never post directly. Always:
+
+1. Lay out findings in chat for the user.
+2. Show the draft comment text in a code block.
+3. Offer 2–3 framing variants (stricter, softer, approval-pending) so the user picks the tone.
+4. Wait for explicit approval.
+
+See [posting-comments.md](posting-comments.md) for full templates.
+
+## Step 6 — Post on approval
+
+Only after the user explicitly approves:
+
+```bash
+gh pr comment <num> --body "$(cat <<'EOF'
+<text>
+EOF
+)"
+```
+
+For inline review comments anchored to a line, use `gh api repos/:owner/:repo/pulls/<num>/comments` with the appropriate JSON body. For a formal review (with `event: COMMENT`/`APPROVE`/`REQUEST_CHANGES`), use `gh pr review` — but never `--approve` or `--request-changes` without an explicit user instruction.
+
+After posting, return the URL.
+
+## Loops and follow-up
+
+If the review surfaces:
+
+- **A formalisable pattern** (could be a hook) → file a follow-up issue via [`github-issues`](../../github-issues/SKILL.md).
+- **A code-level fix the contributor should make** → leave a PR comment with the fix sketched.
+- **A scope concern** (PR too big, mixes themes) → flag in the review summary and reference past examples (`#826` "mega payload" comment is the canonical example here).
+- **A merge blocker** (conflicts with a recently-merged PR) → identify the colliding commits and propose the rebase.


### PR DESCRIPTION
## Summary

Adds `.github/skills/pr-review/` — a new agent skill capturing the review patterns distilled from the #826 review iteration into a reusable form.

Structure:

- `SKILL.md` (orchestrator, ~75 lines, well under the spec's 500-line / 5000-token recommendation)
- `reference/workflow.md` — the 6-step review workflow with concrete `gh` commands and a claim-verification table
- `reference/what-to-look-for.md` — severity-sorted patterns (4 must-fix, 6 should-fix, 7 nits, 3 process), each with a canonical example from #826 and a "how to spot" diagnostic
- `reference/code-patterns.md` — CausalPy source-code conventions (`BaseExperiment`, `PyMCModel`, `_clone()`, `__repr__`, custom exceptions, type hints, helper-promotion checklist)
- `reference/docs-patterns.md` — notebook + docs conventions (single-H1, hide-input/hide-output, sampler warnings, glossary linking, MyST roles, citations, file placement)
- `reference/posting-comments.md` — comment templates (multi-item summary, status update, inline suggestion, correction), tone-calibration with 3-variant offering, attribution rules
- `reference/how-to-extend.md` — when to add patterns (recur 2+ times), when to prune (formalised into hooks), required structure for new entries, six-monthly review cadence

## Design choices worth flagging

- **Doesn't duplicate `pr-to-green` or `pr-workflows`** — explicitly delegates fix-PR work to the former and create-PR work to the latter. New skill is read-and-diagnose only.
- **Hard rule: never post review comments without explicit human approval.** Repeated in `SKILL.md` and `posting-comments.md`. Same for never auto-approving via `gh pr review --approve`.
- **Patterns grounded in real #826 review items** rather than speculative checklists — keeps the skill from drifting into wish-list territory. `how-to-extend.md` documents the 4-element template (ID, title, canonical example, how-to-spot) and the rule that anything formalised into a hook must be removed from the skill at the same time.
- **Followed local convention `reference/` (singular)** matching the existing `github-issues/` and `pr-workflows/` skills, even though the spec at https://agentskills.io/specification suggests `references/`.
- **Frontmatter is minimal** — just `name` and `description` — matching local convention.

## Test plan

- [ ] `prek run --all-files` passes (skill files are markdown, picked up by trailing-whitespace / EOF / codespell hooks).
- [ ] Manual smoke: load the skill on a follow-up review (e.g. an in-flight CausalPy PR) and verify the workflow + look-fors fire correctly.
- [ ] Verify no broken intra-skill links (every reference between SKILL.md and the six reference/*.md files resolves).

## Out of scope

- Single-H1 hook for docs notebooks (#863) — was bundled into a now-closed PR (#864) by mistake; will follow as its own PR from `issue-863-single-h1-check`.
- Pre-commit / CI check for orphan notebooks — discussed separately, no issue filed yet.

## Related

- Builds on review experience from #826
- Closed predecessor: #864 (bundled this with #863 by accident)

Made with [Cursor](https://cursor.com)