### PR TITLE
Add PyMarkdown pre-commit hook for repository Markdown files

### DIFF
--- a/.cursor/agents/ci-failure-investigator.md
+++ b/.cursor/agents/ci-failure-investigator.md
@@ -9,6 +9,7 @@ You are a skeptical CI failure investigator for the CausalPy repository.
 Your goal is to reduce noisy CI output into a precise, maintainer-actionable fix plan.
 
 When invoked:
+
 1. Identify all failing checks/jobs and group by failure family:
    - lint/type/format
    - unit/integration tests

--- a/.cursor/agents/merge-conflict-analyst.md
+++ b/.cursor/agents/merge-conflict-analyst.md
@@ -9,6 +9,7 @@ You are a cautious merge conflict analyst for the CausalPy repository.
 Your purpose is to resolve conflicts safely by preserving intended behavior, not just producing a clean merge.
 
 Operating mode:
+
 - Default to analysis-first.
 - Auto-apply only low-risk, clearly mechanical resolutions.
 - Escalate ambiguous or high-risk conflicts to maintainer decision.

--- a/.cursor/commands/causalpy_methods.md
+++ b/.cursor/commands/causalpy_methods.md
@@ -1,5 +1,6 @@
 # Causal Methods
 
 This command points to Skills in `.github/skills/`:
+
 - `designing-experiments` for method selection
 - `performing-causal-analysis` for method usage and references

--- a/.github/skills/github-issues/SKILL.md
+++ b/.github/skills/github-issues/SKILL.md
@@ -8,17 +8,20 @@ description: Create, evaluate, and triage GitHub issues for CausalPy. Use when f
 This skill covers issue creation, bug reporting, and issue evaluation workflows.
 
 ## When to use
+
 - Filing a new issue (bug, enhancement, or task)
 - Evaluating an existing issue and proposing next steps
 - Preparing issue content for user review before posting
 - Breaking large work into one parent issue with sub-issues
 
 ## References
+
 - [Issue creation workflow](reference/issue-creation.md)
 - [Bug report workflow](reference/bug-report.md)
 - [Issue evaluation workflow](reference/issue-evaluation.md)
 - [Parent-child sub-issues workflow](reference/parent-child-issues.md)
 
 ## Important behavior
+
 - If native sub-issues are not available, do not silently switch to fallback.
 - Explain the limitation and ask the user whether to proceed with markdown tracking links.

--- a/.github/skills/github-issues/reference/bug-report.md
+++ b/.github/skills/github-issues/reference/bug-report.md
@@ -6,22 +6,27 @@ description: Transform a discovered bug into a well-documented GitHub issue.
 # Bug Report Workflow
 
 ## Gather information
+
 - Error message or unexpected behavior
 - Steps to reproduce (if known)
 - Relevant code or notebook
 
 ## Investigate
+
 - Locate relevant source code
 - Reproduce with a minimal example if possible
 - Check for duplicates:
+
   ```bash
   gh issue list --state open --search "<keywords>"
   ```
 
 ## Draft issue
+
 Create `.scratch/issue_summaries/<short-description>.md` with the bug-specific template below, then follow the general issue creation steps in `issue-creation.md` for review, creation, labeling, and cleanup.
 
 Bug-specific template:
+
 ```markdown
 ## Description
 <Clear, concise description of the bug>
@@ -49,5 +54,6 @@ Bug-specific template:
 ```
 
 ## Next steps
+
 - Present the draft for review.
 - Use the `issue-creation` workflow to file and label the issue.

--- a/.github/skills/github-issues/reference/issue-creation.md
+++ b/.github/skills/github-issues/reference/issue-creation.md
@@ -6,10 +6,12 @@ description: Create a GitHub issue with a reviewed markdown body and appropriate
 # Issue Creation Workflow
 
 ## Prerequisites
+
 1. Verify GitHub CLI is installed: `gh --version`
 2. Check authentication: `gh auth status`
 
 ## Drafting the issue
+
 1. Create a markdown file in `.scratch/issue_summaries/` (e.g., `issue.md`) with:
    - Problem statement or feature request
    - Steps to reproduce (for bugs)
@@ -20,12 +22,15 @@ description: Create a GitHub issue with a reviewed markdown body and appropriate
 3. Do not hard-wrap lines in markdown drafts; keep paragraphs on a single line.
 
 ## Create the issue
+
 After approval, run:
+
 ```bash
 gh issue create --title "<descriptive title>" --body-file .scratch/issue_summaries/issue.md
 ```
 
 Add labels with `--label`, e.g.:
+
 ```bash
 gh issue create --title "<descriptive title>" --body-file .scratch/issue_summaries/issue.md --label "bug"
 ```

--- a/.github/skills/github-issues/reference/issue-evaluation.md
+++ b/.github/skills/github-issues/reference/issue-evaluation.md
@@ -6,6 +6,7 @@ description: Analyze an issue, check current relevance, and propose next steps o
 # Issue Evaluation Workflow
 
 ## Fetch issue details
