### PR TITLE
Slim ARCHITECTURE.md and reference it from CONTRIBUTING.md

### DIFF
--- a/.github/skills/review-pr/SKILL.md
+++ b/.github/skills/review-pr/SKILL.md
@@ -65,7 +65,7 @@ Read these when the PR touches the relevant surface:
 
 ## CausalPy Review Norms
 
-- Before reviewing code, read `AGENTS.md` and relevant local context. For docs-heavy PRs, also inspect `docs/source/notebooks/index.md`; for process-sensitive PRs, inspect `CONTRIBUTING.md` when present.
+- Before reviewing code, read `AGENTS.md` (workflow) and `ARCHITECTURE.md` (design) for core changes. For docs-heavy PRs, also inspect `docs/source/notebooks/index.md`; for process-sensitive PRs, inspect `CONTRIBUTING.md` when present.
 - Use `$CONDA_EXE run -n CausalPy <command>` for commands that import project code, run tests, build docs, or invoke repo tooling. `AGENTS.md` defines how to detect or set `CONDA_EXE`; if it is unset, inspect that environment guidance before running project commands.
 - Use full permissions for commands that import PyMC, PyTensor, or matplotlib to avoid false sandbox failures.
 - During review, prefer targeted local checks that match the changed surface. If you edit code or prepare a commit, run `prek run` during iteration and `prek run --all-files` before handoff unless the user explicitly says not to.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 # AGENTS
 
+Agent-facing conventions for working in this repo. For design orientation, read [ARCHITECTURE.md](ARCHITECTURE.md) before core code changes. Do **not** load [CONTRIBUTING.md](CONTRIBUTING.md) by default — it is a long human-contributor guide (setup, permissions, PR etiquette). Consult it only when the task is explicitly about contributor workflow or onboarding humans.
+
 ## Environment
 
 Use `mamba`, `micromamba`, or `conda` (in that preference order) to manage the `CausalPy` environment. Reuse an existing `CausalPy` env whenever possible; do not create or update an env unless the task needs the project environment and the existing env is missing, stale, or broken. Use `$CONDA_EXE run -n CausalPy <command>` for commands that import project code, run tests, build docs, or use repo tooling; never use `$CONDA_EXE activate`. For simple text/JSON inspection helpers that do not import project code, any Python on `PATH` is fine.
@@ -9,7 +11,7 @@ See the [python-environment skill](.github/skills/python-environment/SKILL.md) f
 - If `$CONDA_EXE run -n CausalPy ...` fails because the named env cannot be resolved, inspect `$CONDA_EXE env list` and retry with `$CONDA_EXE run -p <full-prefix> <command>`.
 - In git worktrees, prefer reusing an existing env. Because the repo uses editable installs, rerun `make setup` in the current worktree only when that checkout has not been installed into the env yet or when dependencies changed.
 
-- Dependencies live in `pyproject.toml`; `environment.yml` is generated from it (do not edit by hand—see CONTRIBUTING). Optional: `pymc-marketing` is in the `docs` extra only.
+- Dependencies live in `pyproject.toml`; `environment.yml` is generated from it by a prek hook (do not edit by hand). Optional: `pymc-marketing` is in the `docs` extra only.
 - **Development**: The supported setup is the conda env (`environment.yml`). `pip install -e .[dev]` works but does not include conda-only tooling (e.g. `make`, `pymc-bart`, `marimo`); do not suggest pip-only dev as equivalent.
 
 ## Architecture

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS
 
-Agent-facing conventions for working in this repo. For design orientation, read [ARCHITECTURE.md](ARCHITECTURE.md) before core code changes. Do **not** load [CONTRIBUTING.md](CONTRIBUTING.md) by default — it is a long human-contributor guide (setup, permissions, PR etiquette). Consult it only when the task is explicitly about contributor workflow or onboarding humans.
+Agent workflow for working in this repo. For codebase design and conventions, read [ARCHITECTURE.md](ARCHITECTURE.md) before core code changes. Do **not** load [CONTRIBUTING.md](CONTRIBUTING.md) by default — it is a long human-contributor guide (setup, permissions, PR etiquette). Consult it only when the task is explicitly about contributor workflow or onboarding humans.
 
 ## Environment
 
@@ -14,21 +14,12 @@ See the [python-environment skill](.github/skills/python-environment/SKILL.md) f
 - Dependencies live in `pyproject.toml`; `environment.yml` is generated from it by a prek hook (do not edit by hand). Optional: `pymc-marketing` is in the `docs` extra only.
 - **Development**: The supported setup is the conda env (`environment.yml`). `pip install -e .[dev]` works but does not include conda-only tooling (e.g. `make`, `pymc-bart`, `marimo`); do not suggest pip-only dev as equivalent.
 
-## Architecture
-
-Read [ARCHITECTURE.md](ARCHITECTURE.md) before making changes to core code. It describes the backend dispatch system, experiment lifecycle, formula/data pipeline, and data contracts — the foundational patterns that every change must respect.
-
-**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, or data contract, update ARCHITECTURE.md in the same PR. The file is a living reference, not a snapshot.
-
-## Testing preferences
+## Testing
 
 - Write all Python tests as `pytest` style functions, not unittest classes
 - Use descriptive function names starting with `test_`
 - Prefer fixtures over setup/teardown methods
 - Use assert statements directly, not self.assertEqual
