### PR TITLE
Add deterministic structural check scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -136,3 +136,15 @@ repos:
         language: python
         files: ^causalpy/.*\.py$
         exclude: ^causalpy/tests/
+      - id: check-public-exports
+        name: Check public API export wiring
+        entry: python scripts/check_public_exports.py --check
+        language: python
+        pass_filenames: false
+        files: ^(causalpy/__init__\.py|causalpy/experiments/.*|causalpy/checks/.*)$
+      - id: check-architecture-inventory
+        name: Check ARCHITECTURE.md experiment inventory
+        entry: python scripts/check_architecture_inventory.py --check
+        language: python
+        pass_filenames: false
+        files: ^(ARCHITECTURE\.md|causalpy/experiments/.*)$

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -89,4 +89,4 @@ Copy the closest existing experiment or model and follow the `BaseExperiment` co
 - Raise `FormulaException`, `DataException`, or `BadIndexException` from `causalpy.custom_exceptions` for formula, data, and index errors
 - Avoid backwards-compat shims for APIs introduced in the same PR
 
-**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, or data contract, update this file in the same PR.
+**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, or data contract, update this file in the same PR. Export wiring and the experiment inventory table are enforced by `scripts/check_public_exports.py` and `scripts/check_architecture_inventory.py` (also run via prek); run `make check-exports` / `make check-architecture` locally if needed.

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PACKAGE_DIR = causalpy
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: init setup lint check_lint test uml html cleandocs doctest run_notebooks_full help
+.PHONY: init setup lint check_lint check-exports check-architecture test uml html cleandocs doctest run_notebooks_full help
 
 init: ## Install the package in editable mode
 	python -m pip install -e . --no-deps
@@ -27,6 +27,12 @@ check_lint: ## Check code formatting and linting without making changes
 	ruff check .
 	ruff format --diff --check .
 	interrogate .
+
+check-exports: ## Verify experiment/check public API export wiring
+	python scripts/check_public_exports.py --check
+
+check-architecture: ## Verify ARCHITECTURE.md experiment inventory matches code
+	python scripts/check_architecture_inventory.py --check
 
 doctest: ## Run doctests for the causalpy module
 	python -m pytest --doctest-modules --ignore=causalpy/tests/ causalpy/ --config-file=causalpy/tests/conftest.py

--- a/causalpy/experiments/__init__.py
+++ b/causalpy/experiments/__init__.py
@@ -24,6 +24,7 @@ from .regression_discontinuity import RegressionDiscontinuity
 from .regression_kink import RegressionKink
 from .staggered_did import StaggeredDifferenceInDifferences
 from .synthetic_control import SyntheticControl
