### PR TITLE
Fix inline bullet list rendering in docstrings (closes #892)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -118,3 +118,14 @@ repos:
         language: python
         files: \.bib$
         additional_dependencies: [pybtex]
+      # Catch the Sphinx/Napoleon "wall of prose" rendering bug from issue #892:
+      # bullet lists inside docstrings must be preceded by a blank line, otherwise
+      # they are collapsed into the introductory paragraph. Neither
+      # numpydoc-validation nor ruff/pydocstyle inspect section bodies, so we
+      # enforce this with a small AST check.
+      - id: validate-docstring-lists
+        name: Validate blank line before bullet lists in docstrings
+        entry: python scripts/validate_docstring_lists.py
+        language: python
+        files: ^causalpy/.*\.py$
+        exclude: ^causalpy/tests/

--- a/causalpy/data/simulate_data.py
+++ b/causalpy/data/simulate_data.py
@@ -592,6 +592,7 @@ def generate_staggered_did_data(
     -------
     pd.DataFrame
         Panel data with columns:
+
         - unit: Unit identifier
         - time: Time period
         - treated: Binary indicator (1 if treated at time t, 0 otherwise)
@@ -718,6 +719,7 @@ def generate_piecewise_its_data(
     y_t = β₀ + β₁t + Σₖ(level_k · I_k(t) + slope_k · R_k(t)) + ε_t
 
     Where:
+
     - I_k(t) = 1 if t >= T_k else 0 (step function for level change)
     - R_k(t) = max(0, t - T_k) (ramp function for slope change)
 
@@ -746,6 +748,7 @@ def generate_piecewise_its_data(
     -------
     df : pd.DataFrame
         DataFrame with columns:
+
         - 't': time index (0 to N-1)
         - 'y': observed outcome with noise
         - 'y_true': outcome without noise (ground truth)
@@ -753,6 +756,7 @@ def generate_piecewise_its_data(
         - 'effect': true causal effect at each time point
     params : dict
         Dictionary containing the true parameters:
+
         - 'baseline_intercept': β₀
         - 'baseline_slope': β₁
         - 'level_changes': list of level changes

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -346,11 +346,13 @@ class BaseExperiment(ABC):
         ----------
         window : str, tuple, or slice, default="post"
             Time window for analysis (ITS/SC only, ignored for DiD/RD):
+
             - "post": All post-treatment time points (default)
             - (start, end): Tuple of start and end times (handles both datetime and integer indices)
             - slice: Python slice object for integer indices
         direction : {"increase", "decrease", "two-sided"}, default="increase"
             Direction for tail probability calculation (PyMC only, ignored for OLS):
+
             - "increase": P(effect > 0)
             - "decrease": P(effect < 0)
             - "two-sided": Two-sided p-value, report 1-p as "probability of effect"

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -115,6 +115,7 @@ class InterruptedTimeSeries(BaseExperiment):
     counterfactual prediction uncertainty, but not individual observation variability.
 
     The three-period design is useful for analyzing temporary interventions such as:
+
     - Marketing campaigns with defined start and end dates
     - Policy trials or pilot programs
     - Clinical treatments with limited duration
@@ -329,6 +330,7 @@ class InterruptedTimeSeries(BaseExperiment):
         then sliced into two periods for analysis.
 
         NOTE: treatment_end_time is INCLUSIVE (>=) in post-intervention period.
+
         - Intervention period: treatment_time <= index < treatment_end_time
         - Post-intervention period: index >= treatment_end_time (inclusive)
         """
@@ -1116,6 +1118,7 @@ class InterruptedTimeSeries(BaseExperiment):
         -------
         dict[str, Any]
             Dictionary containing:
+
             - "mean_effect_during": Mean effect during intervention period
             - "mean_effect_post": Mean effect during post-intervention period
             - "persistence_ratio": Post-intervention mean effect divided by intervention mean (decimal, can exceed 1.0)
@@ -1296,6 +1299,7 @@ class InterruptedTimeSeries(BaseExperiment):
         ----------
         window : str, tuple, or slice, default="post"
             Time window for analysis:
+
             - "post": All post-treatment time points (default)
             - (start, end): Tuple of start and end times (handles both datetime and integer indices)
             - slice: Python slice object for integer indices

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -361,6 +361,7 @@ class InversePropensityWeighting(BaseExperiment):
         -------
         tuple
             A tuple of (ate, trt, ntrt) where:
+
             - ate: Average Treatment Effect
             - trt: Weighted mean outcome for treated group
             - ntrt: Weighted mean outcome for non-treated group
@@ -390,6 +391,7 @@ class InversePropensityWeighting(BaseExperiment):
         -------
         tuple
             A tuple of (ate, trt, ntrt) where:
+
             - ate: Average Treatment Effect
             - trt: Weighted mean outcome for treated group
             - ntrt: Weighted mean outcome for non-treated group
@@ -419,6 +421,7 @@ class InversePropensityWeighting(BaseExperiment):
         -------
         tuple
             A tuple of (ate, trt, ntrt) where:
+
             - ate: Average Treatment Effect
             - trt: Weighted mean outcome for treated group
             - ntrt: Weighted mean outcome for non-treated group
@@ -448,6 +451,7 @@ class InversePropensityWeighting(BaseExperiment):
         -------
         tuple
             A tuple of (ate, trt, ntrt) where:
+
             - ate: Average Treatment Effect
             - trt: Weighted mean outcome for treated group
             - ntrt: Weighted mean outcome for non-treated group
@@ -485,6 +489,7 @@ class InversePropensityWeighting(BaseExperiment):
         -------
         list[float]
             A list of [ate, trt, ntrt] where:
+
             - ate: Average Treatment Effect
             - trt: Weighted mean outcome for treated group
             - ntrt: Weighted mean outcome for non-treated group

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -60,6 +60,7 @@ class PanelRegression(BaseExperiment):
         If provided, time fixed effects will be included. Default is None.
     fe_method : {"dummies", "demeaned"}, default="dummies"
         Method for handling fixed effects:
+
         - "dummies": Use unpooled dummy-variable fixed effects
           (``C(unit)``/``C(time)`` in formula). Gets individual unit effect
           estimates but creates N-1 dummy columns. Best for small N.
@@ -784,6 +785,7 @@ class PanelRegression(BaseExperiment):
             Number of units to sample if units not specified.
         select : {"random", "extreme", "high_variance"}, default="random"
             Method for selecting units:
+
             - "random": Random sample of units
             - "extreme": Units with largest positive and negative effects
             - "high_variance": Units with most within-unit variation
@@ -795,6 +797,7 @@ class PanelRegression(BaseExperiment):
             (currently 0.94). Common alternative values are 0.89 or 0.5.
         interval_type : {"mean", "predictive"}, default="mean"
             Which uncertainty interval to show for Bayesian models:
+
             - "mean": HDI of posterior ``mu`` (uncertainty in expected value)
             - "predictive": HDI of posterior predictive ``y_hat``
               (includes observation noise)
@@ -963,6 +966,7 @@ class PanelRegression(BaseExperiment):
         ----------
         kind : {"scatter", "histogram", "qq"}, default="scatter"
             Type of residual plot:
+
             - "scatter": Residuals vs fitted values
             - "histogram": Distribution of residuals
             - "qq": Q-Q plot for normality check

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -418,6 +418,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         2. Event-time ATTs: ATT(e) for each event-time e = t - G
 
         For event-time ATTs, this includes both:
+
         - Post-treatment effects (event_time >= 0): actual treatment effects
         - Pre-treatment effects (event_time < 0): placebo/residual checks
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -886,6 +886,7 @@ class SyntheticControl(BaseExperiment):
         ----------
         window : str, tuple, or slice, default="post"
             Time window for analysis:
+
             - "post": All post-treatment time points (default)
             - (start, end): Tuple of start and end times (handles both datetime and integer indices)
             - slice: Python slice object for integer indices

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -423,10 +423,12 @@ class PyMCModel(pm.Model):
         -----
         By using `mu` (the posterior expectation) rather than `y_hat` (the posterior
         predictive with observation noise), the uncertainty in the impact reflects:
+
         - Parameter uncertainty in the fitted model
         - Uncertainty in the counterfactual prediction
 
         But excludes:
+
         - Observation-level noise (sigma)
 
         This makes the impact plots focus on the systematic causal effect rather than
@@ -652,6 +654,7 @@ class WeightedSumFitter(PyMCModel):
         -------
         Dict[str, Prior]
             Dictionary containing:
+
             - "beta": Dirichlet prior with shape=(1,...,1) for n_control_units
         """
         n_predictors = X.shape[1]
@@ -846,6 +849,7 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         -------
         dict[str, Prior]
             Dictionary containing:
+
             - "beta_raw": Normal prior with dims ["treated_units", "coeffs_raw"]
         """
         return {
@@ -1291,6 +1295,7 @@ class PropensityScore(PyMCModel):
 
         priors : dict, optional
             Dictionary specifying priors for outcome model parameters:
+
                 - "b_outcome": list [mean, std] for regression coefficients.
                 - "sigma": standard deviation of the outcome noise (default 1).
 
@@ -1555,7 +1560,8 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
         Returns
         -------
         tuple
-            (time_for_trend, time_for_seasonality, X_for_pymc, num_obs)
+            ``(time_for_trend, time_for_seasonality, X_for_pymc, num_obs)``:
+
             - time_for_trend: numpy array of time values for trend component
             - time_for_seasonality: numpy array of day-of-year values
             - X_for_pymc: xarray DataArray for exogenous vars, or None if no exog vars

--- a/causalpy/tests/conftest.py
+++ b/causalpy/tests/conftest.py
@@ -15,6 +15,7 @@
 CausalPy Test Configuration
 
 Functions:
+
 * rng: random number generator with session level scope
 """
 

--- a/causalpy/tests/test_hdi_prob_defaults.py
+++ b/causalpy/tests/test_hdi_prob_defaults.py
@@ -38,6 +38,7 @@ def _hdi_prob_defaulted_methods() -> Iterable[tuple[str, Callable[..., Any]]]:
     non-empty default value.
 
     Excluded:
+
       * Private callables (any path component starting with ``_``).
       * The ``causalpy.tests`` package.
       * ``hdi_prob`` parameters with no default (kwarg-only required arg).

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -1617,6 +1617,7 @@ def test_staggered_did_att_event_time_includes_pre_and_post_treatment():
     """Test that att_event_time_ includes both pre and post-treatment event times.
 
     This verifies the design: ATT estimates are computed for both:
+
     - Post-treatment periods (event_time >= 0): actual treatment effects
     - Pre-treatment periods (event_time < 0): placebo check for parallel trends
     """

--- a/causalpy/tests/test_validate_docstring_lists.py
+++ b/causalpy/tests/test_validate_docstring_lists.py
@@ -1,0 +1,206 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for ``scripts/validate_docstring_lists.py``.
+
+These tests guard the local pre-commit hook added in #892. Without them the
+fixer/checker pair could silently regress (the docstring fixes were authored
+before the checker existed, so we need explicit positive evidence that the
+checker actually rejects every shape of offender it claims to cover).
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "validate_docstring_lists.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location(
+        "validate_docstring_lists", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script_module():
+    return _load_script_module()
+
+
+@pytest.mark.parametrize("marker", ["-", "*", "+"])
+def test_flags_inline_bullet_list_for_each_marker(
+    tmp_path: Path, script_module, marker: str
+) -> None:
+    """The checker must flag every bullet-marker style RST/Markdown allows."""
+    src = (
+        f"def f():\n"
+        f'    """Summary.\n'
+        f"\n"
+        f"    Returns\n"
+        f"    -------\n"
+        f"    dict\n"
+        f"        Dictionary with keys:\n"
+        f'        {marker} "a": value\n'
+        f'        {marker} "b": value\n'
+        f'    """\n'
+        f"    return {{}}\n"
+    )
+    target = tmp_path / "broken.py"
+    target.write_text(src)
+
+    findings = script_module.check_file(target)
+
+    assert findings, f"checker missed inline list with marker {marker!r}"
+    assert all(path == target for path, _, _ in findings)
+
+
+def test_passes_when_blank_line_separates_bullets(
+    tmp_path: Path, script_module
+) -> None:
+    """Properly formatted lists must not produce findings."""
+    src = (
+        "def f():\n"
+        '    """Summary.\n'
+        "\n"
+        "    Returns\n"
+        "    -------\n"
+        "    dict\n"
+        "        Dictionary with keys:\n"
+        "\n"
+        '        - "a": value\n'
+        '        - "b": value\n'
+        '    """\n'
+        "    return {}\n"
+    )
+    target = tmp_path / "clean.py"
+    target.write_text(src)
+
+    assert script_module.check_file(target) == []
+
+
+def test_does_not_flag_bullet_continuation_lines(tmp_path: Path, script_module) -> None:
+    """A second bullet whose preceding line is a wrapped first bullet must
+    not be flagged. This is the false-positive class the checker explicitly
+    avoids by treating bullet-prefixed previous lines (and their wraps) as
+    list context rather than introductory prose.
+    """
+    src = (
+        "def f():\n"
+        '    """Summary.\n'
+        "\n"
+        "    Notes\n"
+        "    -----\n"
+        "    Cases:\n"
+        "\n"
+        "    - First bullet whose description wraps onto a second line\n"
+        "      and ends without a colon\n"
+        "    - Second bullet, immediately after the wrap line\n"
+        '    """\n'
+        "    return None\n"
+    )
+    target = tmp_path / "wrap.py"
+    target.write_text(src)
+
+    assert script_module.check_file(target) == []
+
+
+def test_does_not_flag_list_when_intro_lacks_trailing_colon(
+    tmp_path: Path, script_module
+) -> None:
+    """The checker is intentionally conservative: it only flags the ``intro:``
+    pattern, since that's the unambiguous Napoleon-collapse case from #892.
+    Lists introduced by other prose (no trailing colon) are not flagged to
+    avoid false positives on prose that happens to be followed by a list.
+    """
+    src = (
+        "def f():\n"
+        '    """Summary.\n'
+        "\n"
+        "    Some prose without a trailing colon\n"
+        "    - this is not flagged\n"
+        '    """\n'
+        "    return None\n"
+    )
+    target = tmp_path / "no_colon.py"
+    target.write_text(src)
+
+    assert script_module.check_file(target) == []
+
+
+def test_cli_exits_nonzero_when_offenders_present(tmp_path: Path) -> None:
+    """End-to-end CLI smoke test: invoking the script with a broken file
+    must exit with a non-zero status, matching how pre-commit drives it.
+    """
+    broken = (
+        "def f():\n"
+        '    """Summary.\n'
+        "\n"
+        "    Returns\n"
+        "    -------\n"
+        "    dict\n"
+        "        Dictionary with keys:\n"
+        '        - "a": value\n'
+        '    """\n'
+        "    return {}\n"
+    )
+    target = tmp_path / "broken.py"
+    target.write_text(broken)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "Inline bullet list detected" in result.stdout
+
+
+def test_cli_exits_zero_on_clean_file(tmp_path: Path) -> None:
+    """The CLI must succeed when given a properly-formatted file."""
+    clean = (
+        "def f():\n"
+        '    """Summary.\n'
+        "\n"
+        "    Returns\n"
+        "    -------\n"
+        "    dict\n"
+        "        Dictionary with keys:\n"
+        "\n"
+        '        - "a": value\n'
+        '    """\n'
+        "    return {}\n"
+    )
+    target = tmp_path / "clean.py"
+    target.write_text(clean)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), str(target)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == ""

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -210,6 +210,7 @@ def check_convex_hull_violation(
     -------
     dict
         Dictionary with keys:
+
         - 'passes': bool - whether the check passes
         - 'n_violations': int - number of time points with violations
         - 'pct_above': float - percentage of points where treated > max(controls)

--- a/causalpy/variable_selection_priors.py
+++ b/causalpy/variable_selection_priors.py
@@ -238,6 +238,7 @@ class VariableSelectionPrior:
     Built on top of pymc-extras Prior class for consistency and interoperability.
 
     Supported prior types:
+
     - 'spike_and_slab': Mixture prior with near-zero spike and diffuse slab
     - 'horseshoe': Continuous shrinkage with adaptive regularization
     - 'normal': Standard normal prior (no selection, for comparison)
@@ -250,18 +251,21 @@ class VariableSelectionPrior:
         Hyperparameters specific to the chosen prior type. If None, defaults are used.
 
         For 'spike_and_slab':
+
             - pi_alpha: float (default=2) - Beta prior alpha for selection probability
             - pi_beta: float (default=2) - Beta prior beta for selection probability
             - slab_sigma: float (default=2) - SD of slab (non-zero) component
             - temperature: float (default=0.1) - Relaxation parameter for binary approximation
 
         For 'horseshoe':
+
             - tau0: float (default=None) - Global shrinkage, auto-computed if None
             - nu: float (default=3) - Degrees of freedom for half-t prior on tau
             - c2_alpha: float (default=2) - InverseGamma alpha for regularization
             - c2_beta: float (default=2) - InverseGamma beta for regularization
 
         For 'normal':
+
             - mu: float or array (default=0) - Prior mean
             - sigma: float or array (default=1) - Prior SD
 
@@ -445,6 +449,7 @@ class VariableSelectionPrior:
         -------
         dict
             Dictionary with keys:
+
             - 'probabilities': Array of inclusion probabilities per coefficient
             - 'selected': Boolean array indicating which are selected
             - 'gamma_mean': Mean of gamma (indicator) variables
@@ -509,6 +514,7 @@ class VariableSelectionPrior:
         -------
         dict
             Dictionary with keys:
+
             - 'shrinkage_factors': Array of shrinkage factors per coefficient
             - 'tau': Global shrinkage parameter
             - 'lambda_tilde': Regularized local shrinkage parameters

--- a/scripts/validate_docstring_lists.py
+++ b/scripts/validate_docstring_lists.py
@@ -1,0 +1,122 @@
+"""Validate that bullet lists in Python docstrings have a blank line before them.
+
+This catches the rendering defect tracked in issue #892, where Sphinx's Napoleon
+extension collapses an inline ``-`` bullet list (one that follows a non-blank
+prose line ending in ``:``) into a single paragraph of literal hyphens. The fix
+is to leave a blank line between the introductory sentence and the list. RST
+requires that blank line; numpydoc-validation and ruff/pydocstyle don't enforce
+it because they don't inspect section bodies.
+
+Usage
+-----
+
+Run on a list of files (as pre-commit invokes it):
+
+    python scripts/validate_docstring_lists.py path/to/file.py [...]
+
+Or scan the package by default:
+
+    python scripts/validate_docstring_lists.py
+
+Exits with code 1 if any offending docstrings are found and prints their
+locations; exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+
+
+def _docstring_node_lineno(node: ast.AST) -> int:
+    """Line number where this node's docstring starts (1-indexed)."""
+    if isinstance(node, ast.Module):
+        return 1
+    body = getattr(node, "body", None)
+    if not body or not isinstance(body[0], ast.Expr):
+        return getattr(node, "lineno", 1)
+    return body[0].lineno
+
+
+def _find_offenders_in_docstring(doc: str, base_lineno: int) -> list[int]:
+    """Return absolute line numbers of bullet lines lacking a leading blank.
+
+    A line is flagged when it starts with ``- `` (after leading whitespace) and
+    the immediately preceding line is non-blank, ends with ``:``, and is not
+    itself a bullet line. This matches the Napoleon-collapse pattern from #892
+    and avoids false positives on bullet-continuation lines.
+    """
+    offenders: list[int] = []
+    lines = doc.split("\n")
+    for i in range(1, len(lines)):
+        cur_stripped = lines[i].lstrip()
+        prev_stripped = lines[i - 1].rstrip()
+        if not cur_stripped.startswith("- "):
+            continue
+        if not prev_stripped:
+            continue
+        prev_lstripped = prev_stripped.lstrip()
+        if prev_lstripped.startswith(("- ", "* ")):
+            continue
+        if not prev_stripped.endswith(":"):
+            continue
+        offenders.append(base_lineno + i)
+    return offenders
+
+
+def check_file(path: Path) -> list[tuple[Path, int, str]]:
+    """Return a list of (path, lineno, qualified_name) findings for a file."""
+    try:
+        src = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        return []
+
+    findings: list[tuple[Path, int, str]] = []
+    for node in ast.walk(tree):
+        if not isinstance(
+            node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)
+        ):
+            continue
+        doc = ast.get_docstring(node, clean=False)
+        if not doc:
+            continue
+        base = _docstring_node_lineno(node)
+        for lineno in _find_offenders_in_docstring(doc, base):
+            name = getattr(node, "name", "<module>")
+            findings.append((path, lineno, name))
+    return findings
+
+
+def _iter_target_files(args: list[str]) -> list[Path]:
+    if args:
+        return [Path(a) for a in args if a.endswith(".py")]
+    return list(Path("causalpy").rglob("*.py"))
+
+
+def main(argv: list[str]) -> int:
+    findings: list[tuple[Path, int, str]] = []
+    for path in _iter_target_files(argv):
+        findings.extend(check_file(path))
+
+    if not findings:
+        return 0
+
+    print(
+        "Inline bullet list detected without a preceding blank line in the "
+        "following docstrings. Sphinx Napoleon will render these as a single "
+        "paragraph of literal hyphens (see issue #892). Insert a blank line "
+        "between the introductory line and the first bullet."
+    )
+    print()
+    for path, lineno, name in findings:
+        print(f"  {path}:{lineno}: {name}")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/validate_docstring_lists.py
+++ b/scripts/validate_docstring_lists.py
@@ -39,25 +39,32 @@ def _docstring_node_lineno(node: ast.AST) -> int:
     return body[0].lineno
 
 
+# RST and CommonMark both accept ``-``, ``*``, and ``+`` as bullet markers,
+# each followed by whitespace. Track all three so we don't miss alternative
+# bullet styles (or false-positive on continuation lines that use them).
+_BULLET_PREFIXES: tuple[str, ...] = ("- ", "* ", "+ ")
+
+
 def _find_offenders_in_docstring(doc: str, base_lineno: int) -> list[int]:
     """Return absolute line numbers of bullet lines lacking a leading blank.
 
-    A line is flagged when it starts with ``- `` (after leading whitespace) and
-    the immediately preceding line is non-blank, ends with ``:``, and is not
-    itself a bullet line. This matches the Napoleon-collapse pattern from #892
-    and avoids false positives on bullet-continuation lines.
+    A line is flagged when it starts with a bullet marker (``-``, ``*``, or
+    ``+`` followed by whitespace) and the immediately preceding line is
+    non-blank, ends with ``:``, and is not itself a bullet line. This matches
+    the Napoleon-collapse pattern from #892 and avoids false positives on
+    bullet-continuation lines.
     """
     offenders: list[int] = []
     lines = doc.split("\n")
     for i in range(1, len(lines)):
         cur_stripped = lines[i].lstrip()
         prev_stripped = lines[i - 1].rstrip()
-        if not cur_stripped.startswith("- "):
+        if not cur_stripped.startswith(_BULLET_PREFIXES):
             continue
         if not prev_stripped:
             continue
         prev_lstripped = prev_stripped.lstrip()
-        if prev_lstripped.startswith(("- ", "* ")):
+        if prev_lstripped.startswith(_BULLET_PREFIXES):
             continue
         if not prev_stripped.endswith(":"):
             continue
@@ -109,8 +116,8 @@ def main(argv: list[str]) -> int:
     print(
         "Inline bullet list detected without a preceding blank line in the "
         "following docstrings. Sphinx Napoleon will render these as a single "
-        "paragraph of literal hyphens (see issue #892). Insert a blank line "
-        "between the introductory line and the first bullet."
+        "paragraph of prose with the bullet markers inlined (see issue #892). "
+        "Insert a blank line between the introductory line and the first bullet."
     )
     print()
     for path, lineno, name in findings:


### PR DESCRIPTION
# PR: Fix Returns/Notes inline bullet list rendering across docstrings

Closes #892

## Issue Summary

Sphinx's Napoleon extension was collapsing inline `-` bullet lists into a single paragraph of literal hyphens whenever a numpydoc section body contained a list that was not separated from its introductory sentence by a blank line. The most visible offender was `InterruptedTimeSeries.analyze_persistence`, but the pattern existed across many public methods in the library.

## Root Cause

reStructuredText (and therefore Napoleon) requires a blank line between introductory prose and a bullet list, otherwise the `-` markers are read as inline punctuation in the same paragraph. Neither `numpydoc-validation` nor `ruff/pydocstyle` inspect section *body* content, so the defect could be introduced silently and was only visible in rendered HTML.

## Solution

1. Sweep `causalpy/` and insert a blank line between every list-introducing line (ending in `:`) and the first bullet in `Returns`, `Parameters`, `Notes`, and class/extended-summary bodies.
2. Add a small local pre-commit hook (`validate-docstring-lists`) that walks Python ASTs, extracts each docstring, and fails the commit if any section body has a `- `, `* `, or `+ ` bullet immediately following a non-blank, non-bullet line ending in `:`. This prevents regression and shoulders the gap left by `numpydoc-validation` / `ruff`.

## Changes Made

- Inserted a blank line before every inline bullet list inside `Parameters`, `Returns`, and class/extended-summary blocks. Files touched:
  - `causalpy/experiments/base.py`: `effect_summary` Parameters (window, direction).
  - `causalpy/experiments/interrupted_time_series.py`: class docstring, `_split_post_period`, `analyze_persistence` (Returns), `effect_summary`.
  - `causalpy/experiments/synthetic_control.py`: `effect_summary`.
  - `causalpy/experiments/panel_regression.py`: class docstring (`fe_method`), `plot_trajectories`, `plot_residuals`.
  - `causalpy/experiments/staggered_did.py`: `_aggregate_effects`.
  - `causalpy/experiments/inverse_propensity_weighting.py`: `_compute_ate_robust`, `_compute_ate_raw`, `_compute_ate_overlap`, `_compute_ate_doubly_robust`, `get_ate` (5 Returns blocks).
  - `causalpy/pymc_models.py`: `calculate_impact` (Notes), `WeightedSumFitter.priors_from_data`, `SoftmaxWeightedSumFitter.priors_from_data`, `fit_outcome_model`, `_prepare_time_and_exog_features`.
  - `causalpy/utils.py`: `check_convex_hull_violation`.
  - `causalpy/variable_selection_priors.py`: class docstring (Supported prior types, hyperparams subsections), `get_inclusion_probabilities`, `get_shrinkage_factors`.
  - `causalpy/data/simulate_data.py`: `generate_staggered_did_data`, `generate_piecewise_its_data`.
  - `causalpy/tests/test_staggered_did.py`, `causalpy/tests/conftest.py`, `causalpy/tests/test_hdi_prob_defaults.py`: consistency fixes in test docstrings (including two `*`-bullet sites).
- `scripts/validate_docstring_lists.py` (new): AST-based validation script. Recognizes all three RST/CommonMark bullet markers (`-`, `*`, `+`).
- `.pre-commit-config.yaml`: registers `validate-docstring-lists` as a local hook scoped to `^causalpy/.*\.py$` (excluding tests).

## Testing

- [x] `prek run --all-files` passes (including the new `validate-docstring-lists` hook).
- [x] `make html` builds successfully; remaining warnings are all pre-existing and unrelated to this change (third-party PyMC `Model.debug` docstring, duplicate citation keys, and a missing bib key for `goodman2021difference`).
- [x] Spot-checked rendered HTML for `InterruptedTimeSeries.analyze_persistence`, `SyntheticControl.effect_summary`, and `PanelRegression` — all bullets now render as proper `<ul>` lists rather than as inline hyphens.
- [x] Validation script verified on a synthetic broken docstring (exits 1 with a clear error message).

## Notes

- A read-the-docs preview should confirm the bullets render correctly in the hosted documentation.
- Items 2 and 3 of the original issue (the numpydoc `default=...` slot and `causalpy.constants` autosummary) are tracked under #886 and remain out of scope here, as the issue specified.
- Follow-ups opened separately:
  - #898: widen `numpydoc-validation` checks beyond `PR01/PR02` and beyond `.plot` methods.
  - #899: add PyMarkdown pre-commit hook to lint repository `.md` files.