-
-## Testing approach
-
 - Never create throwaway test scripts or ad hoc verification files
 - If you need to test functionality, write a proper test in the test suite
 - All tests go in the `causalpy/tests/` directory following the project structure
@@ -62,18 +53,6 @@ Read [ARCHITECTURE.md](ARCHITECTURE.md) before making changes to core code. It d
   - **PR drafts**: Create PR summary markdown files in `.scratch/pr_summaries/` (untracked).
   - **Issue drafts**: Create issue draft markdown files in `.scratch/issue_summaries/` (untracked).
 - **No hard line wrapping in prose-like text**: Do not hard-wrap lines in any prose context — Markdown files, long comments in code (TOML/YAML/Python/etc.), commit-message bodies, PR descriptions, issue descriptions, or GitHub comments. One paragraph = one line; rely on the viewer/editor to re-wrap. Hard wraps look ragged at different widths, make diffs noisy on every reflow, and mangle when copied or quoted. Code itself, code blocks inside Markdown, ASCII tables, and structured config values are exempt — those need their literal line structure.
-
-## Code structure and style
-
-- **Experiment classes**: All experiment classes inherit from `BaseExperiment` in `causalpy/experiments/`. Must declare `supports_ols` and `supports_bayes` class attributes. Only implement abstract methods for supported model types (e.g., if only Bayesian is supported, implement `_bayesian_plot()` and `get_plot_data_bayesian()`; if only OLS is supported, implement `_ols_plot()` and `get_plot_data_ols()`)
-- **Model-agnostic design**: Experiment classes should work with both PyMC and scikit-learn models. Use `isinstance(self.model, PyMCModel)` vs `isinstance(self.model, RegressorMixin)` to dispatch to appropriate implementations
-- **Model classes**: PyMC models inherit from `PyMCModel` (extends `pm.Model`). Scikit-learn models use `RegressorMixin` and are made compatible via `create_causalpy_compatible_class()`. Common interface: `fit()`, `predict()`, `score()`, `calculate_impact()`, `print_coefficients()`
-- **Data handling**: PyMC models use `xarray.DataArray` with coords (keys like "coeffs", "obs_ind", "treated_units"). Scikit-learn models use numpy arrays. Data index should be named "obs_ind"
-- **Formulas**: Use patsy for formula parsing (via `dmatrices()`)
-- **Custom exceptions**: Use project-specific exceptions from `causalpy.custom_exceptions`: `FormulaException`, `DataException`, `BadIndexException`
-- **File organization**: Experiments in `causalpy/experiments/`, PyMC models in `causalpy/pymc_models.py`, scikit-learn models in `causalpy/skl_models.py`
-- **Backwards compatibility**: Avoid preserving backwards compatibility for API elements introduced within the same PR; only maintain compatibility for previously released APIs.
-- **Public `plot()` signatures**: ``BaseExperiment`` deliberately does **not** define a public ``plot()`` method. Every concrete experiment subclass must declare its own ``plot()`` with an explicit, kwarg-only signature (using ``*,``); bare ``*args`` and ``**kwargs`` are forbidden at the public surface because they silently swallow real, supported parameters and hide them from Sphinx, IDE autocomplete, and ``help()``. The body of ``plot()`` should delegate to the protected helper ``self._render_plot(...)`` (which applies the shared style context, dispatches to ``_bayesian_plot`` / ``_ols_plot``, applies ``legend_kwargs``, and optionally calls ``plt.show()``). Document every parameter in the docstring's ``Parameters`` block — the test ``causalpy/tests/test_public_plot_signatures.py`` and the ``numpydoc-validation`` pre-commit hook enforce this. For experiments without a unified plot view (e.g. ``InversePropensityWeighting``, ``InstrumentalVariable``), still declare an explicit ``plot()`` stub that raises ``NotImplementedError`` and points at the bespoke alternatives. For ``hdi_prob`` defaults, use the prose pattern (``Defaults to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).``) rather than the numpydoc ``default=...`` slot, so the cross-reference renders.
 
 ## Code quality checks
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,39 +1,29 @@
 # ARCHITECTURE
 
-Internal architecture reference for AI agents and contributors working on CausalPy.
+CausalPy implements 10+ quasi-experimental causal inference methods over two statistical backends (PyMC and scikit-learn). This document orients agents and contributors to where things live, how the pieces compose, and the non-obvious conventions.
 
 ## Module Map
 
 | Path | Purpose |
 |------|---------|
-| `causalpy/__init__.py` | Public API surface — re-exports all experiment classes, models, pipeline, steps, transforms |
-| `causalpy/experiments/` | Package of experiment classes (one per file) plus `base.py` |
-| `causalpy/experiments/base.py` | `BaseExperiment` ABC — dispatch logic, `_render_plot`, maketables hooks |
+| `causalpy/__init__.py` | Public API — re-exports experiment classes, models, pipeline, steps, transforms |
+| `causalpy/experiments/` | One experiment class per file; `base.py` holds `BaseExperiment` |
 | `causalpy/pymc_models.py` | All `PyMCModel` subclasses (Bayesian backend) |
