### PR TITLE
Standardise HDI_PROB usage across experiments and reporting

### DIFF
--- a/causalpy/constants.py
+++ b/causalpy/constants.py
@@ -15,5 +15,14 @@
 Shared constants for the CausalPy package.
 """
 
+#: Default probability mass for highest-density-interval (HDI) bands and
+#: summary intervals across CausalPy plots and reports. Matches the
+#: :func:`arviz.hdi` default of 0.94. Override on a per-call basis by passing
+#: ``hdi_prob`` to the relevant method (e.g.
+#: :meth:`causalpy.experiments.interrupted_time_series.InterruptedTimeSeries.analyze_persistence`),
+#: or globally for ``maketables`` rendering via
+#: :meth:`causalpy.experiments.base.BaseExperiment.set_maketables_options`.
 HDI_PROB: float = 0.94
+
+#: Default font size used in matplotlib legends across CausalPy plots.
 LEGEND_FONT_SIZE: int = 12

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -346,7 +346,14 @@ class BaseExperiment(ABC):
             - "decrease": P(effect < 0)
             - "two-sided": Two-sided p-value, report 1-p as "probability of effect"
         alpha : float, default=0.05
-            Significance level for HDI/CI intervals (1-alpha confidence level)
+            Significance level for HDI/CI intervals (1-alpha confidence level).
+            For Bayesian models the effective HDI probability is
+            ``hdi_prob = 1 - alpha``. Note that this is independent of the
+            project-wide :data:`causalpy.constants.HDI_PROB` constant
+            (default 0.94) used by ``plot()`` and ``get_plot_data_bayesian()``,
+            so the same experiment may report a 95% HDI in
+            ``effect_summary()`` and a 94% HDI in ``plot()`` with default
+            settings.
         cumulative : bool, default=True
             Whether to include cumulative effect statistics (ITS/SC only, ignored for DiD/RD)
         relative : bool, default=True

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -349,11 +349,11 @@ class BaseExperiment(ABC):
             Significance level for HDI/CI intervals (1-alpha confidence level).
             For Bayesian models the effective HDI probability is
             ``hdi_prob = 1 - alpha``. Note that this is independent of the
-            project-wide :data:`causalpy.constants.HDI_PROB` constant
-            (default 0.94) used by ``plot()`` and ``get_plot_data_bayesian()``,
-            so the same experiment may report a 95% HDI in
-            ``effect_summary()`` and a 94% HDI in ``plot()`` with default
-            settings.
+            project-wide :data:`~causalpy.constants.HDI_PROB` constant
+            (currently 0.94) used by :meth:`plot` and
+            :meth:`get_plot_data_bayesian`, so the same experiment may report
+            a 95% HDI in :meth:`effect_summary` and a 94% HDI in :meth:`plot`
+            with default settings.
         cumulative : bool, default=True
             Whether to include cumulative effect statistics (ITS/SC only, ignored for DiD/RD)
         relative : bool, default=True

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -1030,8 +1030,9 @@ class InterruptedTimeSeries(BaseExperiment):
 
         Parameters
         ----------
-        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
-            Probability for HDI interval (Bayesian models only)
+        hdi_prob : float
+            Probability for the HDI interval (Bayesian models only). Defaults
+            to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         direction : {"increase", "decrease", "two-sided"}, default="increase"
             Direction for tail probability calculation (Bayesian models only)
 

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -1015,7 +1015,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
     def analyze_persistence(
         self,
-        hdi_prob: float = 0.95,
+        hdi_prob: float = HDI_PROB,
         direction: Literal["increase", "decrease", "two-sided"] = "increase",
     ) -> dict[str, Any]:
         """Analyze effect persistence between intervention and post-intervention periods.
@@ -1030,7 +1030,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
         Parameters
         ----------
-        hdi_prob : float, default=0.95
+        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
             Probability for HDI interval (Bayesian models only)
         direction : {"increase", "decrease", "two-sided"}, default="increase"
             Direction for tail probability calculation (Bayesian models only)

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -27,14 +27,13 @@ from patsy import dmatrices
 from scipy import stats
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import round_num
 
 from .base import BaseExperiment
