### PR TITLE
fix: resolve zizmor dangerous-triggers alert on welcome.yml

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -1,24 +1,34 @@
 name: Welcome New Contributors
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # The `pull_request_target` trigger is required here to write comments/labels on
+  # fork PRs, which run with a read-only GITHUB_TOKEN. This workflow does NOT
+  # checkout or execute any code from the PR head — it only posts a hardcoded
+  # greeting and adds a label based on author association, both via well-known,
+  # SHA-pinned actions. See https://github.com/pymc-labs/CausalPy/issues/888.
   pull_request_target:
     types: [opened]
   issues:
     types: [opened]
 
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    env:
+      # Hoist github.actor to env to avoid inlining user-controlled data in action inputs
+      ACTOR: ${{ github.actor }}
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           issue_message: |
-            👋 **Welcome to CausalPy, @${{ github.actor }}!**
+            👋 **Welcome to CausalPy, @${{ env.ACTOR }}!**
 
             Thank you for opening your first issue! We appreciate you taking the time to post this.
 
@@ -30,7 +40,7 @@ jobs:
             A maintainer will take a look soon. Thanks for being part of the CausalPy community! 🎉
 
           pr_message: |
-            👋 **Welcome to CausalPy, @${{ github.actor }}!**
+            👋 **Welcome to CausalPy, @${{ env.ACTOR }}!**
 
             Thank you for opening your first pull request! We're excited to have you contribute to the project. 🎉
 


### PR DESCRIPTION
Adds an inline zizmor ignore with written justification for the  trigger, hoists  into the job-level HERMES_HOME=/Users/apple/.hermes
timezone=America/New_York
TERMINAL_PERSISTENT_SHELL=True
TERMINAL_DOCKER_ENV={}
TERMINAL_CONTAINER_CPU=1.0
HERMES_CRON_AUTO_DELIVER_CHAT_ID=1495578346216755291
TELEGRAM_ALLOWED_CHATS=
HERMES_GATEWAY_BUSY_INPUT_MODE=interrupt
HERMES_AGENT_NOTIFY_INTERVAL=600
SSL_CERT_FILE=/private/etc/ssl/cert.pem
BROWSER_INACTIVITY_TIMEOUT=120
DISCORD_HISTORY_BACKFILL=true
_HERMES_GATEWAY=1
SHELL=/bin/zsh
EMAIL_SMTP_PORT=465
HERMES_MAX_ITERATIONS=90
TERMINAL_LIFETIME_SECONDS=300
TMPDIR=/var/folders/s7/1lf1pwc5197btg8m513ggrs40000gn/T/
HERMES_RESTART_DRAIN_TIMEOUT=60
HERMES_QUIET=1
AUXILIARY_WEB_EXTRACT_MODEL=MiniMax-M2.7-32K
TERMINAL_DOCKER_VOLUMES=[]
OLDPWD=/Users/apple
DISCORD_ALLOWED_CHANNELS=
TERMINAL_ENV=local
VISION_TOOLS_DEBUG=false
MOA_TOOLS_DEBUG=false
HERMES_SESSION_KEY=agent:main:discord:thread:1501604252496167123:1501604252496167123
TERMINAL_CONTAINER_PERSISTENT=True
USER=apple
HERMES_CRON_AUTO_DELIVER_THREAD_ID=1495578346216755291
WEB_TOOLS_DEBUG=false
HERMES_CRON_AUTO_DELIVER_PLATFORM=discord
SSH_AUTH_SOCK=/private/tmp/com.apple.launchd.8SScw7P37V/Listeners
MATRIX_ALLOWED_ROOMS=
IMAGE_TOOLS_DEBUG=false
__CF_USER_TEXT_ENCODING=0x1F5:0x0:0x0
EMAIL_IMAP_PORT=993
file_read_max_chars=100000
TERMINAL_SINGULARITY_IMAGE=docker://nikolaik/python-nodejs:python3.11-nodejs20
SLACK_REQUIRE_MENTION=true
SLACK_ALLOWED_CHANNELS=
HERMES_TIMEZONE=America/New_York
HERMES_AGENT_TIMEOUT_WARNING=900
PATH=/Users/apple/.cargo/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin
MATTERMOST_ALLOWED_CHANNELS=
HERMES_REDACT_SECRETS=true
BROWSERBASE_ADVANCED_STEALTH=false
PWD=/tmp/contribution/causalpy
AUXILIARY_VISION_MODEL=MiniMax-M2.7-32K
TERMINAL_DAYTONA_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
hooks_auto_accept=False
HERMES_CRON_SESSION=1
TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE=False
_config_version=23
prefill_messages_file=
DISCORD_HISTORY_BACKFILL_LIMIT=50
XPC_FLAGS=0x0
TERMINAL_TIMEOUT=60
TERMINAL_MODAL_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
TERMINAL_DOCKER_IMAGE=nikolaik/python-nodejs:python3.11-nodejs20
APSA_PASSWORD=Wali930629..
TERMINAL_CONTAINER_MEMORY=5120
TERMINAL_CWD=/Users/apple
AUXILIARY_WEB_EXTRACT_PROVIDER=minimax-cn
TERMINAL_VERCEL_RUNTIME=node24
XPC_SERVICE_NAME=0
TELEGRAM_REACTIONS=false
SHLVL=1
HOME=/Users/apple
HERMES_AGENT_TIMEOUT=1800
DISCORD_REACTIONS=true
AUXILIARY_VISION_PROVIDER=minimax-cn
LOGNAME=apple
SLACK_FREE_RESPONSE_CHANNELS=
LC_CTYPE=C.UTF-8
APSA_USERNAME=wali
BROWSERBASE_PROXIES=true
DISCORD_THREAD_REQUIRE_MENTION=false
HERMES_SESSION_ID=cron_ca21d641e5a4_20260608_090027
TERMINAL_DOCKER_RUN_AS_HOST_USER=False
TERMINAL_DOCKER_FORWARD_ENV=[]
BROWSER_SESSION_TIMEOUT=300
HERMES_EXEC_ASK=1
HERMES_AUTO_CONTINUE_FRESHNESS=3600
TERMINAL_CONTAINER_DISK=51200
EMAIL_HOME_CHANNEL=wali.reheman@gmail.com
_=/usr/bin/env block, and tightens the top-level  to  with only the needed writes scoped at the job level. See issue #888 for the full rationale — this follows option 1.