### PR TITLE
Add residual-noise sensitivity checks to power_analysis

### DIFF
--- a/causalpy/experiments/sc_results.py
+++ b/causalpy/experiments/sc_results.py
@@ -171,12 +171,18 @@ class PowerCurveResult:
         The detection criterion used.
     raw_results : list[list[DressRehearsalResult]]
         Nested list: per effect size, per simulation.
+    noise_method : str
+        Residual-noise simulation method used.
+    block_length : int or None
+        Block length used for block-bootstrap residual noise, if applicable.
     """
 
     effect_sizes: list[float]
     detection_rates: list[float]
     criterion: str
     raw_results: list[list[DressRehearsalResult]] = field(repr=False)
+    noise_method: str = "iid_gaussian"
+    block_length: int | None = None
 
     def plot(self) -> tuple[plt.Figure, plt.Axes]:
         """Power curve: effect size vs detection rate."""
@@ -214,6 +220,8 @@ class PowerCurveResult:
                     "mean_recovery": np.mean(means),
                     "median_recovery": np.median(means),
                     "n_simulations": len(sim_results),
+                    "noise_method": self.noise_method,
+                    "block_length": self.block_length,
                 }
             )
         return pd.DataFrame(rows)

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -1155,11 +1155,40 @@ class SyntheticControl(BaseExperiment):
         holdout_periods: int | None = None,
         sample_kwargs: dict | None = None,
         random_seed: int | None = None,
+        noise_method: Literal[
+            "iid_gaussian", "block_bootstrap", "ar1"
+        ] = "iid_gaussian",
+        block_length: int | None = None,
     ) -> PowerCurveResult:
         """Simulation-based Bayesian power curve.
 
         For each candidate effect size, runs :meth:`validate_design`
-        multiple times (with added noise) and records detection rates.
+        multiple times (with added residual noise) and records detection
+        rates. The simulation perturbs only the treated unit's pre-period
+        outcomes; donor paths, the model class, the candidate effect size,
+        and the design are fixed across simulations.
+
+        The default ``noise_method="iid_gaussian"`` preserves the original
+        implementation: it adds iid Gaussian noise with standard deviation
+        equal to the posterior-mean pre-period residual standard deviation.
+        This is a heuristic sensitivity calculation. It assumes independent,
+        homoscedastic Gaussian residual variation, and is not a canonical
+        synthetic-control sampling-distribution power analysis. No clean
+        synthetic-control reference is known for this exact treated-only
+        resampling scheme.
+
+        ``"block_bootstrap"`` and ``"ar1"`` are opt-in sensitivity checks
+        for short-range residual dependence. They are not universally better
+        replacements for iid Gaussian noise. All methods rely on
+        posterior-mean residuals and do not address donor-pool uncertainty,
+        heteroscedasticity, seasonality, posterior-predictive design priors,
+        or pseudo-post misfit bias. Users should compare noise methods and
+        cross-check the resulting curve with placebo-in-space and
+        placebo-in-time diagnostics. The block bootstrap samples overlapping
+        moving blocks of centered residuals. The AR(1) method centers the
+        residuals, estimates the lag-1 coefficient by least squares with no
+        intercept, clips it to ``[-0.99, 0.99]``, and simulates innovations
+        from the fitted residual innovation scale.
 
         Parameters
         ----------
@@ -1181,7 +1210,20 @@ class SyntheticControl(BaseExperiment):
         sample_kwargs : dict or None
             MCMC sampling arguments for refitted models.
         random_seed : int or None
-            RNG seed for reproducible noise injection.
+            RNG seed for reproducible noise injection. When provided and
+            ``sample_kwargs`` does not contain ``"random_seed"``, deterministic
+            per-refit PyMC seeds are drawn from the same RNG.
+        noise_method : {"iid_gaussian", "block_bootstrap", "ar1"}
+            Residual-noise simulation method. ``"iid_gaussian"`` keeps the
+            original iid Gaussian behavior. ``"block_bootstrap"`` resamples
+            contiguous centered residual blocks. ``"ar1"`` estimates and
+            simulates a zero-mean AR(1) residual path.
+        block_length : int or None
+            Block length for ``noise_method="block_bootstrap"``. If ``None``,
+            uses ``ceil(sqrt(n_pre))``, bounded to the pre-period length.
+            ``noise_method="ar1"`` requires at least 3 pre-period residuals;
+            use ``"iid_gaussian"`` or ``"block_bootstrap"`` for very short
+            pre-periods.
 
         Returns
         -------
