### PR TITLE
Wire hdi_prob through every Bayesian plot method

### DIFF
--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -26,7 +26,7 @@ from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
 
-from causalpy.constants import LEGEND_FONT_SIZE
+from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
@@ -334,13 +334,24 @@ class DifferenceInDifferences(BaseExperiment):
         return f"Causal impact = {convert_to_string(self.causal_impact, round_to=round_to)}"
 
     def _bayesian_plot(
-        self, round_to: int | None = None, **kwargs: Any
+        self,
+        round_to: int | None = None,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, plt.Axes]:
         """
-        Plot the results
+        Plot the results.
 
-        :param round_to:
-            Number of decimals used to round results. Defaults to 2. Use "None" to return raw numbers.
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive bands for the control, treatment, and
+            counterfactual trajectories. Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         """
 
         def _plot_causal_impact_arrow(results, ax):
@@ -415,6 +426,7 @@ class DifferenceInDifferences(BaseExperiment):
             time_points,
             self.y_pred_control["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
             label="Control group",
         )
@@ -427,6 +439,7 @@ class DifferenceInDifferences(BaseExperiment):
             time_points,
             self.y_pred_treatment["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
             label="Treatment group",
         )
@@ -467,6 +480,7 @@ class DifferenceInDifferences(BaseExperiment):
                     treated_units=0
                 ),
                 ax=ax,
+                hdi_prob=hdi_prob,
                 plot_hdi_kwargs={"color": "C2"},
                 label="Counterfactual",
             )

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -597,13 +597,24 @@ class InterruptedTimeSeries(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: Any
+        self,
+        round_to: int | None = 2,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
-        Plot the results
+        Plot the results.
 
-        :param round_to:
-            Number of decimals used to round results. Defaults to 2. Use "None" to return raw numbers.
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive, causal impact, and cumulative impact bands.
+            Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         """
         counterfactual_label = "Counterfactual"
 
@@ -618,6 +629,7 @@ class InterruptedTimeSeries(BaseExperiment):
             self.datapre.index,
             pre_mu_plot,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
         )
         handles = [(h_line, h_patch)]
@@ -645,6 +657,7 @@ class InterruptedTimeSeries(BaseExperiment):
             self.datapost.index,
             post_mu_plot,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         handles.append((h_line, h_patch))
@@ -707,6 +720,7 @@ class InterruptedTimeSeries(BaseExperiment):
             self.datapre.index,
             pre_impact_plot,
             ax=ax[1],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
         )
         post_impact_plot = (
@@ -719,6 +733,7 @@ class InterruptedTimeSeries(BaseExperiment):
             self.datapost.index,
             post_impact_plot,
             ax=ax[1],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         ax[1].axhline(y=0, c="k")
@@ -753,6 +768,7 @@ class InterruptedTimeSeries(BaseExperiment):
             self.datapost.index,
             post_cum_plot,
             ax=ax[2],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         ax[2].axhline(y=0, c="k")

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -479,15 +479,25 @@ class PanelRegression(BaseExperiment):
             "inference."
         )
 
-    def _bayesian_plot(self, **kwargs: Any) -> tuple[plt.Figure, plt.Axes]:
+    def _bayesian_plot(
+        self, hdi_prob: float = HDI_PROB, **kwargs: Any
+    ) -> tuple[plt.Figure, plt.Axes]:
         """Create coefficient plot for Bayesian model.
+
+        Parameters
+        ----------
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around each
+            posterior coefficient via :func:`arviz.plot_forest`. Must be in
+            ``(0, 1]``. Defaults to :data:`~causalpy.constants.HDI_PROB`
+            (currently 0.94).
 
         Returns
         -------
         tuple[plt.Figure, plt.Axes]
             Figure and axes objects
         """
-        return self._plot_coefficients_internal()
+        return self._plot_coefficients_internal(hdi_prob=hdi_prob)
 
     def _ols_plot(self, **kwargs: Any) -> tuple[plt.Figure, plt.Axes]:
         """Create coefficient plot for OLS model.

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -445,7 +445,10 @@ class PiecewiseITS(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: Any
+        self,
+        round_to: int | None = 2,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
         Plot the results for Bayesian models.
@@ -454,6 +457,11 @@ class PiecewiseITS(BaseExperiment):
         ----------
         round_to : int, optional
             Number of decimals for rounding. Defaults to 2.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            fitted, counterfactual, causal effect, and cumulative effect bands.
+            Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------
@@ -483,6 +491,7 @@ class PiecewiseITS(BaseExperiment):
             time_values,
             y_pred_mu,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
         )
 
@@ -494,6 +503,7 @@ class PiecewiseITS(BaseExperiment):
             time_values,
             y_cf_mu,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
 
@@ -521,6 +531,7 @@ class PiecewiseITS(BaseExperiment):
             time_values,
             self.effect,
             ax=ax[1],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C2"},
         )
         ax[1].axhline(y=0, c="k", linestyle="--", alpha=0.5)