+from .synthetic_difference_in_differences import SyntheticDifferenceInDifferences
 
 __all__ = [
     "DifferenceInDifferences",
@@ -37,4 +38,5 @@ __all__ = [
     "RegressionKink",
     "StaggeredDifferenceInDifferences",
     "SyntheticControl",
+    "SyntheticDifferenceInDifferences",
 ]

--- a/causalpy/tests/test_check_architecture_inventory.py
+++ b/causalpy/tests/test_check_architecture_inventory.py
@@ -104,3 +104,71 @@ def test_cli_detects_backend_drift(tmp_path: Path, script_module) -> None:
     assert any(
         "RegressionKink" in line and "backends mismatch" in line for line in errors
     )
+
+
+def test_cli_detects_missing_model_required_note(tmp_path: Path, script_module) -> None:
+    """Model-required inventory notes should match ``_default_model_class``."""
+    architecture = tmp_path / "ARCHITECTURE.md"
+    architecture.write_text(
+        "\n".join(
+            [
+                "## Experiment Inventory",
+                "",
+                "| Class | Method | Backends | Notable quirk |",
+                "|-------|--------|----------|---------------|",
+                "| `PanelRegression` | Panel FE | OLS + Bayes | missing note |",
+            ]
+        )
+    )
+    errors = script_module.check_inventory(architecture)
+    assert any(
+        "PanelRegression" in line and "model-required note mismatch" in line
+        for line in errors
+    )
+
+
+def test_cli_detects_stale_model_required_note(tmp_path: Path, script_module) -> None:
+    """Default-model experiments should not be documented as model-required."""
+    architecture = tmp_path / "ARCHITECTURE.md"
+    architecture.write_text(
+        "\n".join(
+            [
+                "## Experiment Inventory",
+                "",
+                "| Class | Method | Backends | Notable quirk |",
+                "|-------|--------|----------|---------------|",
+                "| `RegressionKink` | RKD | Bayes only | model required |",
+            ]
+        )
+    )
+    errors = script_module.check_inventory(architecture)
+    assert any(
+        "RegressionKink" in line and "model-required note mismatch" in line
+        for line in errors
+    )
+
+
+def test_cli_detects_plot_stub_note_drift(tmp_path: Path, script_module) -> None:
+    """Unified-plot inventory notes should match explicit ``plot()`` stubs."""
+    architecture = tmp_path / "ARCHITECTURE.md"
+    architecture.write_text(
+        "\n".join(
+            [
+                "## Experiment Inventory",
+                "",
+                "| Class | Method | Backends | Notable quirk |",
+                "|-------|--------|----------|---------------|",
+                "| `InstrumentalVariable` | IV/2SLS | Bayes only | missing note |",
+                "| `RegressionKink` | RKD | Bayes only | no unified `plot()` |",
+            ]
+        )
+    )
+    errors = script_module.check_inventory(architecture)
+    assert any(
+        "InstrumentalVariable" in line and "plot-stub note mismatch" in line
+        for line in errors
+    )
+    assert any(
+        "RegressionKink" in line and "plot-stub note mismatch" in line
+        for line in errors
+    )

--- a/causalpy/tests/test_check_architecture_inventory.py
+++ b/causalpy/tests/test_check_architecture_inventory.py
@@ -1,0 +1,106 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for ``scripts/check_architecture_inventory.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_architecture_inventory.py"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+ARCHITECTURE_PATH = REPO_ROOT / "ARCHITECTURE.md"
+
+
+def _load_script_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location(
+        "check_architecture_inventory", SCRIPT_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script_module():
+    return _load_script_module()
+
+
+def test_repo_architecture_inventory_is_current(script_module) -> None:
+    """The repository ``ARCHITECTURE.md`` inventory should match the code."""
+    assert script_module.check_inventory(ARCHITECTURE_PATH) == []
+
+
+def test_parses_architecture_inventory_table(script_module) -> None:
+    """The parser should read experiment rows from ``ARCHITECTURE.md``."""
+    rows = script_module._parse_architecture_inventory(ARCHITECTURE_PATH)
+    assert "SyntheticDifferenceInDifferences" in rows
+    assert rows["SyntheticDifferenceInDifferences"]["backends"] == "OLS + Bayes"
+
+
+def test_introspected_backends_match_known_experiments(script_module) -> None:
+    """Introspection should surface backend support and plot stubs."""
+    inventory = script_module.introspected_inventory()
+    assert inventory["RegressionKink"].backends == "Bayes only"
+    assert inventory["PanelRegression"].default_model is None
+    assert inventory["InstrumentalVariable"].plot_is_stub is True
+
+
+def test_print_markdown_includes_all_experiments(script_module) -> None:
+    """``--print-markdown`` output should include every experiment class."""
+    markdown = script_module.print_markdown(ARCHITECTURE_PATH)
+    assert "| Class | Method | Backends | Notable quirk |" in markdown
+    assert "`SyntheticDifferenceInDifferences`" in markdown
+
+
+def test_cli_exits_zero_when_inventory_is_current() -> None:
+    """CLI ``--check`` should succeed on the current repository."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--check"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_cli_detects_backend_drift(tmp_path: Path, script_module) -> None:
+    """Backend mismatches in the doc table should be reported as errors."""
+    architecture = tmp_path / "ARCHITECTURE.md"
+    architecture.write_text(
+        "\n".join(
+            [
+                "## Experiment Inventory",
+                "",
+                "| Class | Method | Backends | Notable quirk |",
+                "|-------|--------|----------|---------------|",
+                "| `RegressionKink` | RKD | OLS + Bayes | wrong |",
+            ]
+        )
+    )
+    errors = script_module.check_inventory(architecture)
+    assert any(
+        "RegressionKink" in line and "backends mismatch" in line for line in errors
+    )

--- a/causalpy/tests/test_check_public_exports.py
+++ b/causalpy/tests/test_check_public_exports.py
@@ -1,0 +1,85 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for ``scripts/check_public_exports.py``."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_public_exports.py"
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _load_script_module():
+    if str(SCRIPTS_DIR) not in sys.path:
+        sys.path.insert(0, str(SCRIPTS_DIR))
+    spec = importlib.util.spec_from_file_location("check_public_exports", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def script_module():
+    return _load_script_module()
+
+
+def test_repo_export_wiring_is_current(script_module) -> None:
+    """The repository export wiring should pass the checker."""
+    assert script_module.check_exports() == []
+
+
+def test_detects_synthetic_did_in_experiment_exports(script_module) -> None:
+    """Synthetic DiD must be exported from ``experiments/__init__.py``."""
+    discovered = script_module.discover_experiment_class_names(
+        REPO_ROOT / "causalpy" / "experiments"
+    )
+    assert "SyntheticDifferenceInDifferences" in discovered
+
+    experiments_init = REPO_ROOT / "causalpy" / "experiments" / "__init__.py"
+    _, exp_imports = script_module._parse_init_exports(experiments_init)
+    assert "SyntheticDifferenceInDifferences" in exp_imports
+
+
+def test_cli_exits_zero_when_exports_are_current() -> None:
+    """CLI ``--check`` should succeed on the current repository."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--check"],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode == 0
+    assert result.stdout == ""
+
+
+def test_cli_requires_check_flag() -> None:
+    """The CLI should require an explicit ``--check`` flag."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH)],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=REPO_ROOT,
+    )
+    assert result.returncode != 0
+    assert "--check is required" in result.stderr

--- a/scripts/_ast_introspection.py
+++ b/scripts/_ast_introspection.py
@@ -1,0 +1,142 @@
+"""AST helpers for structural checks without importing ``causalpy``."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ExperimentMetadata:
+    class_name: str
+    supports_ols: bool
+    supports_bayes: bool
+    default_model: str | None
+    plot_is_stub: bool
+
+    @property
+    def backends(self) -> str:
+        if self.supports_ols and self.supports_bayes:
+            return "OLS + Bayes"
+        if self.supports_bayes:
+            return "Bayes only"
+        if self.supports_ols:
+            return "OLS only"
+        return "none"
+
+
+def _bases_include_base_experiment(node: ast.ClassDef) -> bool:
+    for base in node.bases:
+        if isinstance(base, ast.Name) and base.id == "BaseExperiment":
+            return True
+        if isinstance(base, ast.Attribute) and base.attr == "BaseExperiment":
+            return True
+    return False
+
+
+def _class_bool_constant(node: ast.ClassDef, name: str) -> bool:
+    for item in node.body:
+        if not isinstance(item, ast.Assign):
+            continue
+        for target in item.targets:
+            if (
+                isinstance(target, ast.Name)
+                and target.id == name
+                and isinstance(item.value, ast.Constant)
+                and isinstance(item.value.value, bool)
+            ):
+                return item.value.value
+    return False
+
+
+def _class_name_constant(node: ast.ClassDef, name: str) -> str | None:
+    for item in node.body:
+        if not isinstance(item, ast.Assign):
+            continue
+        for target in item.targets:
+            if (
+                isinstance(target, ast.Name)
+                and target.id == name
+                and isinstance(item.value, ast.Name)
+            ):
+                return item.value.id
+    return None
+
+
+def _plot_raises_not_implemented(node: ast.ClassDef) -> bool:
+    for item in node.body:
+        if not isinstance(item, ast.FunctionDef) or item.name != "plot":
+            continue
+        for stmt in ast.walk(item):
+            if not isinstance(stmt, ast.Raise) or stmt.exc is None:
+                continue
+            exc = stmt.exc
+            if isinstance(exc, ast.Name) and exc.id == "NotImplementedError":
+                return True
+            if (
+                isinstance(exc, ast.Call)
+                and isinstance(exc.func, ast.Name)
+                and exc.func.id == "NotImplementedError"
+            ):
+                return True
+    return False
+
+
+def _class_has_applicable_methods(node: ast.ClassDef) -> bool:
+    for item in node.body:
+        if (
+            isinstance(item, ast.AnnAssign)
+            and isinstance(item.target, ast.Name)
+            and item.target.id == "applicable_methods"
+        ):
+            return True
+        if not isinstance(item, ast.Assign):
+            continue
+        for target in item.targets:
+            if isinstance(target, ast.Name) and target.id == "applicable_methods":
+                return True
+    return False
+
+
+def _experiment_metadata_from_class(node: ast.ClassDef) -> ExperimentMetadata:
+    return ExperimentMetadata(
+        class_name=node.name,
+        supports_ols=_class_bool_constant(node, "supports_ols"),
+        supports_bayes=_class_bool_constant(node, "supports_bayes"),
+        default_model=_class_name_constant(node, "_default_model_class"),
+        plot_is_stub=_plot_raises_not_implemented(node),
+    )
+
+
+def discover_experiment_metadata(
+    experiments_dir: Path,
+) -> dict[str, ExperimentMetadata]:
+    """Return experiment metadata keyed by class name."""
+    metadata: dict[str, ExperimentMetadata] = {}
+    for path in sorted(experiments_dir.glob("*.py")):
+        if path.name in {"__init__.py", "base.py"}:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and _bases_include_base_experiment(node):
+                metadata[node.name] = _experiment_metadata_from_class(node)
+    return metadata
+
+
+def discover_experiment_class_names(experiments_dir: Path) -> set[str]:
+    """Return concrete ``BaseExperiment`` subclass names."""
+    return set(discover_experiment_metadata(experiments_dir))
+
+
+def discover_check_class_names(checks_dir: Path) -> set[str]:
+    """Return check class names that declare ``applicable_methods``."""
+    names: set[str] = set()
+    for path in sorted(checks_dir.glob("*.py")):
+        if path.name in {"__init__.py", "base.py"}:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        for node in tree.body:
+            if isinstance(node, ast.ClassDef) and _class_has_applicable_methods(node):
+                names.add(node.name)
+    return names

--- a/scripts/check_architecture_inventory.py
+++ b/scripts/check_architecture_inventory.py
@@ -1,0 +1,198 @@
+"""Compare or emit the experiment inventory in ARCHITECTURE.md.
+
+Introspects concrete ``BaseExperiment`` subclasses and checks that
+``ARCHITECTURE.md`` documents each class with the correct backend support.
+Use ``--print-markdown`` to regenerate table rows for paste into the doc.
+
+Usage
+-----
+
+    python scripts/check_architecture_inventory.py --check
+    python scripts/check_architecture_inventory.py --print-markdown
+
+Exits with code 1 on drift when ``--check`` is used; exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = _SCRIPTS_DIR.parent
+
+
+def _load_ast_introspection():
+    path = _SCRIPTS_DIR / "_ast_introspection.py"
+    spec = importlib.util.spec_from_file_location("ast_introspection", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ast = _load_ast_introspection()
+ExperimentMetadata = _ast.ExperimentMetadata
+discover_experiment_metadata = _ast.discover_experiment_metadata
+ARCHITECTURE_PATH = REPO_ROOT / "ARCHITECTURE.md"
+INVENTORY_HEADER = "## Experiment Inventory"
+
+
+@dataclass(frozen=True)
+class ExperimentInventoryRow:
+    class_name: str
+    backends: str
+    default_model: str | None
+    plot_is_stub: bool
+
+    @classmethod
+    def from_metadata(cls, metadata: ExperimentMetadata) -> ExperimentInventoryRow:
+        """Build an inventory row from AST-derived experiment metadata."""
+        return cls(
+            class_name=metadata.class_name,
+            backends=metadata.backends,
+            default_model=metadata.default_model,
+            plot_is_stub=metadata.plot_is_stub,
+        )
+
+
+def _parse_architecture_inventory(path: Path) -> dict[str, dict[str, str]]:
+    """Parse the experiment inventory markdown table from ``ARCHITECTURE.md``."""
+    text = path.read_text(encoding="utf-8")
+    start = text.find(INVENTORY_HEADER)
+    if start == -1:
+        msg = f"{path}: missing {INVENTORY_HEADER!r} section"
+        raise ValueError(msg)
+
+    section = text[start:]
+    table_start = section.find("| Class |")
+    if table_start == -1:
+        msg = f"{path}: experiment inventory table not found"
+        raise ValueError(msg)
+
+    table_lines: list[str] = []
+    for line in section[table_start:].splitlines():
+        if not line.startswith("|"):
+            break
+        table_lines.append(line)
+
+    rows: dict[str, dict[str, str]] = {}
+    for line in table_lines[2:]:
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if len(cells) < 3:
+            continue
+        class_name = cells[0].strip("`")
+        rows[class_name] = {
+            "method": cells[1],
+            "backends": cells[2],
+            "quirk": cells[3] if len(cells) > 3 else "",
+        }
+    return rows
+
+
+def _markdown_table_row(row: ExperimentInventoryRow, doc_row: dict[str, str]) -> str:
+    """Format one experiment-inventory markdown table row."""
+    method = doc_row.get("method", "TBD")
+    quirk = doc_row.get("quirk", "")
+    if row.default_model is None and "model required" not in quirk.lower():
+        quirk = quirk or "No `_default_model_class`; model required"
+    if row.plot_is_stub and "plot()" not in quirk:
+        quirk = "no unified `plot()`" if not quirk else f"{quirk}; no unified `plot()`"
+    return f"| `{row.class_name}` | {method} | {row.backends} | {quirk} |"
+
+
+def introspected_inventory() -> dict[str, ExperimentInventoryRow]:
+    """Build inventory rows by introspecting experiment class definitions."""
+    metadata = discover_experiment_metadata(REPO_ROOT / "causalpy" / "experiments")
+    return {
+        name: ExperimentInventoryRow.from_metadata(meta)
+        for name, meta in metadata.items()
+    }
+
+
+def check_inventory(path: Path = ARCHITECTURE_PATH) -> list[str]:
+    """Compare ``ARCHITECTURE.md`` against introspected experiment metadata."""
+    errors: list[str] = []
+    truth = introspected_inventory()
+    documented = _parse_architecture_inventory(path)
+
+    missing = set(truth) - set(documented)
+    extra = set(documented) - set(truth)
+    if missing:
+        errors.append(
+            f"  ARCHITECTURE.md missing experiment rows: {', '.join(sorted(missing))}"
+        )
+    if extra:
+        errors.append(
+            f"  ARCHITECTURE.md stale experiment rows: {', '.join(sorted(extra))}"
+        )
+
+    for class_name, row in sorted(truth.items()):
+        if class_name not in documented:
+            continue
+        doc_backends = documented[class_name]["backends"]
+        if doc_backends != row.backends:
+            errors.append(
+                f"  {class_name}: backends mismatch "
+                f"(doc={doc_backends!r}, code={row.backends!r})"
+            )
+    return errors
+
+
+def print_markdown(path: Path = ARCHITECTURE_PATH) -> str:
+    """Render a markdown table snippet for the experiment inventory."""
+    truth = introspected_inventory()
+    documented = _parse_architecture_inventory(path)
+    header = (
+        "| Class | Method | Backends | Notable quirk |\n"
+        "|-------|--------|----------|---------------|"
+    )
+    body = "\n".join(
+        _markdown_table_row(truth[name], documented.get(name, {}))
+        for name in sorted(truth)
+    )
+    return f"{header}\n{body}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and run or print the inventory check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when ARCHITECTURE.md inventory drifts from the code.",
+    )
+    group.add_argument(
+        "--print-markdown",
+        action="store_true",
+        help="Print a markdown table snippet for the experiment inventory.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.print_markdown:
+        print(print_markdown())
+        return 0
+
+    errors = check_inventory()
+    if not errors:
+        return 0
+
+    print(
+        "ARCHITECTURE.md experiment inventory drift detected. "
+        "Update the table under '## Experiment Inventory' or run "
+        "`python scripts/check_architecture_inventory.py --print-markdown` "
+        "to regenerate rows."
+    )
+    print()
+    for line in errors:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_architecture_inventory.py
+++ b/scripts/check_architecture_inventory.py
@@ -1,7 +1,8 @@
 """Compare or emit the experiment inventory in ARCHITECTURE.md.
 
 Introspects concrete ``BaseExperiment`` subclasses and checks that
-``ARCHITECTURE.md`` documents each class with the correct backend support.
+``ARCHITECTURE.md`` documents each class with the correct backend support and
+structural notes.
 Use ``--print-markdown`` to regenerate table rows for paste into the doc.
 
 Usage
@@ -105,6 +106,17 @@ def _markdown_table_row(row: ExperimentInventoryRow, doc_row: dict[str, str]) ->
     return f"| `{row.class_name}` | {method} | {row.backends} | {quirk} |"
 
 
+def _mentions_model_required(quirk: str) -> bool:
+    """Return whether an inventory note says the experiment requires a model."""
+    return "model required" in quirk.lower()
+
+
+def _mentions_no_unified_plot(quirk: str) -> bool:
+    """Return whether an inventory note says the experiment lacks unified plotting."""
+    quirk_lower = quirk.lower()
+    return "no unified" in quirk_lower and "plot()" in quirk_lower
+
+
 def introspected_inventory() -> dict[str, ExperimentInventoryRow]:
     """Build inventory rows by introspecting experiment class definitions."""
     metadata = discover_experiment_metadata(REPO_ROOT / "causalpy" / "experiments")
@@ -139,6 +151,20 @@ def check_inventory(path: Path = ARCHITECTURE_PATH) -> list[str]:
             errors.append(
                 f"  {class_name}: backends mismatch "
                 f"(doc={doc_backends!r}, code={row.backends!r})"
+            )
+        doc_quirk = documented[class_name]["quirk"]
+        documents_model_required = _mentions_model_required(doc_quirk)
+        code_requires_model = row.default_model is None
+        if documents_model_required != code_requires_model:
+            errors.append(
+                f"  {class_name}: model-required note mismatch "
+                f"(doc={documents_model_required!r}, code={code_requires_model!r})"
+            )
+        documents_no_unified_plot = _mentions_no_unified_plot(doc_quirk)
+        if documents_no_unified_plot != row.plot_is_stub:
+            errors.append(
+                f"  {class_name}: plot-stub note mismatch "
+                f"(doc={documents_no_unified_plot!r}, code={row.plot_is_stub!r})"
             )
     return errors
 

--- a/scripts/check_public_exports.py
+++ b/scripts/check_public_exports.py
@@ -1,0 +1,164 @@
+"""Verify public API export wiring for experiments and checks.
+
+Ensures every concrete ``BaseExperiment`` subclass is imported and listed in
+``causalpy/experiments/__init__.py`` ``__all__`` and ``causalpy/__init__.py``
+``__all__``, and that each package's imports stay in sync with ``__all__``.
+Concrete ``Check`` implementations in ``causalpy/checks/`` must likewise appear
+in ``causalpy/checks/__init__.py``.
+
+Usage
+-----
+
+    python scripts/check_public_exports.py --check
+
+Exits with code 1 when drift is detected; exits 0 otherwise.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import importlib.util
+import sys
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = _SCRIPTS_DIR.parent
+
+
+def _load_ast_introspection():
+    path = _SCRIPTS_DIR / "_ast_introspection.py"
+    spec = importlib.util.spec_from_file_location("ast_introspection", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_ast = _load_ast_introspection()
+discover_check_class_names = _ast.discover_check_class_names
+discover_experiment_class_names = _ast.discover_experiment_class_names
+
+
+def _parse_init_exports(path: Path) -> tuple[set[str], set[str]]:
+    """Return ``__all__`` names and imported public names from an ``__init__.py``."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    all_names: set[str] = set()
+    imported_names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "__all__"
+                    and isinstance(node.value, (ast.List, ast.Tuple))
+                ):
+                    for elt in node.value.elts:
+                        if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                            all_names.add(elt.value)
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name == "*":
+                    continue
+                imported_names.add(alias.asname or alias.name)
+    return all_names, imported_names
+
+
+def _format_set_diff(label: str, missing: set[str], extra: set[str]) -> list[str]:
+    """Format missing/extra set differences as indented error lines."""
+    lines: list[str] = []
+    if missing:
+        lines.append(f"  {label} missing: {', '.join(sorted(missing))}")
+    if extra:
+        lines.append(f"  {label} extra: {', '.join(sorted(extra))}")
+    return lines
+
+
+def check_exports() -> list[str]:
+    """Return human-readable error lines; empty list means success."""
+    errors: list[str] = []
+
+    discovered_experiments = discover_experiment_class_names(
+        REPO_ROOT / "causalpy" / "experiments"
+    )
+    experiments_init = REPO_ROOT / "causalpy" / "experiments" / "__init__.py"
+    package_init = REPO_ROOT / "causalpy" / "__init__.py"
+    checks_init = REPO_ROOT / "causalpy" / "checks" / "__init__.py"
+
+    exp_all, exp_imports = _parse_init_exports(experiments_init)
+    pkg_all, pkg_imports = _parse_init_exports(package_init)
+    checks_all, checks_imports = _parse_init_exports(checks_init)
+    discovered_checks = discover_check_class_names(REPO_ROOT / "causalpy" / "checks")
+
+    errors.extend(
+        _format_set_diff(
+            "experiments/__init__.py vs discovered BaseExperiment subclasses",
+            discovered_experiments - exp_all,
+            exp_all - discovered_experiments,
+        )
+    )
+    if exp_all != exp_imports:
+        errors.append(
+            "  experiments/__init__.py: __all__ and imports are out of sync "
+            f"(only in __all__: {sorted(exp_all - exp_imports)}; "
+            f"only imported: {sorted(exp_imports - exp_all)})"
+        )
+
+    errors.extend(
+        _format_set_diff(
+            "causalpy/__init__.py vs experiments/__init__.py",
+            exp_all - pkg_all,
+            {name for name in pkg_all - exp_all if name in discovered_experiments},
+        )
+    )
+    for name in exp_all:
+        if name not in pkg_imports:
+            errors.append(f"  causalpy/__init__.py missing import for {name}")
+
+    errors.extend(
+        _format_set_diff(
+            "checks/__init__.py vs discovered Check implementations",
+            discovered_checks - checks_all,
+            set(),
+        )
+    )
+    missing_check_imports = checks_all - checks_imports
+    if missing_check_imports:
+        errors.append(
+            "  checks/__init__.py missing imports for __all__ names: "
+            f"{sorted(missing_check_imports)}"
+        )
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse CLI arguments and run the export wiring check."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit 1 when export wiring drifts from the codebase.",
+    )
+    args = parser.parse_args(argv)
+    if not args.check:
+        parser.error("--check is required")
+
+    errors = check_exports()
+    if not errors:
+        return 0
+
+    print(
+        "Public export wiring drift detected. Update causalpy/__init__.py, "
+        "causalpy/experiments/__init__.py, and causalpy/checks/__init__.py "
+        "so imports and __all__ match the concrete experiment and check classes."
+    )
+    print()
+    for line in errors:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
# PR: Add deterministic structural check scripts