+
 ```bash
 gh issue view <issue_number> --json number,title,body,state,labels,comments,assignees
 ```
@@ -26,20 +27,24 @@ gh api graphql -f query='query {
 ```
 
 ## Analyze context
+
 - Extract the problem statement and acceptance criteria
 - Summarize discussion history and blockers
 - Identify affected files/modules
 - Review sub-issues (if any) for work breakdown and progress
 
 ## Assess relevance
+
 - Search codebase for mentioned APIs or modules
 - Check related PRs and closed issues:
-  ```bash
+
+```bash
   gh pr list --search "in:title <keywords>" --json number,title,state,url
   gh issue list --state closed --search "<keywords>" --json number,title,url --limit 5
   ```
 
 ## Recommendation categories
+
 - **Resolved**: recommend closing with rationale
 - **Blocked**: note dependency and workarounds
 - **Needs info**: ask targeted questions
@@ -47,7 +52,9 @@ gh api graphql -f query='query {
 - **Needs decision**: present options with trade-offs
 
 ## Draft comment
+
 Create `.scratch/issue_comments/issue-<number>-evaluation.md` with:
+
 ```markdown
 *This comment was generated with LLM assistance and may have been edited by the commenter.*
 

--- a/.github/skills/github-issues/reference/parent-child-issues.md
+++ b/.github/skills/github-issues/reference/parent-child-issues.md
@@ -43,6 +43,7 @@ gh api graphql -f query='query { __type(name:"Mutation") { fields { name } } }'
 ## 3) Draft issue bodies for user review
 
 Create markdown drafts in `.scratch/issue_summaries/` for:
+
 - one parent tracking issue
 - one draft per child issue
 

--- a/.github/skills/performing-causal-analysis/reference/diff_in_diff.md
+++ b/.github/skills/performing-causal-analysis/reference/diff_in_diff.md
@@ -17,6 +17,7 @@ causalpy.experiments.DifferenceInDifferences(
 ```
 
 ### Parameters
+
 *   **`data`** (`pd.DataFrame`): Input dataframe containing panel data.
 *   **`formula`** (`str`): Statistical formula (e.g., `"y ~ 1 + group * post_treatment"`).
 *   **`time_variable_name`** (`str`): Column name for the time variable.
