### PR TITLE
Skip welcome workflow for bot accounts

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -13,6 +13,11 @@ permissions:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    # Skip automated accounts (pre-commit-ci, dependabot, etc.) — see contributors.yml BOT_PATTERN.
+    if: >-
+      !contains(github.actor, '[bot]') &&
+      !contains(github.actor, 'dependabot') &&
+      !contains(github.actor, 'renovate')
     steps:
       - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:


### PR DESCRIPTION
## Summary
- Add a job-level guard in `welcome.yml` so automated accounts (`[bot]`, dependabot, renovate) do not receive first-contributor welcome comments.
- Fixes the spurious welcome comment on pre-commit.ci autoupdate PRs (e.g. #869).

## Test plan
- [x] Workflow YAML is valid
- [ ] Confirm next bot-opened PR does not get a welcome comment

Made with [Cursor](https://cursor.com)