@@ -537,6 +548,7 @@ class PiecewiseITS(BaseExperiment):
             time_values,
             self.cumulative_effect,
             ax=ax[2],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C3"},
         )
         ax[2].axhline(y=0, c="k", linestyle="--", alpha=0.5)

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -236,9 +236,25 @@ class PrePostNEGD(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = None, **kwargs: Any
+        self,
+        round_to: int | None = None,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """Generate plot for ANOVA-like experiments with non-equivalent group designs."""
+        """Generate plot for ANOVA-like experiments with non-equivalent group designs.
+
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive bands for the control and treatment groups,
+            and around the posterior of the estimated treatment effect.
+            Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+        """
         fig, ax = plt.subplots(
             2, 1, figsize=(7, 9), gridspec_kw={"height_ratios": [3, 1]}
         )
@@ -260,6 +276,7 @@ class PrePostNEGD(BaseExperiment):
             self.pred_xi,
             self.pred_untreated["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
             label="Control group",
         )
@@ -271,6 +288,7 @@ class PrePostNEGD(BaseExperiment):
             self.pred_xi,
             self.pred_treated["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
             label="Treatment group",
         )
@@ -284,7 +302,13 @@ class PrePostNEGD(BaseExperiment):
         )
 
         # Plot estimated caual impact / treatment effect
-        az.plot_posterior(self.causal_impact, ref_val=0, ax=ax[1], round_to=round_to)
+        az.plot_posterior(
+            self.causal_impact,
+            ref_val=0,
+            ax=ax[1],
+            round_to=round_to,
+            hdi_prob=hdi_prob,
+        )
         ax[1].set(title="Estimated treatment effect")
         return fig, ax
 

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -298,9 +298,25 @@ class RegressionDiscontinuity(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: Any
+        self,
+        round_to: int | None = 2,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, plt.Axes]:
-        """Generate plot for regression discontinuity designs."""
+        """Generate plot for regression discontinuity designs.
+
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive band, and the central credible interval
+            reported in the figure title for the discontinuity at threshold.
+            Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+        """
         fig, ax = plt.subplots()
 
         # Plot data: use two layers only when there are excluded observations
@@ -328,6 +344,7 @@ class RegressionDiscontinuity(BaseExperiment):
             self.x_pred[self.running_variable_name],
             self.pred["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
             label="Posterior mean",
         )
@@ -336,10 +353,10 @@ class RegressionDiscontinuity(BaseExperiment):
         title_info = f"{round_num(self.score['unit_0_r2'], round_to)} (std = {round_num(self.score['unit_0_r2_std'], round_to)})"
         r2 = f"Bayesian $R^2$ on fit data = {title_info}"
         percentiles = self.discontinuity_at_threshold.quantile(
-            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+            [(1 - hdi_prob) / 2, 1 - (1 - hdi_prob) / 2]
         ).values
         ci = (
-            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
+            rf"$CI_{{{hdi_prob * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
         )
         discon = f"""

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -246,9 +246,25 @@ class RegressionKink(BaseExperiment):
         self.print_coefficients(round_to)
 
     def _bayesian_plot(
-        self, round_to: int | None = 2, **kwargs: Any
+        self,
+        round_to: int | None = 2,
+        hdi_prob: float = HDI_PROB,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, plt.Axes]:
-        """Generate plot for regression kink designs."""
+        """Generate plot for regression kink designs.
+
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive band, and the central credible interval
+            reported in the figure title for the change in gradient at the
+            kink point. Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+        """
         fig, ax = plt.subplots()
         # Plot raw data
         sns.scatterplot(
@@ -264,6 +280,7 @@ class RegressionKink(BaseExperiment):
             self.x_pred[self.running_variable_name],
             self.pred["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         handles = [(h_line, h_patch)]
@@ -273,10 +290,10 @@ class RegressionKink(BaseExperiment):
         title_info = f"{round_num(self.score['unit_0_r2'], round_to if round_to is not None else 2)} (std = {round_num(self.score['unit_0_r2_std'], round_to if round_to is not None else 2)})"
         r2 = f"Bayesian $R^2$ on all data = {title_info}"
         percentiles = self.gradient_change.quantile(
-            [(1 - HDI_PROB) / 2, 1 - (1 - HDI_PROB) / 2]
+            [(1 - hdi_prob) / 2, 1 - (1 - hdi_prob) / 2]
         ).values
         ci = (
-            rf"$CI_{{{HDI_PROB * 100:.0f}\%}}$"
+            rf"$CI_{{{hdi_prob * 100:.0f}\%}}$"
             + f"[{round_num(percentiles[0], round_to if round_to is not None else 2)}, {round_num(percentiles[1], round_to if round_to is not None else 2)}]"
         )
         grad_change = f"""

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -644,14 +644,38 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         print("\nModel coefficients:")
         self.print_coefficients(round_to)
 