Fixes #947

## Summary

Adds AST-based checkers for public API export wiring and `ARCHITECTURE.md` experiment inventory drift, wires them into prek, and fixes the missing `SyntheticDifferenceInDifferences` export in `causalpy/experiments/__init__.py`.

## Changes

- `scripts/_ast_introspection.py`: shared AST discovery for experiment and check classes (no `causalpy` import required)
- `scripts/check_public_exports.py`: verifies experiment/check `__init__.py` exports stay in sync with the codebase
- `scripts/check_architecture_inventory.py`: compares `ARCHITECTURE.md` experiment inventory backends against code; supports `--print-markdown`
- `causalpy/experiments/__init__.py`: export `SyntheticDifferenceInDifferences`
- `.pre-commit-config.yaml`: add `check-public-exports` and `check-architecture-inventory` hooks
- `Makefile`: add `check-exports` and `check-architecture` targets
- `ARCHITECTURE.md`: note that export/inventory checks are enforced by scripts
- `causalpy/tests/test_check_public_exports.py`, `causalpy/tests/test_check_architecture_inventory.py`: regression tests for the new scripts

## Testing

- [x] `python scripts/check_public_exports.py --check`
- [x] `python scripts/check_architecture_inventory.py --check`
- [x] `pytest causalpy/tests/test_check_public_exports.py causalpy/tests/test_check_architecture_inventory.py`
- [x] `prek run` on changed files

## Checklist

- [x] Acceptance criteria from #947 met for scripts 1 and 2 with `--check` mode
- [x] Both scripts wired into prek
- [x] Export gap for `SyntheticDifferenceInDifferences` fixed
- [x] Agent-facing docs de-emphasize manual inventory/export steps
