### PR TITLE
Fix #664: clone sklearn models to avoid mutating fit_intercept

### DIFF
--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -18,6 +18,8 @@ Base class for quasi experimental designs.
 from __future__ import annotations
 
 import contextlib
+import copy
+import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Literal
@@ -25,7 +27,7 @@ from typing import Any, Literal
 import arviz as az
 import matplotlib.pyplot as plt
 import pandas as pd
-from sklearn.base import RegressorMixin
+from sklearn.base import RegressorMixin, clone
 
 from causalpy.maketables_adapters import get_maketables_adapter
 from causalpy.pymc_models import PyMCModel
@@ -118,7 +120,27 @@ class BaseExperiment(ABC):
         # Ensure we've made any provided Scikit Learn model (as identified as being type
         # RegressorMixin) compatible with CausalPy by appending our custom methods.
         if isinstance(model, RegressorMixin):
+            # Clone to avoid mutating the caller's estimator instance (#664).
+            try:
+                model = clone(model)
+            except TypeError:
+                # Models without get_params() can't be sklearn-cloned;
+                # fall back to a deep copy.
+                model = copy.deepcopy(model)
             model = create_causalpy_compatible_class(model)
+            # Patsy includes the intercept as a design-matrix column, so
+            # sklearn models must not add their own intercept.
+            if getattr(model, "fit_intercept", False):
+                warnings.warn(
+                    f"{type(model).__name__} had fit_intercept=True, but CausalPy "
+                    "requires fit_intercept=False because the intercept is already "
+                    "included in the design matrix by patsy. A cloned copy of the "
+                    "model with fit_intercept=False will be used; the original "
+                    "instance is unchanged.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                model.fit_intercept = False
 
         if model is None and self._default_model_class is not None:
             model = self._default_model_class()

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -160,11 +160,6 @@ class DifferenceInDifferences(BaseExperiment):
             }
             self.model.fit(X=self.X, y=self.y, coords=COORDS)
         elif isinstance(self.model, RegressorMixin):
-            # Ensure the intercept is part of the coefficients array rather than
-            # a separate intercept_ attribute.  See #664 / PR #693 for
-            # centralising this in BaseExperiment.
-            if hasattr(self.model, "fit_intercept"):
-                self.model.fit_intercept = False
             self.model.fit(X=self.X, y=self.y)
         else:
             raise ValueError("Model type not recognized")

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -305,11 +305,6 @@ class PanelRegression(BaseExperiment):
             }
             self.model.fit(X=self.X, y=self.y, coords=COORDS)  # type: ignore[arg-type]
         elif isinstance(self.model, RegressorMixin):
-            # For scikit-learn models, set fit_intercept=False so that the
-            # patsy intercept column is included in the coefficients array.
-            # TODO: later, this should be handled in ScikitLearnAdaptor itself
-            if hasattr(self.model, "fit_intercept"):
-                self.model.fit_intercept = False
             self.model.fit(X=self.X, y=self.y)
 
     def _demean_transform(self, data: pd.DataFrame, group_var: str) -> pd.DataFrame:

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -218,8 +218,6 @@ class PiecewiseITS(BaseExperiment):
             }
             self.model.fit(X=self.X, y=self.y, coords=COORDS)
         elif isinstance(self.model, RegressorMixin):
-            if hasattr(self.model, "fit_intercept"):
-                self.model.fit_intercept = False
             self.model.fit(X=self.X, y=self.y.isel(treated_units=0))
         else:
             raise ValueError("Model type not recognized")

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -466,8 +466,6 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             }
             self.model.fit(X=X_train_xr, y=y_train_xr, coords=COORDS)
         elif isinstance(self.model, RegressorMixin):
-            if hasattr(self.model, "fit_intercept"):
-                self.model.fit_intercept = False
             self.model.fit(X=self.X_train, y=self.y_train)
         else:
             raise ValueError("Model type not recognized")

--- a/causalpy/tests/test_sklearn_clone_fit_intercept.py
+++ b/causalpy/tests/test_sklearn_clone_fit_intercept.py
@@ -1,0 +1,42 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Regression tests for #664: BaseExperiment must not mutate user-supplied sklearn models."""
+
+import warnings
+
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+
+
+def test_fit_intercept_clone_and_warn():
+    """Passing fit_intercept=True must clone the model, override it, and warn (#664)."""
+    model = LinearRegression(fit_intercept=True)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        result = cp.DifferenceInDifferences(
+            cp.load_data("did"),
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=model,
+        )
+
+    # Original instance must be unchanged
+    assert model.fit_intercept is True
+    # Internal clone must have fit_intercept=False
+    assert result.model.fit_intercept is False
+    # A warning must have been emitted
+    assert any("fit_intercept" in str(w.message) for w in caught)

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -846,7 +846,10 @@ def test_staggered_did_mark_non_identified_att_rows_edge_cases():
 @pytest.mark.parametrize(
     "model_factory",
     [
-        pytest.param(lambda: LinearRegression(), id="ols"),
+        # fit_intercept=False avoids the BaseExperiment fit_intercept
+        # override warning (#664) which would be caught by the
+        # simplefilter("error") below.
+        pytest.param(lambda: LinearRegression(fit_intercept=False), id="ols"),
         pytest.param(
             lambda: cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
             id="pymc",


### PR DESCRIPTION
## Problem

`DifferenceInDifferences`, `PiecewiseITS`, `StaggeredDifferenceInDifferences`, and `PanelRegression` all silently mutate the user's sklearn model by setting `fit_intercept=False`. This is a hidden side effect: callers pass in a configured estimator, but the experiment overrides a key hyperparameter without consent. This makes it impossible to safely reuse the same model instance across experiments.

## Solution

Centralise the `fit_intercept` handling in `BaseExperiment.__init__`:

1. **Clone the model** before wrapping it, using `sklearn.base.clone()` (with `copy.deepcopy` fallback for custom regressors that lack `get_params()`). The original user instance is never mutated.
2. **Warn** via `UserWarning` when overriding `fit_intercept=True` on the clone, explaining why CausalPy requires `fit_intercept=False` (patsy already includes the intercept in the design matrix).
3. **Remove** the duplicated `fit_intercept` mutation from all 4 experiment classes.

## Why this approach

- **Clone, don't raise**: raising an error would break existing code that passes `fit_intercept=True` (sklearn's default). Cloning + warning is non-breaking but transparent.
- **`sklearn.clone` preferred over `deepcopy`**: `clone()` is the idiomatic sklearn way to copy estimators — it's lightweight and creates a fresh instance from hyperparameters. `deepcopy` is the fallback for non-standard regressors (e.g. custom `RegressorMixin` subclasses without `get_params()`).
- **Centralised**: one fix in `BaseExperiment` instead of patching 4 experiment classes independently.

## Tests

All existing OLS/sklearn tests pass (38 passed, 0 failed). The existing tests for models without `fit_intercept` (`KNeighborsRegressor`, `MinimalRegressor`) continue to work via the `deepcopy` fallback.

Closes #664

Co-Authored-By: Oz <oz-agent@warp.dev>