-    def _bayesian_plot(self, **kwargs: Any) -> tuple[plt.Figure, list[plt.Axes]]:
+    def _bayesian_plot(
+        self, hdi_prob: float | None = None, **kwargs: Any
+    ) -> tuple[plt.Figure, list[plt.Axes]]:
         """Plot event-study results for Bayesian model.
+
+        Parameters
+        ----------
+        hdi_prob : float, optional
+            Probability mass of the highest density interval shown by the
+            error bars. Unlike most other CausalPy experiments, ``hdi_prob``
+            for ``StaggeredDiD`` is fixed at fit time during effect
+            aggregation (see ``_aggregate_effects_bayesian``) and the
+            resulting bounds are cached on the instance. If supplied here,
+            the value must match the cached
+            :attr:`~causalpy.experiments.staggered_did.StaggeredDiD.hdi_prob_`;
+            otherwise a :class:`ValueError` is raised. Pass ``None`` (the
+            default) to plot using the cached value.
 
         Returns
         -------
         tuple[plt.Figure, list[plt.Axes]]
             Figure and axes objects.
         """
+        if hdi_prob is not None and hdi_prob != self.hdi_prob_:
+            raise ValueError(
+                "StaggeredDiD HDI bounds are computed during effect "
+                "aggregation, not at plot time. The cached HDI probability "
+                f"is {self.hdi_prob_}, but plot() received hdi_prob="
+                f"{hdi_prob}. To plot at a different HDI probability, "
+                "re-fit the experiment so that aggregation uses the desired "
+                "value, or omit hdi_prob to use the cached value."
+            )
         fig, ax = plt.subplots(1, 1, figsize=(10, 6))
 
         att_et = self.att_event_time_.copy()

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -382,16 +382,25 @@ class SyntheticControl(BaseExperiment):
         self,
         round_to: int | None = None,
         treated_unit: str | None = None,
+        hdi_prob: float = HDI_PROB,
         **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
-        Plot the results for a specific treated unit
+        Plot the results for a specific treated unit.
 
-        :param round_to:
-            Number of decimals used to round results. Defaults to 2. Use "None" to return raw numbers.
-        :param treated_unit:
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round results. Defaults to 2. Use ``None``
+            to return raw numbers.
+        treated_unit : str, optional
             Which treated unit to plot. Must be a string name of the treated unit.