@@ -25,6 +26,7 @@ causalpy.experiments.DifferenceInDifferences(
 *   **`model`**: A PyMC model (e.g., `cp.pymc_models.LinearRegression`) or a Scikit-Learn Regressor.
 
 ### How it Works
+
 1.  **Fit**: The model fits all available data (pre/post, treatment/control).
 2.  **Counterfactual**: Predicted by setting the interaction term between `group` and `post_treatment` to 0.
 3.  **Impact**: The causal impact is the difference between observed and counterfactual.

--- a/.github/skills/performing-causal-analysis/reference/interrupted_time_series.md
+++ b/.github/skills/performing-causal-analysis/reference/interrupted_time_series.md
@@ -15,12 +15,14 @@ causalpy.experiments.InterruptedTimeSeries(
 ```
 
 ### Parameters
+
 *   **`data`** (`pd.DataFrame`): Input dataframe. Index should ideally be a `pd.DatetimeIndex`.
 *   **`treatment_time`** (`Union[int, float, pd.Timestamp]`): The point in time when the intervention occurred.
 *   **`formula`** (`str`): Statistical formula (e.g., `"y ~ 1 + t + C(month)"`).
 *   **`model`**: A PyMC model (e.g., `cp.pymc_models.LinearRegression`) or a Scikit-Learn Regressor.
 
 ### How it Works
+
 1.  **Split**: Data is split into pre- and post-intervention.
 2.  **Fit**: Model is trained **only on pre-intervention data**.
 3.  **Predict**: Fitted model predicts the outcome for the post-intervention period.

--- a/.github/skills/performing-causal-analysis/reference/synthetic_control.md
+++ b/.github/skills/performing-causal-analysis/reference/synthetic_control.md
@@ -16,6 +16,7 @@ causalpy.experiments.SyntheticControl(
 ```
 
 ### Parameters
+
 *   **`data`** (`pd.DataFrame`): Input dataframe containing panel data.
 *   **`treatment_time`** (`Union[int, float, pd.Timestamp]`): The time of intervention.
 *   **`control_units`** (`List[str]`): List of column names representing the control units.
@@ -23,6 +24,7 @@ causalpy.experiments.SyntheticControl(
 *   **`model`**: A PyMC model (typically `cp.pymc_models.WeightedSumFitter`) or a Scikit-Learn Regressor.
 
 ### How it Works
+
 1.  **Fit**: Model learns weights for `control_units` to approximate `treated_units` using **only pre-intervention data**.
 2.  **Predict**: Weights are applied to `control_units` in post-intervention period.
 3.  **Impact**: Difference between observed treated unit and synthetic counterfactual.

--- a/.github/skills/pr-to-green/SKILL.md
+++ b/.github/skills/pr-to-green/SKILL.md
@@ -8,12 +8,14 @@ description: Bring a pull request to green by syncing with main, resolving confl
 This skill provides a deterministic maintainer workflow for taking an in-flight PR branch to green.
 
 ## When to use
+
 - A PR is behind `main` and needs sync/rebase
 - There are merge conflicts to resolve intelligently
 - Remote checks are failing (tests, docs, lint, or packaging)
 - You need a concise update for the PR describing what was fixed and what remains
 
 ## Preconditions
+
 - Confirm branch and remotes before making git changes
 - Preserve user/unrelated local modifications; never discard unknown work
 - Use CausalPy environment commands:
@@ -123,6 +125,7 @@ Scope-drift report must include:
 - the recommended next step and why
 
 ## CausalPy guardrails
+
 - Never use destructive git commands unless explicitly requested
 - Do not create ad hoc test scripts; use `pytest` tests in `causalpy/tests/`
 - Keep PyMC-heavy tests runtime-controlled via `sample_kwargs`

--- a/.github/skills/pr-workflows/SKILL.md
+++ b/.github/skills/pr-workflows/SKILL.md
@@ -8,11 +8,13 @@ description: Turn issues into PRs, handle commits, and run prek checks consisten
 This skill covers the end-to-end PR flow, including commits and prek usage.
 
 ## When to use
+
 - Turning an issue into a PR
 - Preparing commits and PR summaries
 - Running prek checks and fixing hook output
 
 ## References
+
 - [Issue to PR workflow](reference/issue-to-pr.md)
 - [Committing changes](reference/committing.md)
 - [Prek usage](reference/pre-commit.md)

--- a/.github/skills/pr-workflows/reference/committing.md
+++ b/.github/skills/pr-workflows/reference/committing.md
@@ -6,6 +6,7 @@ description: Create clean, focused commits with user confirmation and prek check
 # Committing Changes
 
 ## Process
+
 1. Review changes:
    - `git status`
    - `git diff`
@@ -14,10 +15,12 @@ description: Create clean, focused commits with user confirmation and prek check
 4. Ask for user confirmation before committing.
 
 ## Commit steps
+
 1. Run prek (see `pre-commit.md` for details). Prefer scoped runs while iterating, then `prek run --all-files` before final commit.
 2. Stage only relevant files (avoid `git add -A` / `git add .`).
 3. Create the commit with a clear message.
 
 ## Notes
+
 - Commits should be authored by the user (no co-author lines).
 - If hooks modify files, re-add and retry the commit.

--- a/.github/skills/pr-workflows/reference/issue-to-pr.md
+++ b/.github/skills/pr-workflows/reference/issue-to-pr.md
@@ -6,24 +6,30 @@ description: Transform a GitHub issue into a complete pull request through a str
 # Issue → PR Workflow
 
 ## Branch preflight (required before any code edits)
+
 1. Check current branch and working tree state.
 2. Switch to `main` and update it from remote.
 3. Create the issue branch from `main`: `git checkout -b issue-<issue_number>-<short-description>`
 4. Only start implementation after confirming the new branch is based on `main`.
 
 ## Discovery
+
 1. Fetch issue details:
+
    ```bash
    gh issue view <issue_number> --json title,body,labels,comments,state
    ```
+
 2. Summarize the problem, acceptance criteria, and affected files.
 3. Estimate complexity and share approach before implementation.
 
 ## Implementation
+
 1. Implement the fix, following `AGENTS.md` policies.
 2. Run prek and tests until green (see `pre-commit.md`). Use scoped prek runs during iteration and `--all-files` before handoff.
 
 ## Prepare PR
+
 1. Create `.scratch/pr_summaries/<issue_number> - <short-description>.md` with:
    - Summary
    - Fixes #<issue_number>
@@ -34,6 +40,7 @@ description: Transform a GitHub issue into a complete pull request through a str
 3. Commit changes following `committing.md`.
 
 ## Create PR
+
 ```bash
 git push -u origin issue-<issue_number>-<short-description>
 gh pr create --title "<PR title>" --body-file .scratch/pr_summaries/<issue_number> - <short-description>.md --base main

--- a/.github/skills/pr-workflows/reference/pre-commit.md
+++ b/.github/skills/pr-workflows/reference/pre-commit.md
@@ -6,6 +6,7 @@ description: Run prek checks and handle auto-fix output.
 # Prek Usage
 
 ## Run checks
+
 ```bash
 # Fast iteration on changed files
 prek run --files path/to/file.py
@@ -15,10 +16,12 @@ prek run --all-files
 ```
 
 ## If hooks modify files
+
 1. Re-stage modified files.
 2. Re-run prek if needed.
 3. Commit after the working tree is clean.
 
 ## Common fixes
+
 - Formatting or lint auto-fixes
 - Regenerated docs/assets

--- a/.github/skills/research-and-planning/SKILL.md
+++ b/.github/skills/research-and-planning/SKILL.md
@@ -8,5 +8,6 @@ description: Perform structured research and turn findings into an implementatio
 Use this skill to clarify requirements and produce a plan before implementation.
 
 ## References
+
 - [Research workflow](reference/research.md)
 - [Plan creation workflow](reference/make-plan.md)

--- a/.github/skills/research-and-planning/reference/make-plan.md
+++ b/.github/skills/research-and-planning/reference/make-plan.md
@@ -6,11 +6,13 @@ description: Create an implementation plan from research findings.
 # Plan Creation Workflow
 
 ## Requirements
+
 - Define a clear to-do list
 - Verify assumptions against the codebase
 - Note missing information or open risks
 
 ## Suggested structure
+
 1. Goal and non-goals
 2. Scope and affected areas
 3. Step-by-step plan

--- a/.github/skills/research-and-planning/reference/research.md
+++ b/.github/skills/research-and-planning/reference/research.md
@@ -6,12 +6,14 @@ description: Structure research to understand what needs to change and propose o
 # Research Workflow
 
 ## Goals
+
 - Restate the user request precisely.
 - Identify relevant files and APIs.
 - Determine what needs to change and possible impacts.
 - Compare options and select the most practical approach.
 
 ## Steps
+
 1. Review request and context.
 2. Inspect relevant files (code and docs).
 3. Identify impacted areas and dependencies.
@@ -19,4 +21,5 @@ description: Structure research to understand what needs to change and propose o
 5. Record assumptions and risks.
 
 ## Output
+
 - A concise research summary and a recommended approach.

--- a/.github/skills/working-with-marimo/SKILL.md
+++ b/.github/skills/working-with-marimo/SKILL.md
@@ -31,4 +31,5 @@ Follows a **Plan-Execute-Verify** loop to ensure notebook correctness.
 *   **Plots**: Use `plt.gca()` or return figure. **No `plt.show()`**.
 
 ## Reference
+
 See [Best Practices](reference/best_practices.md) for code formatting, reactivity rules, and UI element usage.

--- a/.github/skills/working-with-marimo/reference/best_practices.md
+++ b/.github/skills/working-with-marimo/reference/best_practices.md
@@ -1,29 +1,35 @@
 # Marimo Best Practices
 
 ## CausalPy Specifics
+
 *   **Data**: Use **Pandas** (standard for CausalPy), even though generic marimo docs suggest Polars.
 *   **Plotting**: Use **Matplotlib**, **Seaborn**, or **Arviz**. **Avoid Altair**.
 *   **Display**: Return the figure/axis object or use `plt.gca()` as the last expression. **Do NOT use `plt.show()`**.
 
 ## Code Structure
+
 *   **Decorators**: Every cell must start with `@app.cell` and define a function `def _():`.
 *   **Imports**: Put all imports in one cell (usually the first). Always import `marimo as mo`.
 *   **No Globals**: Variables are local to cells unless returned; marimo handles state passing.
 *   **Reactivity**: Cells run automatically when inputs change. **Avoid cycles**.
 
 ## Visualizations & Outputs
+
 *   **Separation**: Do NOT mix `mo.md` and plots in the same cell. Create a markdown cell, then a plot cell.
 *   **Last Expression**: The last line of a cell is automatically displayed.
 
 ## Data & SQL
+
 *   **DuckDB**: Use `df = mo.sql(f"""SELECT ...""")`.
 *   **Comments**: Do NOT put comments inside `mo.sql` strings or Markdown cells.
 
 ## UI Elements
+
 *   **Access**: Use `.value` (e.g., `slider.value`).
 *   **Definition**: Define UI element in one cell, access value in another to avoid cycles.
 
 ## Example Cell
+
 ```python
 @app.cell
 def _():

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,16 @@ repos:
     rev: v0.25
     hooks:
       - id: validate-pyproject
+  # Lint repository Markdown files (issue #899). Configuration lives in
+  # ``[tool.pymarkdown]`` of pyproject.toml. Notebook Markdown cells and the
+  # generated docs build are intentionally out of scope.
+  - repo: https://github.com/jackdewinter/pymarkdown
+    rev: v0.9.36
+    hooks:
+      - id: pymarkdown
+        args: [scan]
+        files: \.md$
+        exclude: ^(docs/_build/|\.scratch/)
   # Regenerate environment.yml from pyproject.toml when deps change (run on commit; review diff).
   # Dev env uses python>=3.12; conda-only deps (make, pip, pymc-bart, marimo[mcp]) are in args.
   - repo: https://github.com/usnistgov/pyproject2conda

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,7 @@ See the [python-environment skill](.github/skills/python-environment/SKILL.md) f
 - **Scratch files**: Put temporary notes and generated markdown in `.scratch/` (untracked). Move anything that should be kept into a tracked location.
   - **PR drafts**: Create PR summary markdown files in `.scratch/pr_summaries/` (untracked).
   - **Issue drafts**: Create issue draft markdown files in `.scratch/issue_summaries/` (untracked).
-- **Markdown formatting**: Do not hard-wrap lines in markdown files; rely on editor auto-wrapping.
+- **No hard line wrapping in prose-like text**: Do not hard-wrap lines in any prose context — Markdown files, long comments in code (TOML/YAML/Python/etc.), commit-message bodies, PR descriptions, issue descriptions, or GitHub comments. One paragraph = one line; rely on the viewer/editor to re-wrap. Hard wraps look ragged at different widths, make diffs noisy on every reflow, and mangle when copied or quoted. Code itself, code blocks inside Markdown, ASCII tables, and structured config values are exempt — those need their literal line structure.
 
 ## Code structure and style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,6 +77,7 @@ We appreciate being notified of problems with the existing CausalPy code. We pre
 Please verify that your issue is not being currently addressed by other issues or pull requests by using the GitHub search tool to look for key words in the project issue tracker.
 
 ## Use of agents
+
 PR's with agent-generated code are fine. But don't spam us with code you don't understand. See [AGENTS.md](./AGENTS.md) for how we use LLMs in this repo.
 
 ## Contributing code via pull requests
@@ -146,11 +147,11 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
 
     It may also be necessary to [install](https://pandoc.org/installing.html) `pandoc`. On a Mac, run `brew install pandoc`.
 
-	If you are editing or writing new examples in the form of Jupyter notebooks, you may have to run the following command to make Jupyter Lab aware of the `CausalPy` environment.
+    If you are editing or writing new examples in the form of Jupyter notebooks, you may have to run the following command to make Jupyter Lab aware of the `CausalPy` environment.
 
-	```bash
-	conda run -n CausalPy python -m ipykernel install --user --name CausalPy
-	```
+    ```bash
+    conda run -n CausalPy python -m ipykernel install --user --name CausalPy
+    ```
 
 1. You can then work on your changes locally, in your feature branch. Add changed files using `git add` and then `git commit` files:
 
@@ -226,6 +227,7 @@ We recommend that your contribution complies with the following guidelines befor
   ```bash
   make check_lint
   ```
+
   If you want to fix linting errors automatically, run
 
   ```bash
@@ -239,11 +241,14 @@ To build the documentation, run from the **project root**:
 ```bash
 make html
 ```
+
 To clean and rebuild the documentation from scratch:
+
 ```bash
 make cleandocs
 make html
 ```
+
  Docs are built in docs/_build/html, but these docs are not committed to the GitHub repository due to .gitignore.
 
  📌 Note: The previous docs/Makefile has been removed. Please use only the root-level Makefile for documentation commands
@@ -406,6 +411,7 @@ Contributions are welcome from the community. This section describes how contrib
 ### Decision process
 
 #### How people are invited
+
 - A maintainer opens a short nomination discussion (or uses an internal maintainer thread) referencing:
   - contributions (PRs/issues/reviews)
   - areas of ownership
@@ -413,15 +419,18 @@ Contributions are welcome from the community. This section describes how contrib
 - After a short review period, maintainers grant access.
 
 #### Resolving disagreements
+
 - Decisions are made by informal consensus among maintainers.
 - If consensus cannot be reached, a simple majority decides.
 - For project-wide decisions (e.g., major API changes, new maintainers), give at least one week for async discussion before finalizing.
 
 #### How to step down
+
 - Anyone can request to step down at any time.
 - Access can be reduced after long inactivity to minimize risk.
 
 #### A note on Admin access
+
 Admin access is reserved for project leads and is not part of the contributor pathway. Admins handle repository settings, secrets, and GitHub Actions configuration.
 
 ### Role expectations checklist

--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ CausalPy helps you estimate causal effects with transparent assumptions, uncerta
 - **Bayesian-first estimation** via [PyMC](https://www.pymc.io/) with full uncertainty quantification, plus traditional OLS via [scikit-learn](https://scikit-learn.org)
 - **Decision-ready outputs:** Effect summaries with credible intervals (HDI), practical significance (ROPE), and publication-quality plots
 
-
 ## 📞 [**Book a consulting call**](https://calendly.com/benjamin-vincent/causalpy)
 
 CausalPy is built and maintained by [PyMC Labs](https://www.pymc-labs.com). If your team is exploring a consulting engagement for lift testing, complex or high-stakes causal work, you can book an introductory call. _These calls are for consulting inquiries only. For technical usage questions and free community support, please use GitHub Discussions and the documentation below._
@@ -151,7 +150,7 @@ CausalPy emphasizes transparent, uncertainty-aware outputs for rigorous causal a
 
 If you use CausalPy in your research, please cite it. A Zenodo DOI for stable releases is planned. In the meantime, you can cite the repository:
 
-```
+```bibtex
 @software{causalpy,
   author = {{PyMC Labs}},
   title = {CausalPy: Causal inference for quasi-experiments in Python},

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,6 +1,7 @@
 # API
 
 ## Modules
+
 ```{eval-rst}
 .. currentmodule:: causalpy
 .. autosummary::

--- a/docs/source/knowledgebase/causal_video_resources.md
+++ b/docs/source/knowledgebase/causal_video_resources.md
@@ -1,6 +1,5 @@
 # Causal video resources
 
-
 <style>
 .video-container {
     position: relative;
@@ -44,7 +43,6 @@
 <div class="video-container">
     <iframe width="560" height="315" src="https://www.youtube.com/embed/QAzAFess1AA?si=zD6PrljOFUyvjm1I" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
 </div>
-
 
 ## Uncertainty and Causal Inference in Python with CausalPy
 

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -11,6 +11,7 @@ Below is a list of written resources (books, blog posts, etc.) that are useful f
 * Reichardt, C. S. (2019). Quasi-experimentation: A guide to design and analysis. Guilford Publications.
 
 ## Bayesian causal inference resources
+
 * The official [PyMC examples gallery](https://www.pymc.io/projects/examples/en/latest/gallery.html) has a set of examples specifically relating to causal inference.
 
 ## General causal inference resources

--- a/docs/source/knowledgebase/design_notation.md
+++ b/docs/source/knowledgebase/design_notation.md
@@ -43,6 +43,7 @@ This limitation can be addressed by adding a pretest measure. See p115 of {cite:
 | NR: | $O_1$ |   | $O_2$ |
 
 Non-equivalent group designs like this, with a pretest and a posttest measure could be analysed in a number of ways:
+
 1. **{term}`ANCOVA`:** Here, the group would be a categorical predictor (e.g. treated/untreated), the pretest measure would be a covariate (though there could be more than one), and the posttest measure would be the outcome.
 2. **{term}`Difference in differences`:** We can apply linear modeling approaches such as `y ~ group + time + group:time` to estimate the treatment effect. Here, `y` is the outcome measure, `group` is a binary variable indicating treatment or control group, and `time` is a binary variable indicating pretest or posttest. Note that this approach has a strong assumption of [parallel trends](https://en.wikipedia.org/wiki/Difference_in_differences#Assumptions) - that the treatment and control groups would have changed in the same way in the absence of the treatment.
 
@@ -74,7 +75,6 @@ The {term}`comparative interrupted time-series<CITS>` design incorporates aspect
 | NR: | $O_1$ | $O_2$ | $O_3$ | $O_4$ | X | $O_5$ | $O_6$ | $O_7$ | $O_8$ |
 | NR: | $O_1$ | $O_2$ | $O_3$ | $O_4$ |   | $O_5$ | $O_6$ | $O_7$ | $O_8$ |
 
-
 Because this design is very similar to the nonequivalent group design, simply with multiple pre and posttest measures, it is well-suited to analysis under the difference-in-differences approach.
 
 However, if we have many untreated units and one treated unit, then this design could be analysed with the {term}`synthetic control` approach.
@@ -91,4 +91,5 @@ The design notation for {term}`regression discontinuity designs<RDD>` are differ
 From an analysis perspective, regression discontinuity designs are very similar to interrupted time series designs. The key difference is that treatment is determined by a cutoff point along a running variable, rather than by time.
 
 ## Summary
+
 This page has offered a brief overview of the tabular notation used to describe quasi-experimental designs. The notation is a useful tool for summarizing the design of a study, and can be used to help identify the strengths and limitations of a study design. But readers are strongly encouraged to consult the original sources when assessing the relative strengths and limitations of making causal claims under different quasi-experimental designs.

--- a/docs/source/knowledgebase/estimands.md
+++ b/docs/source/knowledgebase/estimands.md
@@ -6,7 +6,7 @@ Understanding **what** a method estimates is just as important as knowing **how*
 
 Following {cite:t}`lundberg2021estimand`, we distinguish three interconnected concepts in causal inference:
 
-```
+```text
 Theoretical Estimand     -->  Empirical Estimand      -->  Estimator
 ```
 

--- a/docs/source/knowledgebase/reporting_statistics.md
+++ b/docs/source/knowledgebase/reporting_statistics.md
@@ -43,6 +43,7 @@ When you use PyMC models, CausalPy performs Bayesian inference, yielding posteri
 ### Point Estimates
 
 **Mean**
+
 - The average of the posterior distribution
 - Represents the expected value of the causal effect
 - **When to use:** Most commonly reported point estimate; balances all posterior information
@@ -72,9 +73,11 @@ The `hdi_prob` parameter controls the interval width (e.g., 0.95 for 95% HDI, 0.
 :::
 
 **Example interpretation:**
-```
+
+```text
 mean: 2.5, 95% HDI: [1.2, 3.8]
 ```
+
 "The estimated effect is 2.5 on average, and we can be 95% certain the true effect lies between 1.2 and 3.8."
 
 ### Hypothesis Testing
@@ -121,9 +124,11 @@ Unlike frequentist p-values, Bayesian posterior probabilities answer the questio
 4. For "two-sided" direction: `p_rope` = P(|effect| > min_effect)
 
 **Example:**
+
 ```python
 result.effect_summary(direction="increase", min_effect=1.0)
 ```
+
 If `p_rope = 0.85`, there's an 85% probability the effect exceeds your meaningful threshold of 1.0.
 
 :::{important}
@@ -163,9 +168,11 @@ Unlike Bayesian estimates, frequentist point estimates don't come with a probabi
 - **Larger standard errors** → wider confidence intervals → more uncertainty
 
 **Example interpretation:**
-```
+
+```text
 mean: 2.5, 95% CI: [1.1, 3.9]
 ```
+
 "The estimated effect is 2.5. If we repeated this study many times, 95% of such confidence intervals would contain the true effect."
 
 :::{important}
@@ -210,6 +217,7 @@ Always report the actual p-value and effect size, not just whether p < 0.05. The
 ## Choosing Between Approaches
 
 ### When to use Bayesian inference (PyMC models):
+
 - ✅ You want direct probability statements about effects
 - ✅ You have prior information to incorporate
 - ✅ You need uncertainty quantification for complex hierarchical models
@@ -217,6 +225,7 @@ Always report the actual p-value and effect size, not just whether p < 0.05. The
 - ✅ Small to moderate sample sizes where uncertainty matters
 
 ### When to use Frequentist inference (OLS models):
+
 - ✅ You need computational speed (OLS is faster)
 - ✅ Your audience expects classical statistical inference
 - ✅ Large sample sizes where approaches converge
@@ -232,6 +241,7 @@ Both approaches are valid and will often lead to similar conclusions, especially
 ## Summary Statistics by Effect Type
 
 ### Scalar Effects (DiD, RD, Regression Kink)
+
 For experiments with a single causal effect parameter:
 
 **Bayesian output:**
@@ -243,6 +253,7 @@ For experiments with a single causal effect parameter:
 - One row with: mean, ci_lower, ci_upper, p_value
 
 ### Time-Series Effects (ITS, Synthetic Control)
+
 For experiments with multiple post-treatment time points:
 
 **Two aggregation levels:**
@@ -283,6 +294,7 @@ print(summary.text)
 ```
 
 ### Basic usage (default Bayesian):
+
 ```python
 import causalpy as cp
 
@@ -296,6 +308,7 @@ print(summary.table)  # Numerical summary
 ```
 
 ### With directional hypothesis:
+
 ```python
 # Test for an increase
 summary = result.effect_summary(direction="increase")  # Reports p_gt_0
@@ -308,6 +321,7 @@ summary = result.effect_summary(direction="two-sided")  # Reports prob_of_effect
 ```
 
 ### With practical significance threshold:
+
 ```python
 # Only care about effects > 2.0
 summary = result.effect_summary(
@@ -320,6 +334,7 @@ print(summary.text)   # Prose interpretation
 ```
 
 ### For time-series experiments with custom window:
+
 ```python
 # ITS or Synthetic Control result
 summary = result.effect_summary(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -222,16 +222,9 @@ ignore_missing_imports = true
 [tool.marimo.runtime]
 watcher_on_save = "autorun"
 
-# PyMarkdown linter (pre-commit hook) configuration.
-# Primary motivator (issue #899) is enforcing MD032 — lists must be surrounded
-# by blank lines — to mirror the docstring rule already enforced by
-# ``validate-docstring-lists`` (issue #892). The rules below are deliberately
-# disabled because they conflict with project conventions or are noisy on the
-# existing Markdown corpus (see PR #899 for the audit).
+# PyMarkdown linter (pre-commit hook) configuration. Primary motivator (issue #899) is enforcing MD032 — lists must be surrounded by blank lines — to mirror the docstring rule already enforced by ``validate-docstring-lists`` (issue #892). The rules below are deliberately disabled because they conflict with project conventions or are noisy on the existing Markdown corpus (see PR #900 for the audit).
 [tool.pymarkdown]
-# Enable GitHub-flavoured / front-matter extensions so the linter understands
-# YAML front-matter (cursor agent / skill files), GFM task lists, tables,
-# strikethrough, and extended autolinks.
+# Enable GitHub-flavoured / front-matter extensions so the linter understands YAML front-matter (cursor agent / skill files), GFM task lists, tables, strikethrough, and extended autolinks.
 extensions.front-matter.enabled = true
 extensions.markdown-task-list-items.enabled = true
 extensions.markdown-tables.enabled = true
@@ -239,8 +232,7 @@ extensions.markdown-strikethrough.enabled = true
 extensions.markdown-extended-autolinks.enabled = true
 # Project convention: do not hard-wrap Markdown lines (see AGENTS.md).
 plugins.md013.enabled = false
-# Many top-level docs (skills, agent definitions, command snippets) start with
-# YAML front-matter or a short paragraph rather than an H1.
+# Many top-level docs (skills, agent definitions, command snippets) start with YAML front-matter or a short paragraph rather than an H1.
 plugins.md041.enabled = false
 # Allow a mix of setext and atx headings across files.
 plugins.md003.enabled = false
@@ -248,8 +240,7 @@ plugins.md003.enabled = false
 plugins.md030.enabled = false
 # Allow varying unordered-list indentation.
 plugins.md007.enabled = false
-# Skill / agent description lines naturally end in punctuation when promoted
-# to headings by the renderer.
+# Skill / agent description lines naturally end in punctuation when promoted to headings by the renderer.
 plugins.md026.enabled = false
 # Bold text used as pseudo-headings is an established pattern in skill files.
 plugins.md036.enabled = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -221,3 +221,43 @@ ignore_missing_imports = true
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"
+
+# PyMarkdown linter (pre-commit hook) configuration.
+# Primary motivator (issue #899) is enforcing MD032 — lists must be surrounded
+# by blank lines — to mirror the docstring rule already enforced by
+# ``validate-docstring-lists`` (issue #892). The rules below are deliberately
+# disabled because they conflict with project conventions or are noisy on the
+# existing Markdown corpus (see PR #899 for the audit).
+[tool.pymarkdown]
+# Enable GitHub-flavoured / front-matter extensions so the linter understands
+# YAML front-matter (cursor agent / skill files), GFM task lists, tables,
+# strikethrough, and extended autolinks.
+extensions.front-matter.enabled = true
+extensions.markdown-task-list-items.enabled = true
+extensions.markdown-tables.enabled = true
+extensions.markdown-strikethrough.enabled = true
+extensions.markdown-extended-autolinks.enabled = true
+# Project convention: do not hard-wrap Markdown lines (see AGENTS.md).
+plugins.md013.enabled = false
+# Many top-level docs (skills, agent definitions, command snippets) start with
+# YAML front-matter or a short paragraph rather than an H1.
+plugins.md041.enabled = false
+# Allow a mix of setext and atx headings across files.
+plugins.md003.enabled = false
+# Allow ``1.  item`` style list-marker spacing produced by some editors.
+plugins.md030.enabled = false
+# Allow varying unordered-list indentation.
+plugins.md007.enabled = false
+# Skill / agent description lines naturally end in punctuation when promoted
+# to headings by the renderer.
+plugins.md026.enabled = false
+# Bold text used as pseudo-headings is an established pattern in skill files.
+plugins.md036.enabled = false
+# Templates and reference docs intentionally repeat heading text.
+plugins.md024.enabled = false
+# Inline HTML (e.g. ``<details>`` blocks) is occasionally used in long-form docs.
+plugins.md033.enabled = false
+# Shell-prompt prefixes (``$ cmd``) are useful in setup instructions.
+plugins.md014.enabled = false
+# Image alt text is enforced in notebooks separately; .md image usage is rare.
+plugins.md045.enabled = false

--- a/scripts/run_notebooks/README.md
+++ b/scripts/run_notebooks/README.md
@@ -25,10 +25,13 @@ The notebook runner mirrors the CI setup and expects a full docs/test environmen
 2. **Install Graphviz (system dependency)**
 
    - macOS:
+
      ```bash
      brew install graphviz
      ```
+
    - Ubuntu/Debian:
+
      ```bash
      sudo apt-get update && sudo apt-get install -y graphviz
      ```


### PR DESCRIPTION
Closes #899.

## Summary

Adds [PyMarkdown](https://pymarkdown.readthedocs.io/) as a `prek`/pre-commit hook so the project's Markdown files (README, AGENTS, CONTRIBUTING, docs, skills, cursor commands/agents, etc.) are linted on every commit. The primary motivator is enforcing **MD032 — Lists should be surrounded by blank lines** to mirror the docstring rule already enforced by `validate-docstring-lists` (issue #892).

## Changes

- `.pre-commit-config.yaml`: Added the `jackdewinter/pymarkdown` hook pinned to `v0.9.36`. Scoped to `\.md$`, excluding `docs/_build/` and `.scratch/` per the issue.
- `pyproject.toml`: Added `[tool.pymarkdown]` configuration. Enables the `front-matter`, GFM task list, table, strikethrough, and extended-autolink extensions so the linter understands skill/agent YAML front-matter and task-list checkboxes. Disables a curated set of style/noisy rules (MD013 line-length, MD041 first-line H1, MD003 heading-style, MD030 list-marker spacing, MD007 ul-indent, MD026 trailing-punctuation, MD036 emphasis-as-heading, MD024 duplicate-headings, MD033 inline-HTML, MD014 shell-prompt, MD045 image-alt). Each disable carries an inline comment explaining the rationale.
- Updated 28 Markdown files so the curated rule set passes on `prek run --all-files`. Edits are mechanical: blank lines added around headings (MD022), lists (MD032), and fenced code blocks (MD031); language hints added to the few remaining bare fences (MD040, e.g. ```` ```bibtex ```` for the BibTeX block in `README.md` and ```` ```text ```` for ASCII illustrations in `docs/source/knowledgebase/`).

## Out of scope (per issue)

- Python docstring lists — already covered by the `validate-docstring-lists` hook from #892.
- Notebook (`.ipynb`) Markdown cells — would require a separate extraction step.

## Testing

- `prek run --all-files` passes (PyMarkdown, ruff, mypy, codespell, numpydoc-validation, validate-notebooks, etc.).
- Spot-checked the auto-fix output: pymarkdown's fix mode mangled an indented fenced code block in `.github/skills/github-issues/reference/bug-report.md` and `scripts/run_notebooks/README.md`; both were corrected by hand.