-| `causalpy/skl_models.py` | `ScikitLearnAdaptor` mixin, `WeightedProportion`, `create_causalpy_compatible_class()` |
-| `causalpy/reporting.py` | `EffectSummary` dataclass, statistics computation, prose generation for both backends |
-| `causalpy/maketables_adapters.py` | Backend-specific adapters for optional `maketables` table export |
+| `causalpy/skl_models.py` | `ScikitLearnAdaptor` mixin, `create_causalpy_compatible_class()` |
+| `causalpy/reporting.py` | `EffectSummary`, statistics and prose for both backends |
 | `causalpy/pipeline.py` | `Pipeline`, `PipelineContext`, `PipelineResult`, `Step` protocol |
-| `causalpy/steps/` | Pipeline steps: `EstimateEffect`, `SensitivityAnalysis`, `GenerateReport` |
-| `causalpy/checks/` | Diagnostic checks: `PlaceboInTime`, `PlaceboInSpace`, `LeaveOneOut`, `ConvexHullCheck`, `BandwidthSensitivity`, `McCraryDensityTest`, `PriorSensitivity`, `PersistenceCheck`, `PreTreatmentPlaceboCheck` |
-| `causalpy/transforms.py` | Patsy stateful transforms `step()` and `ramp()` for piecewise ITS |
-| `causalpy/variable_selection_priors.py` | Spike-and-slab and horseshoe priors for IV variable selection |
-| `causalpy/constants.py` | `HDI_PROB` (0.94), `LEGEND_FONT_SIZE` (12) |
-| `causalpy/custom_exceptions.py` | `BadIndexException`, `FormulaException`, `DataException` |
-| `causalpy/utils.py` | Shared helpers: `round_num`, `_as_scalar`, `extract_lift_for_mmm`, `plot_correlations`, formula parsing utils |
-| `causalpy/plot_utils.py` | `plot_xY` (HDI ribbon helper), `get_hdi_to_df` |
-| `causalpy/date_utils.py` | Date axis formatting for matplotlib (`format_date_axes`, `_combine_datetime_indices`) |
-| `causalpy/data/` | `load_data()` and `simulate_data` module for example/synthetic datasets |
-| `causalpy/version.py` | `__version__` string |
-| `causalpy/tests/` | pytest suite — integration tests per backend, unit tests for models/reporting/checks |
-| `docs/source/notebooks/` | Jupyter how-to notebooks (named `{method}_{backend}.ipynb`) |
-| `docs/source/knowledgebase/` | Educational content (glossary, reporting statistics explainers) |
+| `causalpy/steps/` | `EstimateEffect`, `SensitivityAnalysis`, `GenerateReport` |
+| `causalpy/checks/` | Diagnostic checks (`PlaceboInTime`, `LeaveOneOut`, `ConvexHullCheck`, etc.) |
+| `causalpy/transforms.py` | Patsy `step()` / `ramp()` transforms for piecewise ITS |
+| `causalpy/data/` | `load_data()` and synthetic dataset generators |
+| `causalpy/tests/` | pytest suite |
+| Support modules | `constants.py`, `custom_exceptions.py`, `utils.py`, `plot_utils.py`, `date_utils.py`, `variable_selection_priors.py`, `maketables_adapters.py` |
+| `docs/source/notebooks/` | How-to notebooks (`{method}_{backend}.ipynb`) |
+| `docs/source/knowledgebase/` | Educational content (glossary, reporting explainers) |
 
-## Backend Architecture
+## Two-Backend Model
 
-CausalPy supports two model backends dispatched via `isinstance` checks:
-
-### Dispatch Pattern
+Dispatch is via `isinstance` checks throughout `BaseExperiment` and experiment subclasses:
 
 ```python
 if isinstance(self.model, PyMCModel):
@@ -42,230 +32,53 @@ elif isinstance(self.model, RegressorMixin):
     # OLS path — numpy arrays
 ```
 
-This pattern appears in `BaseExperiment.__init__` (validation), `_render_plot` (plotting), `get_plot_data` (data export), and each experiment's `algorithm()` and `effect_summary()`.
+`PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` (mutates the instance in place).
 