@@ -1195,12 +1237,16 @@ class SyntheticControl(BaseExperiment):
 
         rng = np.random.default_rng(random_seed)
 
-        pre = self.datapre
-        residuals = self.pre_impact
-        if "treated_units" in residuals.dims:
-            residuals = residuals.isel(treated_units=0)
-        residual_std = float(
-            residuals.mean(dim=["chain", "draw"]).std(dim="obs_ind").values
+        residual_path = self._pre_period_residual_path()
+        self._validate_power_analysis_noise_args(
+            residual_path=residual_path,
+            noise_method=noise_method,
+            block_length=block_length,
+        )
+        resolved_block_length = (
+            self._resolve_power_analysis_block_length(block_length, len(residual_path))
+            if noise_method == "block_bootstrap"
+            else None
         )
 
         all_results: list[list[DressRehearsalResult]] = []
@@ -1215,19 +1261,35 @@ class SyntheticControl(BaseExperiment):
 
             for _sim_idx in range(n_simulations):
                 noise_data = self.data.copy()
-                noise = rng.normal(0, residual_std, size=len(pre))
+                noise = self._simulate_power_analysis_noise(
+                    residual_path=residual_path,
+                    rng=rng,
+                    noise_method=noise_method,
+                    block_length=resolved_block_length,
+                )
                 for col in self.treated_units:
                     noise_data.loc[noise_data.index < self.treatment_time, col] += noise
 
+                build_sample_kwargs = self._sample_kwargs_with_generated_seed(
+                    sample_kwargs=sample_kwargs,
+                    rng=rng,
+                    random_seed=random_seed,
+                )
+                validate_sample_kwargs = self._sample_kwargs_with_generated_seed(
+                    sample_kwargs=sample_kwargs,
+                    rng=rng,
+                    random_seed=random_seed,
+                )
+
                 noise_experiment = self._build_noisy_experiment(
-                    noise_data, sample_kwargs
+                    noise_data, build_sample_kwargs
                 )
 
                 result = noise_experiment.validate_design(
                     injected_effect=es,
                     holdout_periods=holdout_periods,
                     effect_type=effect_type,
-                    sample_kwargs=sample_kwargs,
+                    sample_kwargs=validate_sample_kwargs,
                 )
                 sim_results.append(result)
 
@@ -1252,7 +1314,159 @@ class SyntheticControl(BaseExperiment):
             detection_rates=detection_rates,
             criterion=criterion,
             raw_results=all_results,
+            noise_method=noise_method,
+            block_length=resolved_block_length,
         )
