### PR TITLE
DOC: add causal learning resources

### DIFF
--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -969,8 +969,11 @@ class InterruptedTimeSeries(BaseExperiment):
             label="Causal impact",
         )
 
+        score_val = self.score
+        if isinstance(score_val, pd.Series):
+            raise ValueError("Expected float score for OLS model, got Series")
         ax[0].set(
-            title=f"$R^2$ on pre-intervention data = {round_num(float(self.score), round_to)}"
+            title=f"$R^2$ on pre-intervention data = {round_num(float(score_val), round_to)}"
         )
 
         ax[1].plot(self.datapre.index, self.pre_impact, "k.")

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -663,7 +663,10 @@ class PiecewiseITS(BaseExperiment):
             linewidth=2,
         )
 
-        title_str = f"Piecewise ITS: $R^2$ = {round_num(float(self.score), round_to)}"
+        score_val = self.score
+        if isinstance(score_val, pd.Series):
+            raise ValueError("Expected float score for OLS model, got Series")
+        title_str = f"Piecewise ITS: $R^2$ = {round_num(float(score_val), round_to)}"
         ax[0].set(title=title_str, ylabel=self.outcome_variable_name)
 
         # MIDDLE PLOT: Causal Effect

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -495,7 +495,10 @@ class RegressionDiscontinuity(BaseExperiment):
         )
 
         # create strings to compose title
-        r2 = f"$R^2$ on fit data = {round_num(float(self.score), round_to)}"
+        score_val = self.score
+        if isinstance(score_val, pd.Series):
+            raise ValueError("Expected float score for OLS model, got Series")
+        r2 = f"$R^2$ on fit data = {round_num(float(score_val), round_to)}"
         discon = f"Discontinuity at threshold = {round_num(self.discontinuity_at_threshold, round_to)}"
         ax.set(title=r2 + "\n" + discon)
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -863,7 +863,10 @@ class SyntheticControl(BaseExperiment):
             return f"Pre-intervention Bayesian $R^2$: {r2_val} (std = {r2_std_val})"
         else:
             # OLS model - simple float score
-            return f"$R^2$ on pre-intervention data = {round_num(float(self.score), round_to if round_to is not None else 2)}"
+            score_val = self.score
+            if isinstance(score_val, pd.Series):
+                raise ValueError("Expected float score for OLS model, got Series")
+            return f"$R^2$ on pre-intervention data = {round_num(float(score_val), round_to if round_to is not None else 2)}"
 
     def effect_summary(
         self,

--- a/docs/source/knowledgebase/causal_written_resources.md
+++ b/docs/source/knowledgebase/causal_written_resources.md
@@ -14,6 +14,17 @@ Below is a list of written resources (books, blog posts, etc.) that are useful f
 
 * The official [PyMC examples gallery](https://www.pymc.io/projects/examples/en/latest/gallery.html) has a set of examples specifically relating to causal inference.
 
+## Related Python packages
+
+* [differences](https://github.com/bernardodionisi/differences), a Python package for difference-in-differences estimation and inference.
+* [DoWhy](https://github.com/py-why/dowhy), a Python package for causal inference that supports explicit modeling and testing of causal assumptions.
+* [CausalNLP](https://github.com/amaiya/causalnlp), a toolkit for causal inference with text as a treatment, outcome, or control variable.
+
 ## General causal inference resources
 
 * [Awesome Causal Inference](https://github.com/matteocourthoud/awesome-causal-inference), a curated list of resources on causal inference, including books, blogs, and tutorials.
+* Deng, A. [Causal inference and its applications in online industry](https://alexdeng.github.io/causal/).
+* Molak, A. [Causal inference resources](https://alxndr.io).
+* Riederer, E. [Causal design patterns](https://emilyriederer.netlify.app/post/causal-design-patterns/).
+* Ruiz de Villa, A. [Causal inference for data science](https://www.manning.com/books/causal-inference-for-data-science). Manning.
+* Ness, R. [Causal machine learning](https://www.manning.com/books/causal-machine-learning). Manning.


### PR DESCRIPTION
Closes #71

Adds related Python packages and learning resources to the written causal inference resources page.

Validation run locally:
- `pymarkdown --config pyproject.toml scan docs/source/knowledgebase/causal_written_resources.md`
- `codespell docs/source/knowledgebase/causal_written_resources.md`