-### PyMCModel (Bayesian backend)
-
-`PyMCModel` extends `pymc.Model` and provides a sklearn-like interface:
-
-| Method | Contract |
-|--------|----------|
-| `build_model(X, y, coords)` | Define PyMC model graph. Must register `pm.Data("X", ...)` and `pm.Data("y", ...)`, create `mu` Deterministic and `y_hat` likelihood with dims `["obs_ind", "treated_units"]` |
-| `fit(X, y, coords)` | Calls `build_model`, then `pm.sample`, `sample_prior_predictive`, `sample_posterior_predictive`. Returns `az.InferenceData` |
-| `predict(X)` | Calls `_data_setter(X)` then `sample_posterior_predictive` for `["y_hat", "mu"]`. Returns `az.InferenceData` |
-| `score(X, y)` | Computes Bayesian R² per treated unit. Returns `pd.Series` |
-| `calculate_impact(y_true, y_pred)` | `y_true - y_pred["posterior_predictive"]["mu"]` (uses mu, NOT y_hat) |
-| `print_coefficients(labels)` | Prints posterior mean + HDI for each coefficient |
-
-Priors use `pymc_extras.Prior` objects. Priority: user-specified > `priors_from_data()` > `default_priors` class attribute.
-
-### ScikitLearnAdaptor (OLS backend)
-
-`ScikitLearnAdaptor` is a mixin class providing CausalPy-compatible methods:
-
-- `calculate_impact(y_true, y_pred)` → `y_true - y_pred` (numpy subtraction)
-- `calculate_cumulative_impact(impact)` → `np.cumsum(impact)`
-- `print_coefficients(labels)` → prints `coef_` values
-- `get_coeffs()` → `np.squeeze(self.coef_)`
-
-`create_causalpy_compatible_class(estimator)` takes an instantiated sklearn `RegressorMixin` and monkey-patches `ScikitLearnAdaptor` methods onto it via `_add_mixin_methods`. Returns the mutated instance (not a new class).
-
-### supports_ols / supports_bayes
-
-Every experiment class declares these as class attributes. `BaseExperiment.__init__` raises `ValueError` if the wrong model type is passed.
-
-### _default_model_class
-
-When `model=None` is passed to an experiment, `BaseExperiment.__init__` instantiates `_default_model_class()` with no arguments. This always produces a Bayesian model. Experiments without a default (e.g. `PanelRegression`) raise `ValueError` if `model=None`.
+Every experiment declares `supports_ols` and `supports_bayes`; `BaseExperiment.__init__` validates the model type. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model).
 
 ## Experiment Lifecycle
 
