### PR TITLE
Fix scalar score coercions for mypy

### DIFF
--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -970,7 +970,7 @@ class InterruptedTimeSeries(BaseExperiment):
         )
 
         ax[0].set(
-            title=f"$R^2$ on pre-intervention data = {round_num(float(self.score), round_to)}"
+            title=f"$R^2$ on pre-intervention data = {round_num(_as_scalar(self.score), round_to)}"
         )
 
         ax[1].plot(self.datapre.index, self.pre_impact, "k.")

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -663,7 +663,9 @@ class PiecewiseITS(BaseExperiment):
             linewidth=2,
         )
 
-        title_str = f"Piecewise ITS: $R^2$ = {round_num(float(self.score), round_to)}"
+        title_str = (
+            f"Piecewise ITS: $R^2$ = {round_num(_as_scalar(self.score), round_to)}"
+        )
         ax[0].set(title=title_str, ylabel=self.outcome_variable_name)
 
         # MIDDLE PLOT: Causal Effect

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -34,6 +34,7 @@ from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rd
 from causalpy.utils import (
+    _as_scalar,
     _is_variable_dummy_coded,
     convert_to_string,
     round_num,
@@ -495,7 +496,7 @@ class RegressionDiscontinuity(BaseExperiment):
         )
 
         # create strings to compose title
-        r2 = f"$R^2$ on fit data = {round_num(float(self.score), round_to)}"
+        r2 = f"$R^2$ on fit data = {round_num(_as_scalar(self.score), round_to)}"
         discon = f"Discontinuity at threshold = {round_num(self.discontinuity_at_threshold, round_to)}"
         ax.set(title=r2 + "\n" + discon)
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -31,7 +31,7 @@ from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
-from causalpy.utils import check_convex_hull_violation, round_num
+from causalpy.utils import _as_scalar, check_convex_hull_violation, round_num
 
 from .base import BaseExperiment
 
@@ -863,7 +863,7 @@ class SyntheticControl(BaseExperiment):
             return f"Pre-intervention Bayesian $R^2$: {r2_val} (std = {r2_std_val})"
         else:
             # OLS model - simple float score
-            return f"$R^2$ on pre-intervention data = {round_num(float(self.score), round_to if round_to is not None else 2)}"
+            return f"$R^2$ on pre-intervention data = {round_num(_as_scalar(self.score), round_to if round_to is not None else 2)}"
 
     def effect_summary(
         self,


### PR DESCRIPTION
## Summary
- Fix mypy failures from passing pandas-like scalar scores directly to `float()`.
- Reuse the existing `_as_scalar()` helper in experiment plot title formatting.

## Test plan
- [x] `$CONDA_EXE run -n CausalPy prek run --files causalpy/experiments/synthetic_control.py causalpy/experiments/regression_discontinuity.py causalpy/experiments/piecewise_its.py causalpy/experiments/interrupted_time_series.py`
- [x] `$CONDA_EXE run -n CausalPy prek run --all-files`

Unblocks the unrelated pre-commit failure currently visible on #933.

Made with [Cursor](https://cursor.com)