-
-LEGEND_FONT_SIZE = 12
 
 
 class PanelRegression(BaseExperiment):
@@ -501,7 +500,7 @@ class PanelRegression(BaseExperiment):
         return self._plot_coefficients_internal()
 
     def _plot_coefficients_internal(
-        self, var_names: list[str] | None = None, hdi_prob: float = 0.94
+        self, var_names: list[str] | None = None, hdi_prob: float = HDI_PROB
     ) -> tuple[plt.Figure, plt.Axes]:
         """Internal method to create coefficient plot.
 
@@ -510,7 +509,7 @@ class PanelRegression(BaseExperiment):
         var_names : list[str], optional
             Specific coefficient names to plot.  If ``None``, plots all
             non-FE coefficients (as determined by ``_get_non_fe_labels``).
-        hdi_prob : float, default=0.94
+        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
             Probability mass for the HDI interval when plotting Bayesian
             coefficients. Must be in (0, 1).
         """
@@ -606,7 +605,7 @@ class PanelRegression(BaseExperiment):
         return plot_data
 
     def plot_coefficients(
-        self, var_names: list[str] | None = None, hdi_prob: float = 0.94
+        self, var_names: list[str] | None = None, hdi_prob: float = HDI_PROB
     ) -> tuple[plt.Figure, plt.Axes]:
         """Plot coefficient estimates with credible/confidence intervals.
 
@@ -619,7 +618,7 @@ class PanelRegression(BaseExperiment):
             Specific coefficient names to plot.  Names must match the patsy
             design-matrix labels (e.g. ``"treatment"``, ``"x1"``).
             If ``None``, plots all non-FE coefficients.
-        hdi_prob : float, default=0.94
+        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
             Probability mass for the HDI interval when plotting Bayesian
             coefficients. Must be in (0, 1). Ignored for OLS models.
 
@@ -714,7 +713,7 @@ class PanelRegression(BaseExperiment):
         n_sample: int = 10,
         select: Literal["random", "extreme", "high_variance"] = "random",
         show_mean: bool = True,
-        hdi_prob: float = 0.94,
+        hdi_prob: float = HDI_PROB,
         interval_type: Literal["mean", "predictive"] = "mean",
     ) -> tuple[plt.Figure, np.ndarray]:
         """Plot unit-level time series trajectories.
@@ -735,9 +734,9 @@ class PanelRegression(BaseExperiment):
             - "high_variance": Units with most within-unit variation
         show_mean : bool, default=True
             Whether to show the overall mean trajectory.
-        hdi_prob : float, default=0.94
+        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
             Probability mass for the HDI credible interval (Bayesian models only).
-            Common values are 0.94 (default) or 0.89.
+            Common alternative values are 0.89 or 0.5.
         interval_type : {"mean", "predictive"}, default="mean"
             Which uncertainty interval to show for Bayesian models:
             - "mean": HDI of posterior ``mu`` (uncertainty in expected value)

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -509,9 +509,10 @@ class PanelRegression(BaseExperiment):
         var_names : list[str], optional
             Specific coefficient names to plot.  If ``None``, plots all
             non-FE coefficients (as determined by ``_get_non_fe_labels``).
-        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
+        hdi_prob : float
             Probability mass for the HDI interval when plotting Bayesian
