### PR TITLE
ci(docs-preview): cancel when not in defined scopes of git diff

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -14,6 +14,22 @@ build:
     # nodejs: "16"
     # rust: "1.55"
     # golang: "1.17"
+  jobs:
+    post_checkout:
+      # Skip PR preview builds when no docs-relevant files changed.
+      # exit 183 cancels the build (shown as green on the PR, not a failure).
+      # Pushes to main are unaffected — live docs always rebuild.
+      # Ref: https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
+      - git fetch origin main --depth=1
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && \
+           git diff --quiet origin/main -- docs/ .readthedocs.yaml causalpy/ \
+             ':(exclude)causalpy/tests/' \
+             ':(exclude)causalpy/data/' \
+             ':(exclude)causalpy/skills/';
+        then
+          exit 183;
+        fi
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,13 +22,13 @@ build:
       # Ref: https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
       - git fetch origin main --depth=1
       - |
-        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ] && \
-           git diff --quiet origin/main -- docs/ .readthedocs.yaml causalpy/ \
-             ':(exclude)causalpy/tests/' \
-             ':(exclude)causalpy/data/' \
-             ':(exclude)causalpy/skills/';
-        then
-          exit 183;
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+          CHANGED_FILES=$(git diff --name-only origin/main -- docs/ .readthedocs.yaml causalpy/ || true)
+          RELEVANT_FILES=$(printf '%s\n' "$CHANGED_FILES" | grep -Ev '^causalpy/(tests|data|skills)/' || true)
+
+          if [ -z "$RELEVANT_FILES" ]; then
+            exit 183;
+          fi
         fi
 
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -23,10 +23,21 @@ build:
       - git fetch origin main --depth=1
       - |
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
-          CHANGED_FILES=$(git diff --name-only origin/main -- docs/ .readthedocs.yaml causalpy/ || true)
-          RELEVANT_FILES=$(printf '%s\n' "$CHANGED_FILES" | grep -Ev '^causalpy/(tests|data|skills)/' || true)
+          CHANGED_FILES=$(git diff --name-only origin/main -- docs/ .readthedocs.yaml causalpy/ 2>/dev/null || true)
+          SHOULD_SKIP=1
 
-          if [ -z "$RELEVANT_FILES" ]; then
+          for FILE in $CHANGED_FILES; do
+            case "$FILE" in
+              causalpy/tests/*|causalpy/data/*|causalpy/skills/*)
+                ;;
+              *)
+                SHOULD_SKIP=0
+                break
+                ;;
+            esac
+          done
+
+          if [ "$SHOULD_SKIP" -eq 1 ]; then
             exit 183;
           fi
         fi


### PR DESCRIPTION
### Description

In read the docs there is a special exit code 183 that can be triggered to cancel the build docs job.

This is the approach I took for disabling PR builds when unnecessary. I also linked read the docs to my forked repo to test 3 scenarios for expected behaviour.

**Main Change**: 
Skips PR preview builds when no docs-relevant files changed.  Closes #941 
Only builds on PR when changes detected under:
- `docs/`
- `.readthedocs.yaml`
- `causalpy` (exluding sub-folders: `tests/` , `data/`, and `skills/`

### Question

Are you happy with the files/folders specified above @drbenvincent ? 

Let me know if their are any inclusions/exclusions you also want to be made explicit. 
Also note that this only applies to PR preview builds. When merged to main, docs build will trigger regardless.

### Testing

Tested the expected behaviour on my fork repo RussellSB/CausalPy, which I linked to ReadTheDocs:

| # | Scenario | Expected Behavior | Observed Result | Evidence PR(s) | Status |
|---|---|---|---|---|---|
| 1 | Merge to `main` after implementing RTD skip logic and follow-up fixes | Docs build on `main` should still run normally and complete successfully | Docs build on `main` completed successfully after merge | [#1](https://github.com/RussellSB/CausalPy/pull/1), [#4](https://github.com/RussellSB/CausalPy/pull/4), [#5](https://github.com/RussellSB/CausalPy/pull/5) | Pass |
| 2 | PR with no docs-relevant changes | RTD preview build should be cancelled/skipped | Preview was skipped as intended | [#2](https://github.com/RussellSB/CausalPy/pull/2) | Pass |
| 3 | PR with docs-relevant changes | RTD preview build should run | Preview build ran as expected | [#3](https://github.com/RussellSB/CausalPy/pull/3) | Pass |

### Screenshots

Inspecting from the ReadTheDocs builds page `1`, `2`, `3` follows successful expected behaviour described above:

<img width="1416" height="713" alt="image" src="https://github.com/user-attachments/assets/51eab264-cdde-4555-9f94-50721af318bd" />

And clicking on `2`:

<img width="879" height="845" alt="image" src="https://github.com/user-attachments/assets/1c887316-060b-4634-b316-15a9211643e2" />

----

### Resources

Implemented following read the docs guidelines
- https://docs.readthedocs.com/platform/stable/guides/build/skip-build.html
- https://docs.readthedocs.com/platform/stable/build-customization.html
- https://docs.readthedocs.com/platform/stable/config-file/v2.html
