### PR TITLE
Add local patch coverage gate

### DIFF
--- a/.agents/skills/pr-workflows/reference/pre-commit.md
+++ b/.agents/skills/pr-workflows/reference/pre-commit.md
@@ -13,6 +13,9 @@ prek run --files path/to/file.py
 
 # Full verification before push/commit
 prek run --all-files
+
+# Python source/test changes: local patch coverage gate
+make test-patch-cov
 ```
 
 ## If hooks modify files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,7 @@ See the [python-environment skill](.agents/skills/python-environment/SKILL.md) f
 ## Code quality checks
 
 - **Before committing**: Use `prek run` during iterative edits and run `prek run --all-files` before committing to ensure all checks pass (linting, formatting, type checking)
-- **Patch coverage before handoff**: When Python source or tests change, run `$CONDA_EXE run -n CausalPy make test-patch-cov` before pushing or handing off. This keeps the default `prek run` fast while locally approximating the remote Codecov patch gate against `origin/main`. Override `DIFF_COVER_COMPARE_BRANCH` or `DIFF_COVER_FAIL_UNDER` only when the PR deliberately targets a different base or threshold.
+- **Patch coverage before handoff**: When Python source or tests change, run `$CONDA_EXE run -n CausalPy make test-patch-cov` before pushing or handing off. This keeps the default `prek run` fast while locally approximating the remote Codecov patch gate against `upstream/main` when available, falling back to `origin/main`. Override `DIFF_COVER_COMPARE_BRANCH` or `DIFF_COVER_FAIL_UNDER` only when the PR deliberately targets a different base or threshold.
 - **Quick check**: Run `ruff check causalpy/` for fast linting feedback during development
 - **Auto-fix**: Run `ruff check --fix causalpy/` to automatically fix many linting issues
 - **Format**: Run `ruff format causalpy/` to format code according to project standards

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,6 +57,7 @@ See the [python-environment skill](.agents/skills/python-environment/SKILL.md) f
 ## Code quality checks
 
 - **Before committing**: Use `prek run` during iterative edits and run `prek run --all-files` before committing to ensure all checks pass (linting, formatting, type checking)
+- **Patch coverage before handoff**: When Python source or tests change, run `$CONDA_EXE run -n CausalPy make test-patch-cov` before pushing or handing off. This keeps the default `prek run` fast while locally approximating the remote Codecov patch gate against `origin/main`. Override `DIFF_COVER_COMPARE_BRANCH` or `DIFF_COVER_FAIL_UNDER` only when the PR deliberately targets a different base or threshold.
 - **Quick check**: Run `ruff check causalpy/` for fast linting feedback during development
 - **Auto-fix**: Run `ruff check --fix causalpy/` to automatically fix many linting issues
 - **Format**: Run `ruff format causalpy/` to format code according to project standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,7 +216,7 @@ We recommend that your contribution complies with the following guidelines befor
     make test-patch-cov
     ```
 
