### PR TITLE
ci: pin pyproject2conda==0.22.1 to work around 0.23.0 regression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,12 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pyproject2conda
-        run: pip install pyproject2conda
+        # Pinned to match the local prek hook rev (v0.22.1). pyproject2conda
+        # 0.23.0 (released 2026-04-29) regressed with
+        # `AttributeError: 'CondaRequirement' object has no attribute 'channel'`.
+        # Bump in lockstep with the .pre-commit-config.yaml rev once a fixed
+        # release is available.
+        run: pip install "pyproject2conda==0.22.1"
       - name: Regenerate environment.yml (same args as local prek hook config)
         run: |
           pyproject2conda yaml -e dev -o /tmp/environment.generated.yml -n CausalPy \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,12 +49,15 @@ jobs:
         with:
           python-version: "3.12"
       - name: Install pyproject2conda
-        # Pinned to match the local prek hook rev (v0.22.1). pyproject2conda
-        # 0.23.0 (released 2026-04-29) regressed with
-        # `AttributeError: 'CondaRequirement' object has no attribute 'channel'`.
-        # Bump in lockstep with the .pre-commit-config.yaml rev once a fixed
-        # release is available.
-        run: pip install "pyproject2conda==0.22.1"
+        # Pinned to the 0.22.x line to match the local prek hook rev (v0.22.1).
+        # 0.23.0 introduced a regression:
+        # `AttributeError: 'CondaRequirement' object has no attribute 'channel'`
+        # raised from `_iter_parts` during `__hash__` of any conda requirement,
+        # so any invocation that processes conda deps fails immediately.
+        # The upper bound allows a hypothetical 0.22.x patch backport while
+        # excluding 0.23.x. Bump in lockstep with the .pre-commit-config.yaml
+        # rev once a fixed release is available.
+        run: pip install "pyproject2conda>=0.22.1,<0.23"
       - name: Regenerate environment.yml (same args as local prek hook config)
         run: |
           pyproject2conda yaml -e dev -o /tmp/environment.generated.yml -n CausalPy \


### PR DESCRIPTION
## Summary

The `check-environment-yml` CI job has been failing on every PR opened since **2026-04-29** with:

```
File ".../pyproject2conda/_normalized_requirements.py", line 115, in _iter_parts
    if self.channel:
       ^^^^^^^^^^^^
AttributeError: 'CondaRequirement' object has no attribute 'channel'
```

## Root cause

The job does `pip install pyproject2conda` with **no version constraint** ([ci.yml:51-52](https://github.com/pymc-labs/CausalPy/blob/main/.github/workflows/ci.yml#L51-L52)), so each CI run grabs whatever is latest on PyPI.

`pyproject2conda 0.23.0` was published to PyPI on 2026-04-29 and contains a regression where `CondaRequirement` instances no longer expose the `channel` attribute that `_iter_parts()` still tries to read. This is hit during `__hash__` of any conda requirement, so the tool blows up immediately when called with the args our workflow uses.

The local prek hook in `.pre-commit-config.yaml` is already pinned to `v0.22.1` (the last good release), so local `prek run --all-files` is unaffected — only CI breaks.

Filed upstream as [usnistgov/pyproject2conda#94](https://github.com/usnistgov/pyproject2conda/issues/94).

## Fix

Pin the CI `pip install` to `>=0.22.1,<0.23` so it tracks the same 0.22.x line as the local prek hook (`rev: v0.22.1`) while still allowing a hypothetical 0.22.x patch backport to ship without a workflow edit. Added an inline comment explaining the failure mode so future bumps remember to lift CI and the prek hook in lockstep.

## Why pin instead of work around?

The traceback lands in `CondaRequirement.__hash__` → `_iter_parts()`, which is invoked unconditionally as soon as `pyproject2conda` materialises any conda requirement. There is no plausible CLI flag, env extra, or `pyproject.toml` shape change that avoids that code path while still producing a usable conda yaml — the broken attribute access fires before any of our arguments matter. Pinning is therefore the right lever; alternative workarounds were not pursued because they cannot exist for this failure mode.

## Evidence this is environmental, not PR-specific

- PR #871 (`docs/789-sc-sensitivity-walkthrough`) has `check-environment-yml` failing despite touching only a single `.ipynb` file (no `pyproject.toml` or `environment.yml` changes).
- PR #872's last successful `check-environment-yml` run was on 2026-04-28 — it picked up `pyproject2conda 0.22.1` *before* 0.23.0 was published.
- All other open PRs that haven't been pushed to since 2026-04-29 still show the check as green.

## Test plan

- [ ] CI `check-environment-yml` job passes on this PR.
- [ ] After merge, rebase #871 onto main and confirm `check-environment-yml` goes green there too.

## Follow-up

When pyproject2conda ships a fixed release, bump both `.pre-commit-config.yaml` (`rev: v0.22.1` → newer) and `.github/workflows/ci.yml` (the version range → newer) together — or, preferably, merge #882 first so there is only one place to bump.

Tracked separately:

- Upstream regression report: [usnistgov/pyproject2conda#94](https://github.com/usnistgov/pyproject2conda/issues/94)
- Consolidating the CI invocation through the prek hook (removes the dual-pin surface): #879, implemented in #882
- Hardening the `tail -n +10` header comparison in this same job: #880
- Auditing pip-install steps in CI for consistent supply-chain pinning: #881