### PR TITLE
Cross-link Matplotlib types in API docstring `Returns` blocks (#901)

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -100,25 +100,51 @@ bibtex_default_style = "alpha"
 bibtex_reference_style = "author_year"
 
 
-# numpydoc and autodoc typehints config
-numpydoc_show_class_members = False
-numpydoc_xref_param_type = True
-# fmt: off
-numpydoc_xref_ignore = {
-    "of", "or", "optional", "default", "numeric", "type", "scalar", "1D", "2D", "3D", "nD", "array",
-    "instance", "M", "N"
-}
-# fmt: on
-numpydoc_xref_aliases = {
+# -- Napoleon (NumPy-style docstring) config ----------------------------------
+# We use sphinx.ext.napoleon to parse NumPy-style docstrings. ``napoleon_preprocess_types``
+# turns type strings in ``Parameters``/``Returns`` blocks into cross-references (resolved
+# via intersphinx), so ``matplotlib.figure.Figure`` renders as a link rather than plain
+# text. ``napoleon_type_aliases`` lets docstrings use short forms (e.g. ``Figure``) and
+# have them resolve to the fully-qualified target.
+napoleon_preprocess_types = True
+napoleon_type_aliases = {
+    # matplotlib
+    "Figure": ":class:`~matplotlib.figure.Figure`",
+    "Axes": ":class:`~matplotlib.axes.Axes`",
+    "matplotlib.figure.Figure": ":class:`~matplotlib.figure.Figure`",
+    "matplotlib.axes.Axes": ":class:`~matplotlib.axes.Axes`",
+    # numpy
+    "ndarray": ":class:`~numpy.ndarray`",
+    "np.ndarray": ":class:`~numpy.ndarray`",
+    # pandas
+    "pd.DataFrame": ":class:`~pandas.DataFrame`",
+    "pd.Series": ":class:`~pandas.Series`",
+    "pd.Index": ":class:`~pandas.Index`",
+    "pd.Timestamp": ":class:`~pandas.Timestamp`",
+    "DataFrame": ":class:`~pandas.DataFrame`",
+    "Series": ":class:`~pandas.Series`",
+    # xarray
+    "xarray.DataArray": ":class:`~xarray.DataArray`",
+    "xarray.Dataset": ":class:`~xarray.Dataset`",
+    "DataArray": ":class:`~xarray.DataArray`",
+    "Dataset": ":class:`~xarray.Dataset`",
+    # arviz
+    "InferenceData": ":class:`~arviz.InferenceData`",
+    "az.InferenceData": ":class:`~arviz.InferenceData`",
+    "arviz.InferenceData": ":class:`~arviz.InferenceData`",
+    # pymc / pytensor
+    "Model": ":class:`~pymc.Model`",
+    "pm.Model": ":class:`~pymc.Model`",
     "TensorVariable": ":class:`~pytensor.tensor.TensorVariable`",
     "RandomVariable": ":class:`~pytensor.tensor.random.RandomVariable`",
-    "ndarray": ":class:`~numpy.ndarray`",
-    "InferenceData": ":class:`~arviz.InferenceData`",
-    "Model": ":class:`~pymc.Model`",
+    # glossary terms
     "tensor_like": ":term:`tensor_like`",
     "unnamed_distribution": ":term:`unnamed_distribution`",
 }
-# don't add a return type section, use standard return with type info
+
+# -- sphinx-autodoc-typehints config ------------------------------------------
+# Don't add a separate ``Return type`` section; the type appears alongside the
+# return value description in the standard ``Returns`` block instead.
 typehints_document_rtype = False
 
 # -- intersphinx config -------------------------------------------------------


### PR DESCRIPTION
Closes #901.

## Summary

- Enable `napoleon_preprocess_types` and define a `napoleon_type_aliases` map covering matplotlib (`Figure`, `Axes`), numpy (`ndarray`), pandas (`DataFrame`, `Series`, `Index`, `Timestamp`), xarray (`DataArray`, `Dataset`), arviz (`InferenceData`), pymc (`Model`), and pytensor (`TensorVariable`, `RandomVariable`). Both fully-qualified and short / `np.`/`pd.`/`az.`/`pm.`-prefixed forms are aliased so existing docstrings work as-written.
- Delete the dead `numpydoc_xref_*` block from `docs/source/conf.py`. Those keys belong to the `numpydoc` Sphinx extension, which is **not** in the `extensions` list — only `sphinx.ext.napoleon` is loaded — so the entire block was a silent no-op and was actively misleading.
- Replace the misleading "numpydoc and autodoc typehints config" header with explicit `Napoleon` and `sphinx-autodoc-typehints` section markers so future contributors can see at a glance which extension owns which config keys.

## Verification

- `sphinx-build -b html -n docs/source docs/_build` warning count drops from **1047 -> 957 (-90)** on this branch.
- The headline example from the issue (`InterruptedTimeSeries.plot`) now renders the `Returns` block's `fig` entry as a clickable link to upstream `matplotlib.figure.Figure` (confirmed against the rendered HTML).
- The `Return type` line emitted by `sphinx-autodoc-typehints` continues to render correctly — no regressions in that path.
- `prek run` (on the changed file) passes.

## Trade-off and follow-ups (deferred to land **after** #902)

Enabling Napoleon's type preprocessor reduces *total* warnings substantially, but introduces ~40 new ones in two specific shapes that this PR intentionally does **not** fix:

1. **Compound generics that Napoleon's preprocessor parses badly.** Strings like `tuple[plt.Figure, list[plt.Axes]]`, `dict[str, Any]`, `tuple[pd.Series, pd.Series]`, and `list[matplotlib.axes.Axes]` get split on the inner comma, producing broken `:class:` lookups. Affected primarily in `causalpy/experiments/inverse_propensity_weighting.py`, `causalpy/experiments/panel_regression.py`, and the `Returns` blocks of every experiment's `plot()` method.
2. **Project-internal names not in any intersphinx inventory.** `EffectSummary`, `BaseExperiment`, `CheckResult`, `PipelineContext` appear as bare class names in docstrings; Napoleon now tries to cross-reference them and (correctly) reports them as unresolved.

These should be cleaned up in a follow-up PR sequenced **after** #902 lands, because:

- #902 normalizes the docstring shape across `causalpy/experiments/*` (`:param:` blocks -> NumPy-style `Parameters` sections, plus `RT03`/`PR04` enforcement). Doing the type-string rewrites now would conflict with #902's docstring touches.
- After #902 lands, the type-string surface is stable and the cleanup can be done in a single focused pass.

Concretely, the follow-up PR should:

- Rewrite compound generic type strings to forms Napoleon parses cleanly (`tuple of (Figure, list of Axes)`, etc.) or replace them with explicit `:class:` role markup at the call sites where the rewrite would hurt readability.
- Add aliases for project-internal types (`EffectSummary`, `BaseExperiment`, `CheckResult`, `PipelineContext`) so they cross-reference back into the local API docs.
- Re-run the warning diff and confirm net warnings continue to decrease.

I'll open a follow-up issue capturing the above once this PR is in.

## Independence from #902

This PR is config-only (`docs/source/conf.py`); #902 is `pyproject.toml` + docstrings. Zero file overlap, no merge order constraint either direction. They are net-additive: #902's docstring normalization makes #901's preprocessor more useful; #901's preprocessor makes #902's normalized types render as cross-references.


Made with [Cursor](https://cursor.com)