-            coefficients. Must be in (0, 1).
+            coefficients. Must be in (0, 1). Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         """
         if not 0 < hdi_prob < 1:
             raise ValueError("hdi_prob must be between 0 and 1")
@@ -618,9 +619,10 @@ class PanelRegression(BaseExperiment):
             Specific coefficient names to plot.  Names must match the patsy
             design-matrix labels (e.g. ``"treatment"``, ``"x1"``).
             If ``None``, plots all non-FE coefficients.
-        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
+        hdi_prob : float
             Probability mass for the HDI interval when plotting Bayesian
             coefficients. Must be in (0, 1). Ignored for OLS models.
+            Defaults to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------
@@ -734,9 +736,10 @@ class PanelRegression(BaseExperiment):
             - "high_variance": Units with most within-unit variation
         show_mean : bool, default=True
             Whether to show the overall mean trajectory.
-        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
-            Probability mass for the HDI credible interval (Bayesian models only).
-            Common alternative values are 0.89 or 0.5.
+        hdi_prob : float
+            Probability mass for the HDI credible interval (Bayesian models
+            only). Defaults to :data:`~causalpy.constants.HDI_PROB`
+            (currently 0.94). Common alternative values are 0.89 or 0.5.
         interval_type : {"mean", "predictive"}, default="mean"
             Which uncertainty interval to show for Bayesian models:
             - "mean": HDI of posterior ``mu`` (uncertainty in expected value)

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -631,7 +631,7 @@ class PiecewiseITS(BaseExperiment):
 
         Parameters
         ----------
-        hdi_prob : float, default=0.94
+        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
             Probability for the highest density interval.
 
         Returns

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -631,8 +631,9 @@ class PiecewiseITS(BaseExperiment):
 
         Parameters
         ----------
-        hdi_prob : float, default=:data:`causalpy.constants.HDI_PROB` (0.94)
-            Probability for the highest density interval.
+        hdi_prob : float
+            Probability for the highest density interval. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------

--- a/causalpy/maketables_adapters.py
+++ b/causalpy/maketables_adapters.py
@@ -28,6 +28,7 @@ import pandas as pd
 import xarray as xr
 from sklearn.base import RegressorMixin
 
+from causalpy.constants import HDI_PROB
 from causalpy.pymc_models import PyMCModel
 
 
@@ -144,13 +145,13 @@ def _get_maketables_hdi_prob(experiment: Any) -> float:
     Priority:
     1) explicit user override via BaseExperiment.set_maketables_options()
     2) experiment-specific stored value (e.g. staggered_did hdi_prob_)
-    3) default 0.94 to align with CausalPy summary conventions
+    3) project-wide default :data:`causalpy.constants.HDI_PROB`
     """
     hdi_prob = getattr(experiment, "_maketables_hdi_prob", None)
     if hdi_prob is None:
-        hdi_prob = getattr(experiment, "hdi_prob_", 0.94)
+        hdi_prob = getattr(experiment, "hdi_prob_", HDI_PROB)
     if hdi_prob is None:
-        hdi_prob = 0.94
+        hdi_prob = HDI_PROB
 
     try:
         hdi_prob = float(hdi_prob)

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -32,6 +32,7 @@ import pandas as pd
 import xarray as xr
 from scipy.stats import t
 
+from causalpy.constants import HDI_PROB
 from causalpy.utils import _as_scalar
 
 
@@ -728,14 +729,22 @@ def _extract_counterfactual(result, window_coords, treated_unit=None):
 def _compute_statistics(
     impact,
     counterfactual,
-    hdi_prob=0.95,
+    hdi_prob=HDI_PROB,
     direction="increase",
     cumulative=True,
     relative=True,
     min_effect=None,
     time_dim="obs_ind",
 ):
-    """Compute all summary statistics from posterior draws."""
+    """Compute all summary statistics from posterior draws.
+
+    Notes
+    -----
+    All in-tree callers pass ``hdi_prob`` explicitly (typically derived from
+    ``effect_summary``'s ``alpha`` as ``hdi_prob = 1 - alpha``), so this
+    default is effectively unused; it is set to :data:`HDI_PROB` to keep the
+    project-wide convention consistent.
+    """
     stats = {}
 
     # Average effect over window