-### 1. Instantiation
-
-```text
-ExperimentClass(data, ..., model=None)
-  → BaseExperiment.__init__(model)
-      → wrap sklearn model via create_causalpy_compatible_class() if needed
-      → instantiate _default_model_class if model is None
-      → validate supports_ols / supports_bayes
-  → self.data = data; self.formula = formula
-  → input_validation(...)
-  → _build_design_matrices()
-  → _prepare_data()  (convert to xarray DataArrays)
-  → algorithm()
-```
-
-Most experiments fit eagerly in `__init__` — instantiation triggers the full MCMC run. There is no separate `.fit()` on the experiment (only on the model).
-
-### 2. _build_design_matrices()
-
-Uses patsy `dmatrices(formula, data_pre)` for pre-intervention data, stores `design_info`. Uses `build_design_matrices([y_design_info, x_design_info], data_post)` for post-intervention data — this ensures consistent encoding for out-of-sample prediction.
-
-### 3. _prepare_data()
-
-Converts numpy design matrices into `xr.DataArray` with dims `["obs_ind", "coeffs"]` for X and `["obs_ind", "treated_units"]` for y.
-
-### 4. algorithm()
-
-Per-experiment fitting logic:
-1. `model.fit(X_pre, y_pre, coords)` — train on pre-intervention data
-2. `model.score(X_pre, y_pre)` — evaluate fit quality
-3. `model.predict(X_pre)` — in-sample predictions
-4. `model.predict(X_post)` — counterfactual predictions
-5. `model.calculate_impact(y_post, post_pred)` — causal effect
-6. `model.calculate_cumulative_impact(impact)` — cumulative effect
-
-### 5. _render_plot()
-
-Template method called by each subclass's public `plot()`:
-1. Applies `arviz-darkgrid` style context
-2. Dispatches to `_bayesian_plot(**draw_kwargs)` or `_ols_plot(**draw_kwargs)` based on model type
-3. Applies `legend_kwargs` in-place to preserve custom handles
-4. Optionally calls `plt.show()`
-
-### 6. effect_summary()
-
-Abstract method on `BaseExperiment`. Each subclass implements it using helpers from `causalpy.reporting`:
-- Bayesian: `_compute_statistics()` → `_generate_table()` → `_generate_prose_detailed()`
-- OLS: `_compute_statistics_ols()` → `_generate_table_ols()` → `_generate_prose_detailed_ols()`
-
-Returns `EffectSummary(table=pd.DataFrame, text=str)`.
-
-### 7. get_plot_data()
-
-Dispatches to `get_plot_data_bayesian()` or `get_plot_data_ols()`. Returns a `pd.DataFrame` with columns for predictions, impacts, and HDI bounds.
-
-## Formula and Data Pipeline
-
-### patsy workflow
-
-1. `dmatrices(formula, df_pre)` → `(y, X)` numpy DesignMatrix objects
-2. Store `y.design_info` and `X.design_info` for later reuse
-3. `build_design_matrices([y_design_info, x_design_info], df_post)` → counterfactual matrices with consistent factor encoding
-4. `self.labels = X.design_info.column_names` — coefficient names
-
-### Custom transforms (PiecewiseITS)
-
-`step(time, threshold)` → binary indicator `(time >= threshold)`
-`ramp(time, threshold)` → `max(0, time - threshold)`
-
-Both are patsy `stateful_transform` objects that memorize datetime origin during first pass and convert datetime to numeric days internally.
-
-### obs_ind index naming
-
-All experiments rename `data.index.name = "obs_ind"`. This is the canonical dimension name for xarray DataArrays and PyMC model coordinates.
-
-## Data Contracts
-
-### PyMC Backend
-
-| Object | Type | Dims/Coords |
-|--------|------|-------------|
-| X (input) | `xr.DataArray` | `["obs_ind", "coeffs"]` with coord values |
-| y (input) | `xr.DataArray` | `["obs_ind", "treated_units"]` — always 2D |
-| coords dict | `dict` | Keys: `"coeffs"`, `"obs_ind"`, `"treated_units"` (required) |
-| fit() return | `az.InferenceData` | Contains posterior, prior_predictive, posterior_predictive |
-| predict() return | `az.InferenceData` | `posterior_predictive` group with `mu` and `y_hat` vars |
-| mu | `xr.DataArray` | Deterministic mean; dims `["chain", "draw", "obs_ind", "treated_units"]` |
-| y_hat | `xr.DataArray` | Observation with noise; same dims as mu |
-| impact | `xr.DataArray` | `y_true - mu`; trailing dim is `"obs_ind"` |
-
-Key conventions:
-- `treated_units` dim is **always present and 2D** even for single-unit experiments (value: `["unit_0"]`)
-- Impact uses `mu` (posterior expectation), NOT `y_hat` (with observation noise)
-- `coeffs_raw` dim appears in softmax models (N-1 logits, first pinned to zero)
-
-### sklearn Backend
-
-| Object | Type | Notes |
-|--------|------|-------|
-| X (input) | `np.ndarray` or `xr.DataArray` | 2D, shape `(n_obs, n_features)` |
-| y (input) | `np.ndarray` or 1D `xr.DataArray` | `.isel(treated_units=0)` before passing to sklearn |
-| predict() return | `np.ndarray` | Shape `(n_obs, 1)` or `(n_obs,)` |
-| coef_ | `np.ndarray` | Accessed via `get_coeffs()` → squeezed |
-| impact | `np.ndarray` | Simple `y_true - y_pred` |
+Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepare_data()` → `algorithm()`. There is no separate `.fit()` on the experiment. Each subclass's public `plot(*, ...)` delegates to `_render_plot()`, which dispatches to `_bayesian_plot()` or `_ols_plot()`. `effect_summary()` returns `EffectSummary(table, text)` using helpers from `causalpy.reporting`.
 
 ## Experiment Inventory
 
-| Class | Causal Method | `supports_ols` | `supports_bayes` | Default Model | Notable Quirks |
-|-------|--------------|-----------------|-------------------|---------------|----------------|
-| `InterruptedTimeSeries` | ITS (pre/post fit) | Yes | Yes | `LinearRegression` | Supports 3-period design via `treatment_end_time`; eager fit in `__init__` |
-| `PiecewiseITS` | ITS (segmented regression) | Yes | Yes | `LinearRegression` | Fits full time series (not pre-only); uses `step()`/`ramp()` transforms |
-| `DifferenceInDifferences` | DiD | Yes | Yes | `LinearRegression` | Fits all data (no pre/post split); effect from interaction coefficient |
-| `StaggeredDifferenceInDifferences` | Staggered DiD (BJS imputation) | Yes | Yes | `LinearRegression` | Fits untreated observations only; validates absorbing treatment |
-| `SyntheticControl` | SC | Yes | Yes | `WeightedSumFitter` | Multi-unit (multiple `treated_units`); no formula — uses control/treated unit lists |
-| `SyntheticDifferenceInDifferences` | SDiD | Yes | Yes | `SDiDWeightFitter` | Cut-posterior: tau computed analytically from weight posteriors |
-| `RegressionDiscontinuity` | RD (sharp) | Yes | Yes | `LinearRegression` | `epsilon` parameter for causal effect evaluation at threshold; optional `bandwidth` |
-| `RegressionKink` | RKD | No | Yes | `LinearRegression` | `kink_point` instead of threshold; evaluates slope change |
-| `PrePostNEGD` | Pretest/posttest | No | Yes | `LinearRegression` | Uses `group_variable_name` and `pretreatment_variable_name` |
-| `InversePropensityWeighting` | IPW | No | Yes | `PropensityScore` | Non-standard: two-stage (propensity then outcome); no unified `plot()` |
-| `InstrumentalVariable` | IV/2SLS | No | Yes | `IVRegression` | Non-standard `fit()` signature (X, Z, y, t, coords, priors); no unified `plot()` |
-| `PanelRegression` | Panel FE | Yes | Yes | None (required) | Supports demeaned and dummy-variable FE; no `_default_model_class` |
+| Class | Method | Backends | Notable quirk |
+|-------|--------|----------|---------------|
+| `InterruptedTimeSeries` | ITS | OLS + Bayes | 3-period design via `treatment_end_time` |
+| `PiecewiseITS` | Segmented ITS | OLS + Bayes | Fits full series; `step()`/`ramp()` transforms |
+| `DifferenceInDifferences` | DiD | OLS + Bayes | Effect from interaction coefficient |
+| `StaggeredDifferenceInDifferences` | Staggered DiD | OLS + Bayes | Fits untreated obs only |
+| `SyntheticControl` | SC | OLS + Bayes | Multi-unit; control/treated unit lists, no formula |
+| `SyntheticDifferenceInDifferences` | SDiD | OLS + Bayes | Tau computed analytically from weight posteriors |
+| `RegressionDiscontinuity` | RD | OLS + Bayes | `epsilon` at threshold; optional `bandwidth` |
+| `RegressionKink` | RKD | Bayes only | Slope change at `kink_point` |
+| `PrePostNEGD` | Pretest/posttest | Bayes only | `group_variable_name` + `pretreatment_variable_name` |
+| `InversePropensityWeighting` | IPW | Bayes only | Two-stage; no unified `plot()` |
+| `InstrumentalVariable` | IV/2SLS | Bayes only | Non-standard `fit()` signature; no unified `plot()` |
+| `PanelRegression` | Panel FE | OLS + Bayes | No `_default_model_class`; model required |
 
-## PyMC Model Inventory
+## PyMC Models
 
-| Class | Purpose | Used By |
-|-------|---------|---------|
-| `PyMCModel` | Abstract base — provides fit/predict/score/calculate_impact contract | All Bayesian experiments (via subclasses) |
-| `LinearRegression` | Standard linear model: `y ~ Normal(X·β, σ)` | ITS, DiD, RD, RKD, PrePostNEGD, PiecewiseITS, StaggeredDiD, PanelRegression |
-| `WeightedSumFitter` | Dirichlet-weighted sum: `y ~ Normal(X·β, σ)` where `β ~ Dirichlet(1)` | SyntheticControl |
-| `SoftmaxWeightedSumFitter` | Softmax-Normal simplex weights (alternative to Dirichlet) | SyntheticControl (alternative) |
-| `SyntheticDifferenceInDifferencesWeightFitter` | Joint unit + time weight model for SDiD | SyntheticDifferenceInDifferences |
-| `InstrumentalVariableRegression` | 2SLS with correlated errors (LKJ covariance or binary treatment) | InstrumentalVariable |
-| `PropensityScore` | Logistic propensity model: `t ~ Bernoulli(logit⁻¹(X·b))` | InversePropensityWeighting |
-| `BayesianBasisExpansionTimeSeries` | Trend + seasonality via pymc-marketing components (experimental) | InterruptedTimeSeries (alternative) |
-| `StateSpaceTimeSeries` | State-space model via pymc-extras structural (experimental) | InterruptedTimeSeries (alternative) |
+- `LinearRegression` — ITS, DiD, RD, RKD, PrePostNEGD, PiecewiseITS, StaggeredDiD, PanelRegression
+- `WeightedSumFitter` / `SoftmaxWeightedSumFitter` — SyntheticControl
+- `SyntheticDifferenceInDifferencesWeightFitter` — SyntheticDifferenceInDifferences
+- `InstrumentalVariableRegression` — InstrumentalVariable
+- `PropensityScore` — InversePropensityWeighting
+- `BayesianBasisExpansionTimeSeries` / `StateSpaceTimeSeries` — ITS alternatives (experimental)
 
-## Extension Guide
-
-### Add a new experiment class
-
-1. Create `causalpy/experiments/your_method.py`
-2. Subclass `BaseExperiment`
-3. Set `supports_ols`, `supports_bayes`, and optionally `_default_model_class`
-4. Implement `__init__` calling `super().__init__(model=model)` then `_build_design_matrices()` → `algorithm()`
-5. Implement `algorithm()` with the fit/predict/impact flow
-6. Implement `_bayesian_plot()` and/or `_ols_plot()` (only for supported backends)
-7. Implement `effect_summary()` using helpers from `causalpy.reporting`
-8. Declare an explicit public `plot(*, ...)` method with kwarg-only signature that calls `self._render_plot(...)`
-9. Export from `causalpy/experiments/__init__.py` and `causalpy/__init__.py`
-
-### Add a new PyMC model
-
-1. Add class to `causalpy/pymc_models.py` inheriting from `PyMCModel`
-2. Implement `build_model(X, y, coords)` — must create `pm.Data("X", ...)`, `pm.Data("y", ...)`, a `pm.Deterministic("mu", ..., dims=["obs_ind", "treated_units"])`, and a likelihood named `"y_hat"`
-3. Set `default_priors` dict with `Prior` objects
-4. Optionally override `priors_from_data(X, y)` for data-adaptive priors
-5. Optionally override `_data_setter(X)` if prediction requires custom data updates
-6. If `fit()` signature differs from base (non-standard arguments), override it with `# type: ignore[override]`
-
-### Add a new sklearn-compatible model
-
-1. Create a class inheriting from both `ScikitLearnAdaptor` and sklearn's `LinearModel` + `RegressorMixin`
-2. Implement `fit(X, y)` and `predict(X)` — store coefficients in `self.coef_` as 2D array
-3. Alternatively, pass any fitted sklearn `RegressorMixin` instance — `create_causalpy_compatible_class()` will monkey-patch the adapter methods automatically
-
-### Add a new plotting backend or report format
-
-- For plots: override `_bayesian_plot()` / `_ols_plot()` in experiment subclass, or create a new dispatch in `_render_plot()`
-- For reports: extend `causalpy/steps/report.py` (`GenerateReport` step produces HTML); the experiment's `generate_report()` method wraps this
-- For table export: add a new adapter in `causalpy/maketables_adapters.py` implementing the `MaketablesAdapter` protocol
-
-## Key Conventions and Gotchas
+## Key Conventions
 
 | Topic | Detail |
 |-------|--------|