+
+    def _pre_period_residual_path(self) -> np.ndarray:
+        """Posterior-mean pre-period residual path used for power-analysis noise."""
+        residuals = self.pre_impact
+        if "treated_units" in residuals.dims:
+            residuals = residuals.isel(treated_units=0)
+        residual_path = residuals.mean(dim=["chain", "draw"])
+        return np.asarray(residual_path.values, dtype=float).reshape(-1)
+
+    @classmethod
+    def _validate_power_analysis_noise_args(
+        cls,
+        residual_path: np.ndarray,
+        noise_method: str,
+        block_length: int | None,
+    ) -> None:
+        """Validate residual-noise simulation arguments before refitting models."""
+        n_obs = len(residual_path)
+        if n_obs < 1:
+            raise ValueError("power_analysis() requires at least one pre-period row.")
+        if noise_method not in {"iid_gaussian", "block_bootstrap", "ar1"}:
+            raise ValueError(f"Unknown noise_method: {noise_method}")
+        if noise_method == "block_bootstrap":
+            cls._resolve_power_analysis_block_length(block_length, n_obs)
+        if noise_method == "ar1" and n_obs < 3:
+            raise ValueError(
+                'noise_method="ar1" requires at least 3 pre-period residuals. '
+                'Use noise_method="iid_gaussian" or "block_bootstrap" for very '
+                "short pre-periods."
+            )
+
+    @classmethod
+    def _simulate_power_analysis_noise(
+        cls,
+        residual_path: np.ndarray,
+        rng: np.random.Generator,
+        noise_method: str,
+        block_length: int | None,
+    ) -> np.ndarray:
+        """Simulate one residual-noise path for ``power_analysis``."""
+        cls._validate_power_analysis_noise_args(
+            residual_path=residual_path,
+            noise_method=noise_method,
+            block_length=block_length,
+        )
+        if noise_method == "iid_gaussian":
+            return cls._simulate_iid_gaussian_noise(residual_path, rng)
+        if noise_method == "block_bootstrap":
+            return cls._simulate_block_bootstrap_noise(
+                residual_path=residual_path,
+                rng=rng,
+                block_length=block_length,
+            )
+        return cls._simulate_ar1_noise(residual_path, rng)
+
+    @staticmethod
+    def _simulate_iid_gaussian_noise(
+        residual_path: np.ndarray,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Simulate iid Gaussian residual noise using the original scalar scale."""
+        residual_std = float(np.std(residual_path))
+        return rng.normal(0, residual_std, size=len(residual_path))
+
+    @staticmethod
+    def _resolve_power_analysis_block_length(
+        block_length: int | None,
+        n_obs: int,
+    ) -> int:
+        """Resolve and validate the moving-block bootstrap block length."""
+        if block_length is None:
+            return max(1, min(n_obs, int(np.ceil(np.sqrt(n_obs)))))
+        if block_length < 1 or block_length > n_obs:
+            raise ValueError(
+                "block_length must be between 1 and the number of pre-period "
+                f"residuals ({n_obs}); got {block_length}."
+            )
+        return block_length
+
+    @classmethod
+    def _simulate_block_bootstrap_noise(
+        cls,
+        residual_path: np.ndarray,
+        rng: np.random.Generator,
+        block_length: int | None,
+    ) -> np.ndarray:
+        """Resample centered residuals in overlapping contiguous blocks."""
+        residuals = np.asarray(residual_path, dtype=float)
+        n_obs = len(residuals)
+        resolved_block_length = cls._resolve_power_analysis_block_length(
+            block_length, n_obs
+        )
+        centered = residuals - residuals.mean()
+        max_start = n_obs - resolved_block_length
+        n_blocks = int(np.ceil(n_obs / resolved_block_length))
+        starts = rng.integers(0, max_start + 1, size=n_blocks)
+        blocks = [centered[start : start + resolved_block_length] for start in starts]
+        return np.concatenate(blocks)[:n_obs]
+
+    @staticmethod
+    def _simulate_ar1_noise(
+        residual_path: np.ndarray,
+        rng: np.random.Generator,
+    ) -> np.ndarray:
+        """Estimate and simulate a zero-mean AR(1) residual path."""
+        residuals = np.asarray(residual_path, dtype=float)
+        n_obs = len(residuals)
+        if n_obs < 3:
+            raise ValueError(
+                'noise_method="ar1" requires at least 3 pre-period residuals. '
+                'Use noise_method="iid_gaussian" or "block_bootstrap" for very '
+                "short pre-periods."
+            )
+
+        centered = residuals - residuals.mean()
+        if float(np.var(centered)) == 0:
+            return np.zeros(n_obs)
+
+        lagged = centered[:-1]
+        current = centered[1:]
+        denominator = float(np.dot(lagged, lagged))
+        phi = 0.0 if denominator == 0 else float(np.dot(lagged, current) / denominator)
+        phi = float(np.clip(phi, -0.99, 0.99))
+
+        innovations = current - phi * lagged
+        innovation_std = float(np.std(innovations))
+        if innovation_std == 0:
+            return np.zeros(n_obs)
+
+        simulated = np.empty(n_obs)
+        simulated[0] = rng.normal(0, innovation_std / np.sqrt(1 - phi**2))
+        shocks = rng.normal(0, innovation_std, size=n_obs - 1)
+        for idx in range(1, n_obs):
+            simulated[idx] = phi * simulated[idx - 1] + shocks[idx - 1]
+        return simulated
+
+    @staticmethod
+    def _sample_kwargs_with_generated_seed(
+        sample_kwargs: dict | None,
+        rng: np.random.Generator,
+        random_seed: int | None,
+    ) -> dict | None:
+        """Add a deterministic PyMC seed unless the user supplied one."""
+        if random_seed is None:
+            return sample_kwargs
+
+        seeded_kwargs = dict(sample_kwargs) if sample_kwargs is not None else {}
+        if "random_seed" not in seeded_kwargs:
+            seeded_kwargs["random_seed"] = int(rng.integers(0, np.iinfo(np.int32).max))
+        return seeded_kwargs
 
     def _build_noisy_experiment(
         self,

--- a/causalpy/tests/test_sc_design.py
+++ b/causalpy/tests/test_sc_design.py
@@ -17,6 +17,7 @@ validate_design(), power_analysis(), and donor_pool_quality().
 """
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -28,6 +29,7 @@ from causalpy.experiments.sc_results import (
     DressRehearsalResult,
     PowerCurveResult,
 )
+from causalpy.experiments.synthetic_control import SyntheticControl
 
 sample_kwargs = {
     "tune": 20,
@@ -40,6 +42,21 @@ sample_kwargs = {
 
 CONTROL_UNITS = ["a", "b", "c", "d", "e", "f", "g"]
 TREATED_UNITS = ["actual"]
+
+
+def _lag1_autocorrelation(values):
+    """Lag-1 autocorrelation for synthetic noise sanity checks."""
+    return np.corrcoef(values[:-1], values[1:])[0, 1]
+
+
+def _synthetic_ar1_residuals(n_obs=200, phi=0.85, random_seed=123):
+    """Generate a deterministic positively autocorrelated residual path."""
+    rng = np.random.default_rng(random_seed)
+    residuals = np.zeros(n_obs)
+    shocks = rng.normal(0, 1, size=n_obs - 1)
+    for idx in range(1, n_obs):
+        residuals[idx] = phi * residuals[idx - 1] + shocks[idx - 1]
+    return residuals
 
 
 @pytest.fixture(scope="module")
@@ -290,6 +307,8 @@ class TestPowerAnalysis:
         assert "effect_size" in df.columns
         assert "detection_rate" in df.columns
         assert "n_simulations" in df.columns
+        assert "noise_method" in df.columns
+        assert set(df["noise_method"]) == {"iid_gaussian"}
 
     @pytest.mark.integration
     def test_power_analysis_reproducible(self, fitted_sc):
@@ -302,6 +321,108 @@ class TestPowerAnalysis:
         r1 = fitted_sc.power_analysis(**kwargs)
         r2 = fitted_sc.power_analysis(**kwargs)
         assert r1.detection_rates == r2.detection_rates
+
+    @pytest.mark.integration
+    def test_power_analysis_accepts_block_bootstrap_noise_method(self, fitted_sc):
+        result = fitted_sc.power_analysis(
+            effect_sizes=[0.10],
+            n_simulations=1,
+            sample_kwargs=sample_kwargs,
+            random_seed=42,
+            noise_method="block_bootstrap",
+        )
+        assert isinstance(result, PowerCurveResult)
+        assert result.noise_method == "block_bootstrap"
+        assert result.block_length is not None
+
+    @pytest.mark.integration
+    def test_power_analysis_accepts_ar1_noise_method(self, fitted_sc):
+        result = fitted_sc.power_analysis(
+            effect_sizes=[0.10],
+            n_simulations=1,
+            sample_kwargs=sample_kwargs,
+            random_seed=42,
+            noise_method="ar1",
+        )
+        assert isinstance(result, PowerCurveResult)
+        assert result.noise_method == "ar1"
+
+    def test_power_analysis_rejects_unknown_noise_method(self, fitted_sc):
+        with pytest.raises(ValueError, match="Unknown noise_method"):
+            fitted_sc.power_analysis(
+                effect_sizes=[0.10],
+                n_simulations=1,
+                sample_kwargs=sample_kwargs,
+                noise_method="not_a_method",
+            )
+
+    def test_power_analysis_rejects_invalid_block_length(self, fitted_sc):
+        with pytest.raises(ValueError, match="block_length"):
+            fitted_sc.power_analysis(
+                effect_sizes=[0.10],
+                n_simulations=1,
+                sample_kwargs=sample_kwargs,
+                noise_method="block_bootstrap",
+                block_length=0,
+            )
+
+    def test_ar1_noise_rejects_very_short_pre_period(self):
+        with pytest.raises(ValueError, match="at least 3 pre-period residuals"):
+            SyntheticControl._simulate_power_analysis_noise(
+                residual_path=np.array([0.1, -0.1]),
+                rng=np.random.default_rng(42),
+                noise_method="ar1",
+                block_length=None,
+            )
+
+    def test_noise_helpers_are_reproducible_with_same_seed(self):
+        residuals = _synthetic_ar1_residuals()
+        for noise_method in ("iid_gaussian", "block_bootstrap", "ar1"):
+            noise_1 = SyntheticControl._simulate_power_analysis_noise(
+                residual_path=residuals,
+                rng=np.random.default_rng(42),
+                noise_method=noise_method,
+                block_length=10 if noise_method == "block_bootstrap" else None,
+            )
+            noise_2 = SyntheticControl._simulate_power_analysis_noise(
+                residual_path=residuals,
+                rng=np.random.default_rng(42),
+                noise_method=noise_method,
+                block_length=10 if noise_method == "block_bootstrap" else None,
+            )
+            np.testing.assert_array_equal(noise_1, noise_2)
+
+    def test_block_bootstrap_noise_preserves_positive_autocorrelation(self):
+        residuals = _synthetic_ar1_residuals()
+        rng = np.random.default_rng(42)
+        autocorrelations = [
+            _lag1_autocorrelation(
+                SyntheticControl._simulate_power_analysis_noise(
+                    residual_path=residuals,
+                    rng=rng,
+                    noise_method="block_bootstrap",
+                    block_length=20,
+                )
+            )
+            for _ in range(100)
+        ]
+        assert np.mean(autocorrelations) > 0.4
+
+    def test_ar1_noise_preserves_positive_autocorrelation(self):
+        residuals = _synthetic_ar1_residuals()
+        rng = np.random.default_rng(42)
+        autocorrelations = [
+            _lag1_autocorrelation(
+                SyntheticControl._simulate_power_analysis_noise(
+                    residual_path=residuals,
+                    rng=rng,
+                    noise_method="ar1",
+                    block_length=None,
+                )
+            )
+            for _ in range(100)
+        ]
+        assert np.mean(autocorrelations) > 0.6
 
     def test_power_analysis_requires_pymc(self):
         df = cp.load_data("sc")

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -590,6 +590,19 @@ author={Springford, John}
   howpublished={NBER Working Paper No. 22791}
 }
 
+% Time-Series Resampling
+
+@article{kunsch1989jackknife,
+  title={The Jackknife and the Bootstrap for General Stationary Observations},
+  author={K{\"u}nsch, Hans R.},
+  journal={The Annals of Statistics},
+  volume={17},
+  number={3},
+  pages={1217--1241},
+  year={1989},
+  doi={10.1214/aos/1176347265}
+}
+
 % Synthetic Control -- Industry Tools
 
 @misc{geolift2022,


### PR DESCRIPTION
## Summary

Closes #914.

This PR keeps the existing iid Gaussian residual-noise simulation in `SyntheticControl.power_analysis()` as the default, and adds two opt-in residual simulation methods for sensitivity analysis:

- `noise_method="block_bootstrap"`
- `noise_method="ar1"`

It also documents the assumptions behind the default iid Gaussian scheme, clarifies that the resulting power curve is heuristic, and adds tests for the default and alternative methods.

## Motivation

The existing implementation perturbs only the treated unit’s pre-period values with iid Gaussian noise scaled by a scalar residual standard deviation. That is simple and backward-compatible, but it assumes independent and homoscedastic residual variation. For synthetic-control time series, residuals may be autocorrelated, seasonal, heteroscedastic, or affected by structural misfit.

This PR does not replace the default. Instead, it makes the assumptions explicit and gives users opt-in sensitivity checks for whether the power curve changes under residual-noise models that preserve short-range dependence.

## Design

- `iid_gaussian` preserves the current behavior.
- `block_bootstrap` resamples centered pre-period residuals in overlapping contiguous blocks. When `block_length=None`, it uses `ceil(sqrt(n_pre))`; users can override it.
- `ar1` centers the residual path, estimates `phi` by least squares on lagged residuals, clips it to the stationary range, estimates the innovation scale, and simulates a zero-mean AR(1) residual path.
- Very short pre-periods are handled explicitly: AR(1) requires at least three residual observations, while block bootstrap validates `block_length`.
- `random_seed` now makes both residual noise and generated refit seeds reproducible unless the user explicitly supplies `sample_kwargs["random_seed"]`.

These methods are intentionally framed as sensitivity checks, not as canonical SC sampling-distribution power analysis. Users should still compare against placebo-in-space and placebo-in-time diagnostics.

## Tests

Added coverage for:

- default iid Gaussian behavior
- block-bootstrap and AR(1) power-analysis calls
- invalid `noise_method`
- invalid `block_length`
- AR(1) short-pre-period validation
- reproducible helper draws under fixed seeds
- autocorrelation sanity checks on synthetic AR(1) residuals

## Documentation

Updated the `power_analysis()` docstring and the Prop 99 notebook narrative to describe the residual resampling assumptions and show a sensitivity comparison across noise methods.

## References

The iid Gaussian treated-only perturbation is documented as a heuristic because I did not find a clean SC reference endorsing that exact scheme. The block-bootstrap alternative is motivated by Künsch (1989), while Abadie (2021) is cited for general synthetic-control feasibility and placebo-diagnostic framing.

## Validation

- `.venv/bin/python -m pytest causalpy/tests/test_sc_design.py -k "PowerAnalysis or noise" --no-cov`
- `.venv/bin/prek run --all-files`
