### PR TITLE
Warn when staggered DiD ATTs lack untreated-period support

### DIFF
--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -19,6 +19,7 @@ the approach of Borusyak, Jaravel, and Spiess (2024). It handles settings where
 different units receive treatment at different times.
 """
 
+import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -58,6 +59,13 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
        units would have followed parallel outcome trajectories.
     3. **No anticipation**: Units do not change their behavior in anticipation
        of future treatment.
+    4. **Untreated support at each calendar period**: The time fixed effect
+       :math:`\\gamma_t` for calendar period :math:`t` is identified only if at
+       least one unit is untreated in that period. Without never-treated units,
+       post-treatment effects for the last-treated cohort (and any calendar
+       periods where every unit is already treated) are not identified. CausalPy
+       warns when this condition fails and marks the affected ``ATT(g, t)`` and
+       ``ATT(e)`` cells as non-identified in the output tables.
 
     Parameters
     ----------
@@ -94,8 +102,14 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         and tau_hat (treatment effect) columns.
     att_group_time_ : pd.DataFrame
         Group-time ATT estimates: ATT(g, t) for each cohort g and calendar time t.
+        Includes an ``identified`` column; non-identified cells have ``NaN`` estimates.
     att_event_time_ : pd.DataFrame
         Event-time ATT estimates: ATT(e) for each event-time e = t - G.
+        Includes an ``identified`` column; non-identified cells have ``NaN`` estimates.
+    non_identified_periods_ : set
+        Calendar periods with no untreated observations.
+    non_identified_cohorts_ : set
+        Treatment cohorts with at least one non-identified post-treatment ATT(g, t).
 
     Notes
     -----
@@ -184,6 +198,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         # Step 3: Identify untreated observations (training set)
         self._identify_untreated_observations()
+
+        # Step 3b: Check calendar-period identification support
+        self._check_att_identification()
 
         # Step 4: Build design matrices
         self._build_design_matrices()
@@ -318,6 +335,92 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 "No untreated observations found. Cannot fit the model. "
                 "Ensure there are never-treated units or pre-treatment periods."
             )
+
+    def _get_periods_without_untreated_support(self) -> set[Any]:
+        """Return calendar periods with zero untreated observations."""
+        untreated_periods = set(
+            self.data.loc[self.data["_is_untreated"], self.time_variable_name].unique()
+        )
+        all_periods = set(self.data[self.time_variable_name].unique())
+        return all_periods - untreated_periods
+
+    def _get_non_identified_cohorts(self, periods: set[Any]) -> set[Any]:
+        """Return cohorts with post-treatment cells in non-identified periods."""
+        non_identified_cohorts: set[Any] = set()
+        for cohort in self.cohorts:
+            for period in periods:
+                if period >= cohort:
+                    non_identified_cohorts.add(cohort)
+                    break
+        return non_identified_cohorts
+
+    def _check_att_identification(self) -> None:
+        """Detect non-identified ATT cells and warn when untreated support is missing."""
+        self.non_identified_periods_ = self._get_periods_without_untreated_support()
+        self.non_identified_cohorts_ = self._get_non_identified_cohorts(
+            self.non_identified_periods_
+        )
+
+        if not self.non_identified_periods_:
+            return
+
+        periods_str = ", ".join(str(p) for p in sorted(self.non_identified_periods_))
+        cohorts_str = ", ".join(str(c) for c in sorted(self.non_identified_cohorts_))
+        warnings.warn(
+            "No untreated observations in calendar period(s) "
+            f"{{{periods_str}}}; treatment effects for cohort(s) "
+            f"{{{cohorts_str}}} are not identified at the affected post-treatment "
+            "cells. Provide never-treated units or restrict the event window. "
+            "Non-identified ATT(g, t) and ATT(e) cells are marked in the output "
+            "tables (identified=False) with NaN estimates.",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    def _is_calendar_period_identified(self, period: Any) -> bool:
+        """Return whether calendar period ``period`` has untreated support."""
+        return period not in self.non_identified_periods_
+
+    def _is_event_time_att_identified(self, event_time: int) -> bool:
+        """Return whether aggregated ATT(e) is identified."""
+        for cohort in self.cohorts:
+            period = cohort + event_time
+            has_contributing_obs = (
+                (self.data["G"] == cohort)
+                & (self.data[self.time_variable_name] == period)
+                & (self.data["event_time"] == event_time)
+            ).any()
+            if has_contributing_obs and not self._is_calendar_period_identified(period):
+                return False
+        return True
+
+    def _mark_non_identified_att_rows(self, att_df: pd.DataFrame) -> pd.DataFrame:
+        """Add ``identified`` column and mask non-identified point estimates."""
+        if len(att_df) == 0:
+            att_df = att_df.copy()
+            att_df["identified"] = pd.Series(dtype=bool)
+            return att_df
+
+        att_df = att_df.copy()
+        if "cohort" in att_df.columns and "time" in att_df.columns:
+            att_df["identified"] = att_df["time"].map(
+                self._is_calendar_period_identified
+            )
+        elif "event_time" in att_df.columns:
+            att_df["identified"] = att_df["event_time"].apply(
+                lambda e: self._is_event_time_att_identified(int(e))
+            )
+        else:
+            att_df["identified"] = True
+
+        value_columns = [
+            col
+            for col in ("att", "att_lower", "att_upper", "att_std")
+            if col in att_df.columns
+        ]
+        for col in value_columns:
+            att_df.loc[~att_df["identified"], col] = np.nan
+        return att_df
 
     def _build_design_matrices(self) -> None:
         """Build design matrices using patsy."""
@@ -499,7 +602,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                     "att_upper": float(np.percentile(tau_gt, upper_pct)),
                 }
             )
-        self.att_group_time_ = pd.DataFrame(att_gt_rows)
+        self.att_group_time_ = self._mark_non_identified_att_rows(
+            pd.DataFrame(att_gt_rows)
+        )
 
         # --- Event-time ATTs (including pre-treatment placebo) ---
         att_et_rows: list[dict] = []
@@ -563,7 +668,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 }
             )
 
-        self.att_event_time_ = pd.DataFrame(att_et_rows)
+        self.att_event_time_ = self._mark_non_identified_att_rows(
+            pd.DataFrame(att_et_rows)
+        )
 
     def _aggregate_effects_ols(
         self, treated_data: pd.DataFrame, pretreatment_data: pd.DataFrame
@@ -585,7 +692,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             .reset_index()
         )
         att_gt.columns = ["cohort", "time", "att", "att_std", "n_obs"]
-        self.att_group_time_ = att_gt
+        self.att_group_time_ = self._mark_non_identified_att_rows(att_gt)
 
         # --- Event-time ATTs (including pre-treatment placebo) ---
         # Compute tau_hat for pre-treatment observations (residuals)
@@ -613,7 +720,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         )
         att_et.columns = ["event_time", "att", "att_std", "n_obs"]
         att_et["event_time"] = att_et["event_time"].astype(int)
-        self.att_event_time_ = att_et
+        self.att_event_time_ = self._mark_non_identified_att_rows(att_et)
 
     def summary(
         self, round_to: int | None = 2, include_group_time: bool = False

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -1613,7 +1613,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 }
             )
 
-        return pd.DataFrame(att_et_rows)
+        return self._mark_non_identified_att_rows(pd.DataFrame(att_et_rows))
 
     def get_plot_data_ols(self) -> pd.DataFrame:
         """Get plotting data for OLS model.

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -382,6 +382,10 @@ def _effect_summary_staggered_did(
     # Separate pre-treatment (placebo) and post-treatment effects
     pre_treatment = att_et[att_et["event_time"] < 0]
     post_treatment = att_et[att_et["event_time"] >= 0]
+    if "identified" in post_treatment.columns:
+        post_treatment = post_treatment[post_treatment["identified"]]
+    if "identified" in pre_treatment.columns:
+        pre_treatment = pre_treatment[pre_treatment["identified"]]
 
     # Build summary table with all event-time effects
     table = att_et.copy()

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -762,6 +762,37 @@ def test_staggered_did_warns_non_identified_without_never_treated(
     assert non_identified_et["att"].isna().all()
 
 
+def test_staggered_did_get_plot_data_bayesian_masks_non_identified_on_recompute(
+    mock_pymc_sample,
+):
+    """Non-default hdi_prob recompute path must still mask non-identified cells."""
+    df = _no_never_treated_staggered_did_df()
+
+    with pytest.warns(
+        UserWarning, match="No untreated observations in calendar period"
+    ):
+        result = cp.StaggeredDifferenceInDifferences(
+            df,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    plot_data = result.get_plot_data_bayesian(hdi_prob=0.80)
+
+    assert "identified" in plot_data.columns
+    non_identified_post = plot_data[
+        (plot_data["event_time"] >= 0) & ~plot_data["identified"]
+    ]
+    assert len(non_identified_post) > 0
+    assert non_identified_post["att"].isna().all()
+    assert non_identified_post["att_lower"].isna().all()
+    assert non_identified_post["att_upper"].isna().all()
+
+
 @pytest.mark.parametrize(
     "model_factory",
     [

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -793,6 +793,56 @@ def test_staggered_did_get_plot_data_bayesian_masks_non_identified_on_recompute(
     assert non_identified_post["att_upper"].isna().all()
 
 
+def test_staggered_did_effect_summary_excludes_non_identified_cells():
+    """effect_summary prose should average only identified post-treatment ATTs."""
+    df = _no_never_treated_staggered_did_df()
+
+    with pytest.warns(
+        UserWarning, match="No untreated observations in calendar period"
+    ):
+        result = cp.StaggeredDifferenceInDifferences(
+            df,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=LinearRegression(),
+        )
+
+    post_treatment = result.att_event_time_[result.att_event_time_["event_time"] >= 0]
+    assert (~post_treatment["identified"]).any()
+
+    summary = result.effect_summary()
+    assert "Staggered DiD" in summary.text
+    assert isinstance(summary.table, pd.DataFrame)
+
+
+def test_staggered_did_mark_non_identified_att_rows_edge_cases():
+    """Cover empty and unknown-column paths in _mark_non_identified_att_rows."""
+    df = _no_never_treated_staggered_did_df()
+
+    with pytest.warns(
+        UserWarning, match="No untreated observations in calendar period"
+    ):
+        result = cp.StaggeredDifferenceInDifferences(
+            df,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=LinearRegression(),
+        )
+
+    empty = result._mark_non_identified_att_rows(pd.DataFrame())
+    assert list(empty.columns) == ["identified"]
+    assert len(empty) == 0
+
+    unknown_cols = result._mark_non_identified_att_rows(pd.DataFrame({"x": [1]}))
+    assert unknown_cols["identified"].all()
+
+
 @pytest.mark.parametrize(
     "model_factory",
     [

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -15,6 +15,8 @@
 Tests for StaggeredDifferenceInDifferences experiment class.
 """
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -701,6 +703,102 @@ def test_staggered_did_group_time_att_structure():
 
     # Check we have multiple cohorts
     assert len(result.att_group_time_["cohort"].unique()) >= 2
+
+
+def _no_never_treated_staggered_did_df() -> pd.DataFrame:
+    """Return a staggered panel where every unit is eventually treated."""
+    return generate_staggered_did_data(
+        n_units=20,
+        n_time_periods=10,
+        treatment_cohorts={3: 10, 7: 10},
+        seed=42,
+    )
+
+
+@pytest.mark.parametrize(
+    "model_factory",
+    [
+        pytest.param(lambda: LinearRegression(), id="ols"),
+        pytest.param(
+            lambda: cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+            id="pymc",
+        ),
+    ],
+)
+def test_staggered_did_warns_non_identified_without_never_treated(
+    model_factory, mock_pymc_sample
+):
+    """No never-treated units should warn about non-identified post-treatment ATTs."""
+    df = _no_never_treated_staggered_did_df()
+
+    with pytest.warns(
+        UserWarning, match="No untreated observations in calendar period"
+    ):
+        result = cp.StaggeredDifferenceInDifferences(
+            df,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=model_factory(),
+        )
+
+    assert result.non_identified_periods_
+    assert 7 in result.non_identified_periods_
+    assert 7 in result.non_identified_cohorts_
+
+    assert "identified" in result.att_group_time_.columns
+    non_identified_gt = result.att_group_time_[~result.att_group_time_["identified"]]
+    assert len(non_identified_gt) > 0
+    assert non_identified_gt["att"].isna().all()
+
+    assert "identified" in result.att_event_time_.columns
+    non_identified_et = result.att_event_time_[
+        (result.att_event_time_["event_time"] >= 0)
+        & ~result.att_event_time_["identified"]
+    ]
+    assert len(non_identified_et) > 0
+    assert non_identified_et["att"].isna().all()
+
+
+@pytest.mark.parametrize(
+    "model_factory",
+    [
+        pytest.param(lambda: LinearRegression(), id="ols"),
+        pytest.param(
+            lambda: cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+            id="pymc",
+        ),
+    ],
+)
+def test_staggered_did_all_identified_with_never_treated(
+    model_factory, mock_pymc_sample
+):
+    """Never-treated units should identify all post-treatment ATT cells."""
+    df = generate_staggered_did_data(
+        n_units=30,
+        n_time_periods=10,
+        treatment_cohorts={3: 10, 7: 10},
+        seed=42,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        result = cp.StaggeredDifferenceInDifferences(
+            df,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=model_factory(),
+        )
+
+    assert result.non_identified_periods_ == set()
+    assert result.att_group_time_["identified"].all()
+    post_treatment = result.att_event_time_[result.att_event_time_["event_time"] >= 0]
+    assert post_treatment["identified"].all()
 
 
 def test_staggered_did_no_untreated_observations():

--- a/docs/source/notebooks/staggered_did_pymc.ipynb
+++ b/docs/source/notebooks/staggered_did_pymc.ipynb
@@ -41,13 +41,20 @@
     "\n",
     "### Identifying Assumptions\n",
     "\n",
-    "This estimator relies on three key assumptions:\n",
+    "This estimator relies on four key assumptions:\n",
     "\n",
     "1. **{term}`Absorbing treatment`**: once a unit is treated, it stays treated in all subsequent periods.\n",
     "2. **{term}`Parallel trends assumption`**: absent treatment, treated and control units would have followed parallel outcome trajectories.\n",
     "3. **No anticipation**: units do not change behavior in anticipation of future treatment.\n",
+    "4. **Untreated support at each calendar period**: calendar time fixed effects $\\gamma_t$ are identified only when at least one unit is untreated in period $t$.\n",
     "\n",
-    "If these assumptions are violated, event-time estimates can be biased and causal interpretation may no longer hold. In CausalPy, non-absorbing treatment is rejected during input validation."
+    "If these assumptions are violated, event-time estimates can be biased and causal interpretation may no longer hold. In CausalPy, non-absorbing treatment is rejected during input validation.\n",
+    "\n",
+    "### Untreated support and never-treated units\n",
+    "\n",
+    "The imputation estimator fits calendar time fixed effects $\\gamma_t$ using untreated observations only. A calendar period $t$ therefore needs at least one untreated unit; otherwise $\\gamma_t$ is not identified and post-treatment `ATT(g, t)` cells that rely on that period are not identified either. In practice, the **last-treated cohort** needs **never-treated units** (or a shorter post-treatment window) so that late calendar periods still have untreated support.\n",
+    "\n",
+    "When this condition fails, `StaggeredDifferenceInDifferences` emits a `UserWarning` and marks affected rows in `att_group_time_` and `att_event_time_` with `identified=False` and `NaN` estimates."
    ]
   },
   {


### PR DESCRIPTION
## Summary

Detect calendar periods without untreated support in `StaggeredDifferenceInDifferences`, warn users when post-treatment ATTs are not identified (e.g. no never-treated units), and mark affected `ATT(g, t)` / `ATT(e)` cells with `identified=False` and `NaN` estimates instead of silently returning biased values.

Fixes #938

## Root cause

The imputation estimator fits time fixed effects `γ_t` using untreated observations only. When every unit is already treated in a calendar period, `γ_t` is not identified and counterfactual imputation for that period is invalid. The only existing guard checked that *some* untreated observation exists globally, not per-period support.

## Changes

- `causalpy/experiments/staggered_did.py`: Add per-period identification checks, `UserWarning`, `non_identified_periods_` / `non_identified_cohorts_` attributes, and `identified` column on ATT output tables with masked estimates.
- `causalpy/reporting.py`: Exclude non-identified cells from staggered DiD effect-summary prose averages.
- `causalpy/tests/test_staggered_did.py`: Parametrized tests for OLS and PyMC paths (warning + masking; no warning when never-treated units present).
- `docs/source/notebooks/staggered_did_pymc.ipynb`: Document untreated-support assumption and warning behaviour.

## Testing

- [x] `pytest causalpy/tests/test_staggered_did.py --no-cov` (64 passed)
- [x] `prek run` on changed files (all hooks passed)

## Checklist

- [x] Warns on datasets without never-treated units when last cohort post-treatment ATTs are non-identified
- [x] Non-identified cells distinguished in `att_group_time_` and `att_event_time_`
- [x] Tests cover OLS and PyMC paths
- [x] Docstring and notebook updated