-| **Intercept handling** | Patsy includes an intercept by default (`1 +` in formula). sklearn models must use `fit_intercept=False` because the intercept is already in the design matrix as a column of ones. |
-| **treated_units is always 2D** | Even single-unit experiments use `treated_units=["unit_0"]`. y is always shape `(n_obs, n_treated)`. Never pass 1D y to a PyMC model. |
-| **Impact uses mu, not y_hat** | `calculate_impact()` subtracts `posterior_predictive["mu"]` (expected value), not `["y_hat"]` (with observation noise). This gives cleaner effect estimates reflecting only parameter uncertainty. |
-| **labels must align with coefficients** | `self.labels` comes from `X.design_info.column_names` and must match the `coeffs` dimension of the posterior `beta` variable exactly in order and length. |
-| **maketables adapter dispatch** | `get_maketables_adapter(model)` mirrors the `isinstance` dispatch: `PyMCModel` → `PyMCMaketablesAdapter`, `RegressorMixin` → `SklearnMaketablesAdapter`. |
-| **obs_ind index naming** | Experiments rename `data.index.name = "obs_ind"` early. All xarray dims use this name. PyMC coords key must be `"obs_ind"`. |
-| **design_info for out-of-sample** | Store `_x_design_info` and `_y_design_info` from `dmatrices()`. Use `build_design_matrices([info], new_data)` for counterfactual prediction to preserve factor encoding. |
-| **Eager fitting in __init__** | Most experiments run MCMC during `__init__`. There is no lazy `.fit()` — the experiment object is fully fitted upon construction. |
-| **HDI_PROB default** | The project uses 0.94 (matching ArviZ default), NOT 0.95. `effect_summary()` defaults to `alpha=0.05` (95% HDI), which is independent of `HDI_PROB`. |
-| **SyntheticControl multi-unit** | `SyntheticControl` loops over `treated_units` fitting one model per unit (via `_clone()`). Each unit gets its own `pre_pred`, `post_pred`, `impact`. |
-| **SDiD cut-posterior** | Treatment effect tau is NOT estimated inside the MCMC model. Unit and time weights are sampled jointly, then tau is computed analytically via double-differencing the observed data with the weight posteriors. |
-| **InstrumentalVariable non-standard fit** | `IVRegression.fit(X, Z, y, t, coords, priors, ...)` — does NOT follow the base `fit(X, y, coords)` signature. The experiment class handles this internally. |
-| **create_causalpy_compatible_class mutates** | This function mutates the passed instance (adds methods), it does NOT create a new class or return a new instance. The name is misleading. |
-| **Pipeline vs direct instantiation** | Experiments can be used standalone (just instantiate) or via `Pipeline` with steps. The pipeline adds `SensitivityAnalysis` and `GenerateReport` on top. |
+| **Formulas** | Patsy `dmatrices()` for design matrices; `build_design_matrices()` for counterfactual prediction. `PiecewiseITS` uses `step()`/`ramp()` stateful transforms. |
+| **obs_ind** | All experiments set `data.index.name = "obs_ind"`. Canonical xarray/PyMC dimension name. |
+| **treated_units always 2D** | Even single-unit experiments use `treated_units=["unit_0"]`. Never pass 1D y to PyMC. |
+| **Impact uses mu, not y_hat** | `calculate_impact()` subtracts posterior `mu` (expected value), not `y_hat` (with observation noise). |
+| **Intercept handling** | Patsy includes intercept by default. sklearn models must use `fit_intercept=False`. |
+| **Eager fitting** | MCMC runs during `__init__`. No lazy `.fit()` on the experiment. |
+| **HDI_PROB** | Project default is 0.94 (ArviZ default), not 0.95. |
+| **create_causalpy_compatible_class** | Mutates the passed sklearn instance in place; does not return a new object. |
+
+## Adding New Code
+
+Copy the closest existing experiment or model and follow the `BaseExperiment` contract (`supports_ols`/`supports_bayes`, `algorithm()`, explicit `plot()`, `effect_summary()`). See [AGENTS.md](AGENTS.md) for coding conventions and the requirement to update this file when making structural changes.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,4 +81,12 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 
 ## Adding New Code
 