-    This runs the test suite with coverage, writes `coverage.xml`, and uses `diff-cover` to fail when changed lines versus `origin/main` fall below the local patch threshold. If your branch targets a different base, set `DIFF_COVER_COMPARE_BRANCH`, for example `DIFF_COVER_COMPARE_BRANCH=upstream/main make test-patch-cov`.
+    This runs the test suite with coverage, writes `coverage.xml`, and uses `diff-cover` to fail when changed lines fall below the local patch threshold. The compare branch defaults to `upstream/main` when that tracking branch exists and falls back to `origin/main` otherwise. If your branch targets a different base, set `DIFF_COVER_COMPARE_BRANCH`, for example `DIFF_COVER_COMPARE_BRANCH=upstream/release make test-patch-cov`.
 
 - When adding additional functionality, either edit an existing example, or create a new example (typically in the form of a Jupyter Notebook). Have a look at other examples for reference. Examples should demonstrate why the new functionality is useful in practice.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -210,6 +210,14 @@ We recommend that your contribution complies with the following guidelines befor
     make test
     ```
 
+- For pull requests that change Python source or tests, also run the local patch coverage gate before pushing:
+
+    ```bash
+    make test-patch-cov
+    ```
+
+    This runs the test suite with coverage, writes `coverage.xml`, and uses `diff-cover` to fail when changed lines versus `origin/main` fall below the local patch threshold. If your branch targets a different base, set `DIFF_COVER_COMPARE_BRANCH`, for example `DIFF_COVER_COMPARE_BRANCH=upstream/main make test-patch-cov`.
+
 - When adding additional functionality, either edit an existing example, or create a new example (typically in the form of a Jupyter Notebook). Have a look at other examples for reference. Examples should demonstrate why the new functionality is useful in practice.
 
 - If your pull request makes a structural change — adding, removing, or reshaping an experiment class, PyMC or scikit-learn model, check, pipeline step, or a data contract — update [ARCHITECTURE.md](./ARCHITECTURE.md) in the same PR so the design overview stays accurate.

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PACKAGE_DIR = causalpy
 
 .PHONY: init setup lint check_lint check-exports check-architecture test test-patch-cov uml html cleandocs doctest run_notebooks_full help
 
-DIFF_COVER_COMPARE_BRANCH ?= origin/main
+DIFF_COVER_COMPARE_BRANCH ?= $(shell if git show-ref --verify --quiet refs/remotes/upstream/main; then printf "upstream/main"; else printf "origin/main"; fi)
 DIFF_COVER_FAIL_UNDER ?= 95
 
 init: ## Install the package in editable mode
@@ -43,7 +43,7 @@ doctest: ## Run doctests for the causalpy module
 test: ## Run all tests with pytest
 	python -m pytest
 
-test-patch-cov: ## Run tests and fail if patch coverage versus main is too low
+test-patch-cov: ## Run tests and fail if patch coverage versus the base branch is too low
 	python -m pytest --cov-report=xml --no-cov-on-fail
 	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_COMPARE_BRANCH) --fail-under=$(DIFF_COVER_FAIL_UNDER)
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ PACKAGE_DIR = causalpy
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: init setup lint check_lint check-exports check-architecture test uml html cleandocs doctest run_notebooks_full help
+.PHONY: init setup lint check_lint check-exports check-architecture test test-patch-cov uml html cleandocs doctest run_notebooks_full help
+
+DIFF_COVER_COMPARE_BRANCH ?= origin/main
+DIFF_COVER_FAIL_UNDER ?= 95
 
 init: ## Install the package in editable mode
 	python -m pip install -e . --no-deps
@@ -39,6 +42,10 @@ doctest: ## Run doctests for the causalpy module
 
 test: ## Run all tests with pytest
 	python -m pytest
+
+test-patch-cov: ## Run tests and fail if patch coverage versus main is too low
+	python -m pytest --cov-report=xml --no-cov-on-fail
+	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_COMPARE_BRANCH) --fail-under=$(DIFF_COVER_FAIL_UNDER)
 
 uml: ## Generate UML diagrams from code
 	pyreverse -o png causalpy --output-directory docs/source/_static --ignore tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ docs = [
     "sphinx-togglebutton",
 ]
 lint = ["interrogate", "prek", "ruff", "mypy"]
-test = ["pytest", "pytest-cov", "codespell", "nbformat", "nbconvert", "papermill"]
+test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill"]
 
 [tool.pyproject2conda]
 channels = ["conda-forge"]


### PR DESCRIPTION
# PR: Add local patch coverage gate

Fixes #950

## Summary

- Add an opt-in `make test-patch-cov` command that runs the full pytest suite with coverage and checks changed-line coverage against `origin/main` using `diff-cover`.
- Document the command for contributors and agents so patch coverage failures can be caught before pushing.

## Changes

- `Makefile`: Add configurable `DIFF_COVER_COMPARE_BRANCH` and `DIFF_COVER_FAIL_UNDER` variables plus the `test-patch-cov` target.
- `pyproject.toml`: Add `diff-cover` to the test extra installed by `make setup`.
- `AGENTS.md`: Tell agents to run the patch coverage gate for Python source or test changes before handoff.
- `CONTRIBUTING.md`: Add the contributor-facing pre-push workflow and base-branch override example.
- `.github/skills/pr-workflows/reference/pre-commit.md`: Include the patch coverage target in the PR workflow checklist.

## Testing

- [x] `mamba run -n CausalPy prek run --files pyproject.toml Makefile AGENTS.md CONTRIBUTING.md .github/skills/pr-workflows/reference/pre-commit.md`
- [x] `mamba run -n CausalPy make setup`
- [x] `mamba run -n CausalPy make test-patch-cov`
- [x] `mamba run -n CausalPy prek run --all-files`