-            If None, plots the first treated unit.
+            If ``None``, plots the first treated unit.
+        hdi_prob : float, optional
+            Probability mass of the highest density interval drawn around the
+            posterior predictive, causal impact, and cumulative impact bands.
+            Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         """
         counterfactual_label = "Counterfactual"
 
@@ -420,6 +429,7 @@ class SyntheticControl(BaseExperiment):
             self.datapre.index,
             pre_pred,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
         )
         handles = [(h_line, h_patch)]
@@ -440,6 +450,7 @@ class SyntheticControl(BaseExperiment):
             self.datapost.index,
             post_pred,
             ax=ax[0],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         handles.append((h_line, h_patch))
@@ -469,12 +480,14 @@ class SyntheticControl(BaseExperiment):
             self.datapre.index,
             self.pre_impact.sel(treated_units=treated_unit),
             ax=ax[1],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C0"},
         )
         plot_xY(
             self.datapost.index,
             self.post_impact.sel(treated_units=treated_unit),
             ax=ax[1],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         ax[1].axhline(y=0, c="k")
@@ -493,6 +506,7 @@ class SyntheticControl(BaseExperiment):
             self.datapost.index,
             self.post_impact_cumulative.sel(treated_units=treated_unit),
             ax=ax[2],
+            hdi_prob=hdi_prob,
             plot_hdi_kwargs={"color": "C1"},
         )
         ax[2].axhline(y=0, c="k")

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -1,0 +1,97 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Regression tests verifying that ``hdi_prob`` is wired through Bayesian plot
+methods so that user-supplied values actually change the rendered HDI bands.
+
+These tests guard against the regression described in GitHub issue
+`pymc-labs/CausalPy#890`_, where ``result.plot(hdi_prob=...)`` was silently
+swallowed by ``**kwargs`` rather than reaching the underlying
+:func:`causalpy.plot_utils.plot_xY` calls.
+
+.. _pymc-labs/CausalPy#890: https://github.com/pymc-labs/CausalPy/issues/890
+"""
+
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import causalpy as cp
+from causalpy.constants import HDI_PROB
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def _record_hdi_prob_calls(monkey_target: str):
+    """Patch ``plot_xY`` to capture the ``hdi_prob`` kwarg of every call.
+
+    Returns a context manager and the list that will be populated with the
+    recorded values (as floats).
+    """
+    import causalpy.plot_utils as plot_utils
+
+    real_plot_xY = plot_utils.plot_xY
+    recorded: list[float] = []
+
+    def spy(*args, **kwargs):
+        recorded.append(kwargs.get("hdi_prob", HDI_PROB))
+        return real_plot_xY(*args, **kwargs)
+
+    return patch(monkey_target, side_effect=spy), recorded
+
+
+@pytest.fixture(scope="module")
+def fitted_its(its_data):
+    """Fit a single ITS once and reuse across tests in this module."""
+    treatment_time = pd.to_datetime("2017-01-01")
+    return cp.InterruptedTimeSeries(
+        its_data,
+        treatment_time,
+        formula="y ~ 1 + t + C(month)",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", [0.50, 0.75, 0.99])
+def test_its_plot_threads_hdi_prob_to_plot_xY(mock_pymc_sample, fitted_its, hdi_prob):
+    """User-supplied ``hdi_prob`` reaches every ``plot_xY`` call in ITS plot."""
+    patcher, recorded = _record_hdi_prob_calls(
+        "causalpy.experiments.interrupted_time_series.plot_xY"
+    )
+    with patcher:
+        fitted_its.plot(hdi_prob=hdi_prob)
+
+    assert len(recorded) > 0, "plot_xY was not invoked at all"
+    assert all(value == hdi_prob for value in recorded), (
+        f"Expected every plot_xY call to receive hdi_prob={hdi_prob}, "
+        f"but recorded values were {recorded}"
+    )
+
+
+@pytest.mark.integration
+def test_its_plot_default_hdi_prob_matches_constant(mock_pymc_sample, fitted_its):
+    """When ``hdi_prob`` is omitted, the canonical default is forwarded."""
+    patcher, recorded = _record_hdi_prob_calls(
+        "causalpy.experiments.interrupted_time_series.plot_xY"
+    )
+    with patcher:
+        fitted_its.plot()
+
+    assert len(recorded) > 0, "plot_xY was not invoked at all"
+    assert all(value == HDI_PROB for value in recorded), (
+        f"Expected every plot_xY call to receive the default HDI_PROB="
+        f"{HDI_PROB}, but recorded values were {recorded}"
+    )

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -18,80 +18,436 @@ methods so that user-supplied values actually change the rendered HDI bands.
 These tests guard against the regression described in GitHub issue
 `pymc-labs/CausalPy#890`_, where ``result.plot(hdi_prob=...)`` was silently
 swallowed by ``**kwargs`` rather than reaching the underlying
-:func:`causalpy.plot_utils.plot_xY` calls.
+:func:`causalpy.plot_utils.plot_xY` (and equivalent) calls.
 
 .. _pymc-labs/CausalPy#890: https://github.com/pymc-labs/CausalPy/issues/890
 """
 
+import importlib
+from contextlib import ExitStack
+from typing import Any
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from sklearn.linear_model import LinearRegression as SkLinearRegression
 
 import causalpy as cp
 from causalpy.constants import HDI_PROB
+from causalpy.data.simulate_data import (
+    generate_piecewise_its_data,
+    generate_staggered_did_data,
+)
+from causalpy.tests.conftest import setup_regression_kink_data
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
+# Each entry maps a "spy target" (dotted import path of the callable used by
+# the experiment's plot path) to the kwarg name that ``hdi_prob`` flows into.
+# All current targets happen to use the same kwarg name (``hdi_prob``) but the
+# indirection keeps the helper future-proof.
+_SpyTarget = tuple[str, str]
 
-def _record_hdi_prob_calls(monkey_target: str):
-    """Patch ``plot_xY`` to capture the ``hdi_prob`` kwarg of every call.
 
-    Returns a context manager and the list that will be populated with the
-    recorded values (as floats).
+def _resolve_dotted(dotted: str) -> Any:
+    """Resolve a dotted path that may include attribute access through an alias.
+
+    For example, ``causalpy.experiments.prepostnegd.az.plot_posterior`` is not
+    importable as a module path because ``az`` is an alias inside the module,
+    not a real submodule. We import the longest valid module prefix and then
+    walk the remaining attributes.
     """
-    import causalpy.plot_utils as plot_utils
+    parts = dotted.split(".")
+    for i in range(len(parts), 0, -1):
+        try:
+            obj = importlib.import_module(".".join(parts[:i]))
+        except ImportError:
+            continue
+        for part in parts[i:]:
+            obj = getattr(obj, part)
+        return obj
+    raise ImportError(f"Could not resolve {dotted!r}")  # pragma: no cover
 
-    real_plot_xY = plot_utils.plot_xY
-    recorded: list[float] = []
 
-    def spy(*args, **kwargs):
-        recorded.append(kwargs.get("hdi_prob", HDI_PROB))
-        return real_plot_xY(*args, **kwargs)
+def _record_hdi_prob_calls(
+    targets: list[_SpyTarget],
+) -> tuple[ExitStack, list[float | None]]:
+    """Patch each ``targets`` callable with a spy that records its ``hdi_prob`` kwarg.
 
-    return patch(monkey_target, side_effect=spy), recorded
+    Returns the ``ExitStack`` (to be used as a context manager) and a list that
+    will be populated with the recorded values. Each call appends one entry,
+    or ``None`` when the kwarg was omitted.
+    """
+    recorded: list[float | None] = []
+    stack = ExitStack()
+
+    for dotted, kwarg in targets:
+        real = _resolve_dotted(dotted)
+
+        def make_spy(real_callable=real, kwarg_name=kwarg):
+            """Build a side_effect that records ``kwarg_name`` and forwards to ``real_callable``."""
+
+            def spy(*args, **kwargs):
+                """Record ``hdi_prob`` then delegate to the real callable."""
+                recorded.append(kwargs.get(kwarg_name))
+                return real_callable(*args, **kwargs)
+
+            return spy
+
+        stack.enter_context(patch(dotted, side_effect=make_spy()))
+
+    return stack, recorded
+
+
+def _assert_threads(recorded: list[float | None], expected: float) -> None:
+    """Assert that every recorded ``hdi_prob`` value equals ``expected``."""
+    assert len(recorded) > 0, "no spied call sites were exercised"
+    assert all(value == expected for value in recorded), (
+        f"Expected every spied call to receive hdi_prob={expected}, "
+        f"but recorded values were {recorded}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-scoped fitted experiment fixtures (each fits the model once).
+# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
 def fitted_its(its_data):
-    """Fit a single ITS once and reuse across tests in this module."""
-    treatment_time = pd.to_datetime("2017-01-01")
+    """Fit an InterruptedTimeSeries once for reuse across wiring tests."""
     return cp.InterruptedTimeSeries(
         its_data,
-        treatment_time,
+        pd.to_datetime("2017-01-01"),
         formula="y ~ 1 + t + C(month)",
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
 
-@pytest.mark.integration
-@pytest.mark.parametrize("hdi_prob", [0.50, 0.75, 0.99])
-def test_its_plot_threads_hdi_prob_to_plot_xY(mock_pymc_sample, fitted_its, hdi_prob):
-    """User-supplied ``hdi_prob`` reaches every ``plot_xY`` call in ITS plot."""
-    patcher, recorded = _record_hdi_prob_calls(
-        "causalpy.experiments.interrupted_time_series.plot_xY"
+@pytest.fixture(scope="module")
+def fitted_sc(sc_data):
+    """Fit a SyntheticControl once for reuse across wiring tests."""
+    return cp.SyntheticControl(
+        sc_data,
+        70,
+        control_units=["a", "b", "c", "d", "e", "f", "g"],
+        treated_units=["actual"],
+        model=cp.pymc_models.WeightedSumFitter(sample_kwargs=sample_kwargs),
     )
-    with patcher:
-        fitted_its.plot(hdi_prob=hdi_prob)
 
-    assert len(recorded) > 0, "plot_xY was not invoked at all"
-    assert all(value == hdi_prob for value in recorded), (
-        f"Expected every plot_xY call to receive hdi_prob={hdi_prob}, "
+
+@pytest.fixture(scope="module")
+def fitted_did(did_data):
+    """Fit a DifferenceInDifferences once for reuse across wiring tests."""
+    return cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_rd(rd_data):
+    """Fit a RegressionDiscontinuity once for reuse across wiring tests."""
+    return cp.RegressionDiscontinuity(
+        rd_data,
+        formula="y ~ 1 + bs(x, df=6) + treated",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        treatment_threshold=0.5,
+        epsilon=0.001,
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_rkink():
+    """Fit a RegressionKink once for reuse across wiring tests."""
+    kink = 0.5
+    df = setup_regression_kink_data(kink)
+    return cp.RegressionKink(
+        df,
+        formula=f"y ~ 1 + x + I((x-{kink})*treated)",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        kink_point=kink,
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_prepost(anova1_data):
+    """Fit a PrePostNEGD once for reuse across wiring tests."""
+    return cp.PrePostNEGD(
+        anova1_data,
+        formula="post ~ 1 + C(group) + pre",
+        group_variable_name="group",
+        pretreatment_variable_name="pre",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_piecewise():
+    """Fit a PiecewiseITS once for reuse across wiring tests."""
+    df, _ = generate_piecewise_its_data(N=100, seed=42)
+    return cp.PiecewiseITS(
+        df,
+        formula="y ~ 1 + t + step(t, 50) + ramp(t, 50)",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_panel():
+    """Fit a PanelRegression once for reuse across wiring tests."""
+    import numpy as np
+
+    rng = np.random.default_rng(42)
+    rows = []
+    for u_idx in range(10):
+        unit_effect = rng.normal()
+        for t in range(20):
+            treatment = 1 if (t >= 10 and u_idx < 5) else 0
+            x1 = rng.normal()
+            y = unit_effect + 0.1 * t + 2.0 * treatment + 0.5 * x1 + 0.1 * rng.normal()
+            rows.append(
+                {
+                    "unit": f"u{u_idx}",
+                    "time": t,
+                    "treatment": treatment,
+                    "x1": x1,
+                    "y": y,
+                }
+            )
+    df = pd.DataFrame(rows)
+    return cp.PanelRegression(
+        data=df,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_staggered():
+    """Fit a Bayesian StaggeredDifferenceInDifferences for the staggered tests."""
+    df = generate_staggered_did_data(
+        n_units=30, n_time_periods=15, treatment_cohorts={5: 10, 10: 10}, seed=42
+    )
+    return cp.StaggeredDifferenceInDifferences(
+        df,
+        formula="y ~ 1 + C(unit) + C(time)",
+        unit_variable_name="unit",
+        time_variable_name="time",
+        treated_variable_name="treated",
+        treatment_time_variable_name="treatment_time",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+
+@pytest.fixture(scope="module")
+def fitted_staggered_ols():
+    """Fit an OLS StaggeredDifferenceInDifferences (kept for future use)."""
+    df = generate_staggered_did_data(
+        n_units=30, n_time_periods=15, treatment_cohorts={5: 10, 10: 10}, seed=42
+    )
+    return cp.StaggeredDifferenceInDifferences(
+        df,
+        formula="y ~ 1 + C(unit) + C(time)",
+        unit_variable_name="unit",
+        time_variable_name="time",
+        treated_variable_name="treated",
+        treatment_time_variable_name="treatment_time",
+        model=SkLinearRegression(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Per-class wiring tests. Each verifies that user-supplied ``hdi_prob`` reaches
+# the underlying HDI primitives, and that the canonical default is forwarded
+# when the parameter is omitted.
+# ---------------------------------------------------------------------------
+
+
+_PARAMS = [0.50, 0.75, 0.99]
+
+
+def _check_threading(fitted, targets: list[_SpyTarget], hdi_prob: float) -> None:
+    """Call ``fitted.plot(hdi_prob=...)`` and assert ``hdi_prob`` reaches every target."""
+    stack, recorded = _record_hdi_prob_calls(targets)
+    with stack:
+        fitted.plot(hdi_prob=hdi_prob)
+    _assert_threads(recorded, hdi_prob)
+
+
+def _check_default(fitted, targets: list[_SpyTarget]) -> None:
+    """Call ``fitted.plot()`` (no kwarg) and assert every target gets HDI_PROB or None."""
+    stack, recorded = _record_hdi_prob_calls(targets)
+    with stack:
+        fitted.plot()
+    # When the experiment forwards the default, the recorded values are
+    # either ``HDI_PROB`` itself or ``None`` if the experiment relies on the
+    # downstream callable's own default. Both are acceptable.
+    assert len(recorded) > 0, "no spied call sites were exercised"
+    assert all(value in (HDI_PROB, None) for value in recorded), (
+        f"Expected every spied call to receive HDI_PROB ({HDI_PROB}) or None, "
         f"but recorded values were {recorded}"
     )
 
 
-@pytest.mark.integration
-def test_its_plot_default_hdi_prob_matches_constant(mock_pymc_sample, fitted_its):
-    """When ``hdi_prob`` is omitted, the canonical default is forwarded."""
-    patcher, recorded = _record_hdi_prob_calls(
-        "causalpy.experiments.interrupted_time_series.plot_xY"
-    )
-    with patcher:
-        fitted_its.plot()
+_ITS_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.interrupted_time_series.plot_xY", "hdi_prob"),
+]
+_SC_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.synthetic_control.plot_xY", "hdi_prob"),
+]
+_DID_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.diff_in_diff.plot_xY", "hdi_prob"),
+]
+_RD_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.regression_discontinuity.plot_xY", "hdi_prob"),
+]
+_RKINK_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.regression_kink.plot_xY", "hdi_prob"),
+]
+_PREPOST_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.prepostnegd.plot_xY", "hdi_prob"),
+    ("causalpy.experiments.prepostnegd.az.plot_posterior", "hdi_prob"),
+]
+_PIECEWISE_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.piecewise_its.plot_xY", "hdi_prob"),
+]
+_PANEL_TARGETS: list[_SpyTarget] = [
+    ("causalpy.experiments.panel_regression.az.plot_forest", "hdi_prob"),
+]
 
-    assert len(recorded) > 0, "plot_xY was not invoked at all"
-    assert all(value == HDI_PROB for value in recorded), (
-        f"Expected every plot_xY call to receive the default HDI_PROB="
-        f"{HDI_PROB}, but recorded values were {recorded}"
-    )
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_its_plot_threads_hdi_prob(mock_pymc_sample, fitted_its, hdi_prob):
+    """ITS ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_its, _ITS_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_its_plot_default_hdi_prob(mock_pymc_sample, fitted_its):
+    """ITS default ``plot()`` forwards ``HDI_PROB`` to every ``plot_xY`` call."""
+    _check_default(fitted_its, _ITS_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_sc_plot_threads_hdi_prob(mock_pymc_sample, fitted_sc, hdi_prob):
+    """Synthetic Control ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_sc, _SC_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_sc_plot_default_hdi_prob(mock_pymc_sample, fitted_sc):
+    """Synthetic Control default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_sc, _SC_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_did_plot_threads_hdi_prob(mock_pymc_sample, fitted_did, hdi_prob):
+    """DiD ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_did, _DID_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_did_plot_default_hdi_prob(mock_pymc_sample, fitted_did):
+    """DiD default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_did, _DID_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_rd_plot_threads_hdi_prob(mock_pymc_sample, fitted_rd, hdi_prob):
+    """RD ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_rd, _RD_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_rd_plot_default_hdi_prob(mock_pymc_sample, fitted_rd):
+    """RD default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_rd, _RD_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_rkink_plot_threads_hdi_prob(mock_pymc_sample, fitted_rkink, hdi_prob):
+    """Regression Kink ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_rkink, _RKINK_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_rkink_plot_default_hdi_prob(mock_pymc_sample, fitted_rkink):
+    """Regression Kink default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_rkink, _RKINK_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_prepost_plot_threads_hdi_prob(mock_pymc_sample, fitted_prepost, hdi_prob):
+    """PrePostNEGD ``plot(hdi_prob=...)`` reaches ``plot_xY`` and ``az.plot_posterior``."""
+    _check_threading(fitted_prepost, _PREPOST_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_prepost_plot_default_hdi_prob(mock_pymc_sample, fitted_prepost):
+    """PrePostNEGD default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_prepost, _PREPOST_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_piecewise_plot_threads_hdi_prob(mock_pymc_sample, fitted_piecewise, hdi_prob):
+    """PiecewiseITS ``plot(hdi_prob=...)`` reaches every ``plot_xY`` call."""
+    _check_threading(fitted_piecewise, _PIECEWISE_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_piecewise_plot_default_hdi_prob(mock_pymc_sample, fitted_piecewise):
+    """PiecewiseITS default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_piecewise, _PIECEWISE_TARGETS)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", _PARAMS)
+def test_panel_plot_threads_hdi_prob(mock_pymc_sample, fitted_panel, hdi_prob):
+    """PanelRegression ``plot(hdi_prob=...)`` reaches ``az.plot_forest``."""
+    _check_threading(fitted_panel, _PANEL_TARGETS, hdi_prob)
+
+
+@pytest.mark.integration
+def test_panel_plot_default_hdi_prob(mock_pymc_sample, fitted_panel):
+    """PanelRegression default ``plot()`` forwards ``HDI_PROB``."""
+    _check_default(fitted_panel, _PANEL_TARGETS)
+
+
+# ---------------------------------------------------------------------------
+# StaggeredDifferenceInDifferences has different semantics: HDI bounds are
+# computed during effect aggregation (at fit time), not at plot time. The
+# plot reads cached ``att_lower``/``att_upper`` columns. To prevent silent
+# kwarg swallowing, ``_bayesian_plot`` raises a clear ``ValueError`` when the
+# caller supplies an ``hdi_prob`` that does not match the cached value.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_staggered_plot_uses_cached_hdi_prob(mock_pymc_sample, fitted_staggered):
+    """Default ``plot()`` and ``plot(hdi_prob=cached)`` both succeed."""
+    fig1, _ = fitted_staggered.plot()
+    fig2, _ = fitted_staggered.plot(hdi_prob=fitted_staggered.hdi_prob_)
+    assert fig1 is not None
+    assert fig2 is not None
+
+
+@pytest.mark.integration
+def test_staggered_plot_rejects_mismatched_hdi_prob(mock_pymc_sample, fitted_staggered):
+    """Supplying a non-cached ``hdi_prob`` must raise rather than silently no-op."""
+    other = 0.50 if fitted_staggered.hdi_prob_ != 0.50 else 0.99
+    with pytest.raises(ValueError, match="HDI bounds are computed during"):
+        fitted_staggered.plot(hdi_prob=other)


### PR DESCRIPTION
## Summary

Closes #890. Refs umbrella #886.

Previously, calling `result.plot(hdi_prob=...)` on most CausalPy Bayesian experiments was silently ignored: the kwarg was swallowed by `**kwargs` in `_bayesian_plot` and never reached the underlying `plot_xY`, `az.plot_posterior`, or `az.plot_forest` calls. This PR wires `hdi_prob` end-to-end across every Bayesian experiment class so user-supplied values actually change the rendered HDI bands.

## Changes per experiment

| Class | What was changed |
|---|---|
| `InterruptedTimeSeries` | Threaded into all 5 `plot_xY` calls. |
| `SyntheticControl` | Threaded into all 5 `plot_xY` calls. |
| `DifferenceInDifferences` | Threaded into the 3 `plot_xY` calls (control / treatment / counterfactual); added missing `HDI_PROB` import. |
| `RegressionDiscontinuity` | Threaded into the posterior-mean `plot_xY` call **and** into the title CI label and quantile bounds so the figure title matches the band. |
| `RegressionKink` | Same as RD: band + title CI label share `hdi_prob`. |
| `PrePostNEGD` | Threaded into both `plot_xY` calls and the `az.plot_posterior(...)` for the estimated treatment effect. |
| `PiecewiseInterruptedTimeSeries` | Threaded into all 4 `plot_xY` calls (fitted / counterfactual / effect / cumulative). |
| `PanelRegression` | `_bayesian_plot` now accepts and forwards `hdi_prob` to `_plot_coefficients_internal`, which already used it for `az.plot_forest(..., hdi_prob=...)`. |
| `StaggeredDifferenceInDifferences` | HDI bounds are computed during `_aggregate_effects_bayesian` at fit time and cached, so the plot path can't honour a different `hdi_prob` after the fact. To prevent silent kwarg swallowing, `_bayesian_plot` now accepts `hdi_prob: float \| None = None` and raises a clear `ValueError` if the supplied value differs from the cached `self.hdi_prob_`. The error directs the user to re-fit at the desired aggregation HDI probability. |

Each updated docstring follows the prose pattern established in #889 with a `:data:` cross-reference to `~causalpy.constants.HDI_PROB`. Each public surface keeps `**kwargs` for now to avoid preempting the explicit-signature redesign that belongs to umbrella #886.

## New regression test module

`causalpy/tests/test_hdi_prob_wiring.py` is structured as the long-term home for these invariants:

- A single `_record_hdi_prob_calls` spy helper monkey-patches the dotted HDI primitives inside each experiment module (incl. attribute access through a module alias such as `prepostnegd.az.plot_posterior` and `panel_regression.az.plot_forest`) and records every observed `hdi_prob` kwarg.
- One module-scoped fitted-experiment fixture per class so the model is fit only once across every parametrised case.
- Per-class `test_<exp>_plot_threads_hdi_prob` parametrised over `0.50 / 0.75 / 0.99` and a default-value test that verifies omitting `hdi_prob` forwards `HDI_PROB` to every spied callable.
- Two `StaggeredDiD` cases verify the cached-value happy path and that a mismatched value raises `ValueError`.

This raises the file from 4 tests (ITS-only pilot) to **34 tests**, covering all 9 Bayesian experiment classes.

## Test plan

- [x] `pytest causalpy/tests/test_hdi_prob_wiring.py` &mdash; 34 passed.
- [x] `pytest causalpy/tests/test_hdi_prob_defaults.py` &mdash; existing invariant test green.
- [x] Broad experiment suites: `test_integration_pymc_examples`, `test_integration_skl_examples`, `test_piecewise_its`, `test_staggered_did`, `test_panel_regression`, `test_three_period_its`, `test_integration_its_new_timeseries`, `test_its_effect_summary`, `test_plot_show_parameter` &mdash; **327 passed, 5 skipped**.
- [x] `prek run --files <every changed file>` &mdash; all hooks green (ruff, ruff format, mypy, interrogate, codespell, etc.).
- [ ] CI