### PR TITLE
fix: SDiD plot() API and sdid_pymc notebook ruff compliance

### DIFF
--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -568,6 +568,43 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             f"{round(float(tau_hdi[1]), round_to)}]"
         )
 
+    def plot(
+        self,
+        *,
+        round_to: int | None = None,
+        show: bool = True,
+        legend_kwargs: dict[str, Any] | None = None,
+    ) -> tuple[plt.Figure, np.ndarray]:
+        """Plot SDiD results: counterfactual, period impact, and cumulative impact.
+
+        Parameters
+        ----------
+        round_to : int, optional
+            Number of decimals used to round the ATT in the title. Defaults to
+            2. Use ``None`` for raw values.
+        show : bool, optional
+            Whether to call :func:`matplotlib.pyplot.show` after drawing.
+            Defaults to ``True``.
+        legend_kwargs : dict, optional
+            Keyword arguments applied to the top-axis legend in place after
+            the figure is built. Supported keys include ``loc``,
+            ``bbox_to_anchor``, ``fontsize``, ``frameon``, ``title``, and
+            optionally ``bbox_transform`` alongside ``bbox_to_anchor``. See
+            :meth:`~causalpy.experiments.base.BaseExperiment._render_plot`.
+
+        Returns
+        -------
+        fig : matplotlib.figure.Figure
+            The figure containing the three stacked panels.
+        ax : numpy.ndarray
+            Array of the three :class:`matplotlib.axes.Axes` instances.
+        """
+        return self._render_plot(
+            show=show,
+            legend_kwargs=legend_kwargs,
+            round_to=round_to,
+        )
+
     @staticmethod
     def _convert_treatment_time_for_axis(
         axis: plt.Axes, treatment_time: int | float | pd.Timestamp

--- a/causalpy/tests/test_public_plot_signatures.py
+++ b/causalpy/tests/test_public_plot_signatures.py
@@ -116,6 +116,7 @@ def test_every_concrete_subclass_declares_plot() -> None:
         "RegressionKink",
         "StaggeredDifferenceInDifferences",
         "SyntheticControl",
+        "SyntheticDifferenceInDifferences",
     }
     missing = expected - set(names)
     assert not missing, (

--- a/docs/source/notebooks/sdid_pymc.ipynb
+++ b/docs/source/notebooks/sdid_pymc.ipynb
@@ -21,11 +21,11 @@
    "outputs": [],
    "source": [
     "import arviz as az\n",
-    "import causalpy as cp\n",
     "import matplotlib.pyplot as plt\n",
-    "import matplotlib.ticker as mticker\n",
     "import numpy as np\n",
-    "from pymc_extras.prior import Prior"
+    "from pymc_extras.prior import Prior\n",
+    "\n",
+    "import causalpy as cp"
    ]
   },
   {
@@ -884,8 +884,6 @@
     }
    ],
    "source": [
-    "from causalpy.tests.test_default_models import sample_kwargs\n",
-    "\n",
     "sc_result = cp.SyntheticControl(\n",
     "    df,\n",
     "    treatment_time,\n",


### PR DESCRIPTION
## Summary

- Add the missing public `plot()` on `SyntheticDifferenceInDifferences`, delegating to `_render_plot`, so integration tests and callers match the #886 experiment contract (and the SDiD docs notebook).
- Apply Ruff/import-order fixes in `docs/source/notebooks/sdid_pymc.ipynb` so `pre-commit.ci` passes on merge previews.
- Register `SyntheticDifferenceInDifferences` in `test_public_plot_signatures.py` so the subclass is covered by the explicit-`plot()` invariant.

## Context

`main` could fail `test (3.14)` with `AttributeError: ... no attribute 'plot'` even though SDiD already implemented `_bayesian_plot`; this PR completes the public API.

## Test plan

- [x] `prek run` on touched Python files
- [x] `pytest causalpy/tests/test_integration_pymc_examples.py::test_sdid causalpy/tests/test_integration_pymc_examples.py::test_sdid_datetime_index_and_effect_summary causalpy/tests/test_public_plot_signatures.py`
- [ ] CI green (including required `prek` / `test (3.14)`)