-Copy the closest existing experiment or model and follow the `BaseExperiment` contract (`supports_ols`/`supports_bayes`, `algorithm()`, explicit `plot()`, `effect_summary()`). See [AGENTS.md](AGENTS.md) for coding conventions and the requirement to update this file when making structural changes.
+Copy the closest existing experiment or model and follow the `BaseExperiment` contract:
+
+- Declare `supports_ols` / `supports_bayes`; implement `_bayesian_plot()` / `_ols_plot()` only for supported backends
+- `algorithm()` with the fit/predict/impact flow; `effect_summary()` via helpers in `causalpy.reporting`
+- Public `plot(*, ...)` with a kwarg-only signature that delegates to `_render_plot()` — bare `*args` / `**kwargs` are forbidden on the public surface (enforced by `causalpy/tests/test_public_plot_signatures.py`). For experiments without a unified plot view (e.g. `InversePropensityWeighting`, `InstrumentalVariable`), declare an explicit `plot()` stub that raises `NotImplementedError`. For `hdi_prob` defaults, use ``Defaults to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).`` in the docstring.
+- Raise `FormulaException`, `DataException`, or `BadIndexException` from `causalpy.custom_exceptions` for formula, data, and index errors
+- Avoid backwards-compat shims for APIs introduced in the same PR
+
+**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, or data contract, update this file in the same PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ Please verify that your issue is not being currently addressed by other issues o
 
 PR's with agent-generated code are fine. But don't spam us with code you don't understand. See [AGENTS.md](./AGENTS.md) for how we use LLMs in this repo.
 