--- a/causalpy/tests/test_hdi_prob_defaults.py
+++ b/causalpy/tests/test_hdi_prob_defaults.py
@@ -1,0 +1,146 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Invariant tests pinning the project-wide ``HDI_PROB`` default across all
+public methods that accept an ``hdi_prob`` keyword argument.
+
+If a future change introduces a method that takes ``hdi_prob`` with a default
+that diverges from :data:`causalpy.constants.HDI_PROB`, these tests will fail
+and prompt the author to either align the default with the constant or
+deliberately update this invariant.
+"""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable, Iterable
+from typing import Any
+
+import pytest
+
+from causalpy.constants import HDI_PROB
+
+
+def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
+    """Yield ``(qualified_name, callable)`` for every public function/method
+    in ``causalpy`` whose signature has an ``hdi_prob`` parameter with a
+    non-empty default value.
+
+    Excluded:
+      * Private callables (any path component starting with ``_``).
+      * The ``causalpy.tests`` package.
+      * ``hdi_prob`` parameters with no default (kwarg-only required arg).
+      * ``hdi_prob`` parameters defaulted to ``None`` (sentinel for "no
+        override" semantics, e.g.
+        :meth:`BaseExperiment.set_maketables_options`).
+    """
+    import importlib
+    import pkgutil
+
+    import causalpy
+
+    seen: set[int] = set()
+
+    for module_info in pkgutil.walk_packages(
+        causalpy.__path__, prefix=f"{causalpy.__name__}."
+    ):
+        name = module_info.name
+        if name.startswith("causalpy.tests"):
+            continue
+        if any(part.startswith("_") for part in name.split(".")[1:]):
+            continue
+        try:
+            mod = importlib.import_module(name)
+        except Exception:
+            continue
+
+        for attr_name, attr in vars(mod).items():
+            if attr_name.startswith("_"):
+                continue
+            if not callable(attr):
+                continue
+            if id(attr) in seen:
+                continue
+            seen.add(id(attr))
+
+            attr_module = getattr(attr, "__module__", None)
+            if not isinstance(attr_module, str) or not attr_module.startswith(
+                "causalpy"
+            ):
+                continue
+            attr_qualname = getattr(attr, "__qualname__", None)
+            if not isinstance(attr_qualname, str):
+                continue
+
+            candidates: list[tuple[str, Callable[..., Any]]] = []
+            if inspect.isclass(attr):
+                for member_name, member in vars(attr).items():
+                    if member_name.startswith("_"):
+                        continue
+                    if not callable(member):
+                        continue
+                    candidates.append(
+                        (f"{attr_module}.{attr_qualname}.{member_name}", member)
+                    )
+            else:
+                candidates.append((f"{attr_module}.{attr_qualname}", attr))
+
+            for qualname, fn in candidates:
+                try:
+                    sig = inspect.signature(fn)
+                except (TypeError, ValueError):
+                    continue
+                param = sig.parameters.get("hdi_prob")
+                if param is None:
+                    continue
+                if param.default is inspect.Parameter.empty:
+                    continue
+                if param.default is None:
+                    continue
+                yield qualname, fn
+
+
+def test_at_least_one_hdi_prob_defaulted_method_discovered() -> None:
+    """Sanity: the discovery helper finds at least a few real methods.
+
+    This guards against the pkgutil walk silently returning nothing (which
+    would make the parametrised invariant trivially pass).
+    """
+    methods = list(_hdi_prob_defaulted_methods())
+    assert len(methods) >= 3, (
+        f"Expected to find several public methods with an hdi_prob default; "
+        f"got {len(methods)}: {[name for name, _ in methods]}"
+    )
+
+
+@pytest.mark.parametrize(
+    ("qualname", "fn"),
+    list(_hdi_prob_defaulted_methods()),
+    ids=lambda v: v if isinstance(v, str) else "fn",
+)
+def test_hdi_prob_default_matches_constant(
+    qualname: str, fn: Callable[..., Any]
+) -> None:
+    """Every public callable with an ``hdi_prob`` default must use ``HDI_PROB``.
+
+    See :issue:`889`. If you intentionally need a different default, update
+    this invariant in the same PR and document the divergence.
+    """
+    sig = inspect.signature(fn)
+    default = sig.parameters["hdi_prob"].default
+    assert default == HDI_PROB, (
+        f"{qualname} has hdi_prob default {default!r}; "
+        f"expected HDI_PROB ({HDI_PROB!r}). Either align the default with "
+        f"HDI_PROB or deliberately update test_hdi_prob_defaults.py."
+    )

--- a/causalpy/tests/test_hdi_prob_defaults.py
+++ b/causalpy/tests/test_hdi_prob_defaults.py
@@ -52,6 +52,11 @@ def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
 
     seen: set[int] = set()
 
+    # Defensive branches below (private modules, import failures, callables
+    # without a usable signature, etc.) are hit during the walk depending on
+    # which optional dependencies and modules happen to be importable; they
+    # are exempt from coverage so the safety net does not become a CI
+    # liability.
     for module_info in pkgutil.walk_packages(
         causalpy.__path__, prefix=f"{causalpy.__name__}."
     ):
@@ -59,10 +64,10 @@ def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
         if name.startswith("causalpy.tests"):
             continue
         if any(part.startswith("_") for part in name.split(".")[1:]):
-            continue
+            continue  # pragma: no cover
         try:
             mod = importlib.import_module(name)
-        except Exception:
+        except Exception:  # pragma: no cover
             continue
 
         for attr_name, attr in vars(mod).items():
@@ -81,7 +86,7 @@ def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
                 continue
             attr_qualname = getattr(attr, "__qualname__", None)
             if not isinstance(attr_qualname, str):
-                continue
+                continue  # pragma: no cover
 
             candidates: list[tuple[str, Callable[..., Any]]] = []
             if inspect.isclass(attr):
@@ -99,13 +104,13 @@ def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
             for qualname, fn in candidates:
                 try:
                     sig = inspect.signature(fn)
-                except (TypeError, ValueError):
+                except (TypeError, ValueError):  # pragma: no cover
                     continue
                 param = sig.parameters.get("hdi_prob")
                 if param is None:
                     continue
                 if param.default is inspect.Parameter.empty:
-                    continue
+                    continue  # pragma: no cover
                 if param.default is None:
                     continue
                 yield qualname, fn

--- a/docs/source/_templates/autosummary/module.rst
+++ b/docs/source/_templates/autosummary/module.rst
@@ -10,6 +10,10 @@
    {% for item in attributes %}
       {{ item }}
    {%- endfor %}
+
+   {% for item in attributes %}
+   .. autodata:: {{ item }}
+   {% endfor %}
    {% endif %}
    {% endblock %}
 

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -7,6 +7,7 @@
   :recursive:
   :toctree: generated/
 
+  constants
   data
   pymc_models
   skl_models


### PR DESCRIPTION
Closes #889. Sub-PR of the umbrella issue #886.

## Summary

- Replace hard-coded `0.94` / `0.95` HDI literals with the project-wide `HDI_PROB` constant in `panel_regression.py`, `maketables_adapters.py`, and `reporting.py` so plots and summaries share a single source of truth.
- **Behavioural change**: `InterruptedTimeSeries.analyze_persistence` now defaults to `hdi_prob=HDI_PROB` (0.94) instead of the previous hard-coded `0.95`, matching the convention used elsewhere in the library.
- Add a new invariant test `test_hdi_prob_defaults.py` that walks every public method in `causalpy/` and fails if any introduces an `hdi_prob` default that diverges from `HDI_PROB`. This pins the convention and prevents future drift.
- Document the `hdi_prob = 1 - alpha` relationship in `BaseExperiment.effect_summary` so users understand why `effect_summary()` and `plot()` can report different HDI widths with default settings (the former at 0.95, the latter at `HDI_PROB = 0.94`).

## Out of scope

- Changing the value of `HDI_PROB` itself (still 0.94, matching the arviz default).
- Wiring `hdi_prob` through the `_bayesian_plot` methods so the kwarg actually has an effect when passed to `plot()` — that is tracked as #890.
- Replacing `**kwargs` with explicit named parameters in public `plot()` overrides — that is the umbrella #886.

## Testing

- `prek run --all-files` passes locally.
- `python -m pytest causalpy/tests/ --ignore=test_integration_pymc_examples.py --ignore=test_integration_skl_examples.py`: 821 passed, 5 skipped (no failures, no warnings introduced).
- The new `test_hdi_prob_defaults.py` discovers and pins 9 distinct public methods.

## Test plan

- [ ] CI green (3.11, 3.14)
- [ ] Codecov shows the new test file is covered
- [ ] Read-the-Docs preview build succeeds and the rendered docstrings still read correctly

Made with [Cursor](https://cursor.com)