+This file is aimed at human contributors. AI agents working on code should follow [AGENTS.md](./AGENTS.md) and [ARCHITECTURE.md](./ARCHITECTURE.md) instead — not load this guide into context unless the task is about contributor workflow or onboarding.
+
 ## Contributing code via pull requests
 
 While issue reporting is valuable, we strongly encourage users who are inclined to do so to submit patches for new or existing issues via pull requests. This is particularly the case for simple fixes, such as typos or tweaks to documentation, which do not require a heavy investment of time and attention.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,8 @@ We recommend that your contribution complies with the following guidelines befor
 
 - When adding additional functionality, either edit an existing example, or create a new example (typically in the form of a Jupyter Notebook). Have a look at other examples for reference. Examples should demonstrate why the new functionality is useful in practice.
 
+- If your pull request makes a structural change — adding, removing, or reshaping an experiment class, PyMC or scikit-learn model, check, pipeline step, or a data contract — update [ARCHITECTURE.md](./ARCHITECTURE.md) in the same PR so the design overview stays accurate.
+
 - Documentation and high-coverage tests are necessary for enhancements to be accepted.
 
 - Documentation follows [NumPy style guide](https://numpydoc.readthedocs.io/en/latest/format.html)
@@ -254,6 +256,10 @@ make html
  📌 Note: The previous docs/Makefile has been removed. Please use only the root-level Makefile for documentation commands
 
 ## Overview of code structure
+
+For a prose overview of CausalPy's design — the layered architecture, the `BaseExperiment` contract, the two-backend (PyMC / scikit-learn) model system, the pipeline and checks systems, the formula interface, and the reporting layer — see [ARCHITECTURE.md](./ARCHITECTURE.md). It is the fastest way to understand where things live and how the pieces fit together.
+
+The auto-generated UML diagrams below complement that overview:
 
 Classes
 ![](docs/source/_static/classes.png)

--- a/causalpy/tests/test_public_plot_signatures.py
+++ b/causalpy/tests/test_public_plot_signatures.py
@@ -228,11 +228,11 @@ def test_base_experiment_has_no_public_plot() -> None:
     **kwargs`` signature and re-introduce the discoverability problem
     described in #886. If this test starts failing, somebody has added a
     public ``plot`` back to :class:`BaseExperiment`; either remove it or
-    update the design contract documented in ``AGENTS.md``.
+    update the design contract documented in ``ARCHITECTURE.md``.
     """
     assert "plot" not in BaseExperiment.__dict__, (
         "BaseExperiment must not declare a public plot(); the shared "
-        "dispatcher is _render_plot. See AGENTS.md and issue #886."
+        "dispatcher is _render_plot. See ARCHITECTURE.md and issue #886."
     )
     assert hasattr(BaseExperiment, "_render_plot"), (
         "BaseExperiment should define the protected _render_plot helper "


### PR DESCRIPTION
# Slim ARCHITECTURE.md and separate agent documentation

Fixes #843

## Summary

Closes #843. The original issue asked for a new `ARCHITECTURE.md` plus updates to `AGENTS.md` and `CONTRIBUTING.md`. `ARCHITECTURE.md` and the `AGENTS.md` architecture pointer already existed on `main`; this PR completes the issue by slimming that doc for agent context budgets, wiring `CONTRIBUTING.md` into the keep-current workflow, and separating `AGENTS.md` (workflow) from `ARCHITECTURE.md` (design) so there is no functional overlap.

## Changes

- **`ARCHITECTURE.md`**: condensed from ~272 to ~93 lines — module map, two-backend dispatch, lifecycle, experiment/PyMC inventories, key conventions, and extension contract (`plot()` signatures, custom exceptions, keeping-it-current policy). Removed deep reference tables, data-contract specs, and the extension guide.
- **`CONTRIBUTING.md`**: PR checklist item to update `ARCHITECTURE.md` on structural changes; pointer at top of "Overview of code structure"; note that agents should use `AGENTS.md` + `ARCHITECTURE.md`, not load this file by default.
- **`AGENTS.md`**: minimal workflow-only doc; upfront pointer to `ARCHITECTURE.md` for design; explicit instruction not to load `CONTRIBUTING.md` by default. Removed `## Code structure and style` (moved to `ARCHITECTURE.md`).
- **`causalpy/tests/test_public_plot_signatures.py`**: design-contract references updated from `AGENTS.md` to `ARCHITECTURE.md`.
- **`.github/skills/review-pr/SKILL.md`**: core PR reviews read `AGENTS.md` (workflow) and `ARCHITECTURE.md` (design).

## Testing

- `prek` and full CI green on head commit.
- No runtime code changes beyond test docstring/error-message strings.
