### PR TITLE
Bump pre-commit hooks and fix PyMarkdown MD032 violations

### DIFF
--- a/.agents/skills/github-issues/reference/bug-report.md
+++ b/.agents/skills/github-issues/reference/bug-report.md
@@ -32,6 +32,7 @@ Bug-specific template:
 <Clear, concise description of the bug>
 
 ## Steps to Reproduce
+
 1. <Step 1>
 2. <Step 2>
 
@@ -42,6 +43,7 @@ Bug-specific template:
 <What actually happens>
 
 ## Environment
+
 - CausalPy version:
 - Python version:
 - OS:

--- a/.agents/skills/github-issues/reference/issue-evaluation.md
+++ b/.agents/skills/github-issues/reference/issue-evaluation.md
@@ -65,6 +65,7 @@ Create `.scratch/issue_comments/issue-<number>-evaluation.md` with:
 <Restate issue + status>
 
 ### Current Relevance
+
 - Code references checked:
 - Related PRs:
 - Changes since issue creation:
@@ -73,8 +74,10 @@ Create `.scratch/issue_comments/issue-<number>-evaluation.md` with:
 <Key points from comments>
 
 ### Recommendation
+
 - **Status:** <Ready / Needs info / Blocked / Can be closed>
 - **Proposed next steps:** <Actionable items>
+
 ```
 
 Present the draft for user approval before posting. Do not hard-wrap lines in markdown drafts; keep paragraphs on a single line.

--- a/.agents/skills/github-issues/reference/parent-child-issues.md
+++ b/.agents/skills/github-issues/reference/parent-child-issues.md
@@ -128,6 +128,7 @@ gh api graphql -f query='query {
 Do **not** apply fallback automatically.
 
 When native sub-issues are unavailable, first inform the user:
+
 - what capability check failed (missing `parent`/`subIssues` fields or no `addSubIssue` mutation)
 - that native hierarchy cannot be created in this repo/account context
 - that a markdown tracking-issue fallback is available
@@ -137,8 +138,10 @@ Then explicitly ask whether they want to proceed with fallback. Only continue af
 Use a tracking issue body with markdown task links:
 
 ```md
+
 - [ ] #123 Child issue one
 - [ ] #124 Child issue two
+
 ```
 
 This renders correctly on GitHub and preserves parent-child tracking even without native hierarchy.

--- a/.agents/skills/pr-to-green/SKILL.md
+++ b/.agents/skills/pr-to-green/SKILL.md
@@ -81,6 +81,7 @@ Use subagents (via the Task tool) when work is noisy, broad, or high-risk. Each 
 Trigger when CI logs are long/noisy, failures span multiple jobs, or failure family is unclear.
 
 Handoff (include in Task prompt):
+
 - PR number and branch name
 - Failed job names and relevant log snippets or `gh run view` output
 - Ask for: root cause ranking, fix-first order, and minimal patch plan
@@ -90,6 +91,7 @@ Handoff (include in Task prompt):
 Trigger when rebase/merge produces non-trivial conflicts, intent differs across branches, or conflict count is high.
 
 Handoff (include in Task prompt):
+
 - Target branch and merge/rebase direction
 - Full conflict list (`git diff --name-only --diff-filter=U`) and key conflict markers/snippets
 - Ask for: conflict risk map, lowest-risk resolution order, and explicit escalations
@@ -99,11 +101,13 @@ Handoff (include in Task prompt):
 Do not auto-resolve and continue silently when conflicts are highly complex. Instead, stop and request maintainer input with a brief report.
 
 Escalate by default when:
+
 - `.ipynb` conflicts are messy (overlapping cell content plus metadata/output churn)
 - conflict resolution would drop one branch's meaningful behavior
 - conflicts touch core contracts and intent is ambiguous (experiments/models/tests/docs all changed around same behavior)
 
 Escalation report must include:
+
 - conflicted file list and risk class
 - resolution options (1-2) with trade-offs
 - recommended next step and what decision is needed from maintainer
@@ -113,12 +117,14 @@ Escalation report must include:
 Do not keep patching silently when greening a PR turns into broader compatibility work outside the PR's feature surface. Stop after root-cause identification and ask the maintainer whether to continue in the PR or split the work into a separate branch/PR from `main`.
 
 Escalate by default when:
+
 - the failing checks are caused by third-party API or version drift in shared/core code
 - the fix would benefit multiple open PRs or the default branch, not just the current PR
 - the next fix would modify shared integrations beyond the feature the PR is introducing
 - successive CI reruns keep exposing new failure families outside the original PR scope
 
 Scope-drift report must include:
+
 - the original PR goal and the newly discovered broader issue
 - which files are feature-specific versus shared/core compatibility files
 - options: patch in the PR, split a separate compatibility PR, or pause for maintainer direction

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -79,6 +79,7 @@ Use this structure:
 
 ```markdown
 ## Findings
+
 - [severity] `path`: issue, why it matters, and what should change.
 
 ## Merge Readiness

--- a/.agents/skills/review-pr/resources/maintenance.md
+++ b/.agents/skills/review-pr/resources/maintenance.md
@@ -42,6 +42,7 @@ Each recurring pattern should include:
 
 - Canonical example: <PR reference and concrete instance>.
 - How to spot: <specific diagnostic prompt>.
+
 ```
 
 ## When to Prune

--- a/.agents/skills/review-pr/resources/review-comments.md
+++ b/.agents/skills/review-pr/resources/review-comments.md
@@ -57,6 +57,7 @@ Thanks for the PR. I have comments grouped by severity below.
 
 - [Specific positive about the implementation, tests, docs, or scope.]
 - [Another specific positive when available.]
+
 ```
 
 Keep positives specific. Generic praise adds little, but concrete reinforcement helps contributors preserve the good parts while fixing issues.

--- a/.cursor/agents/ci-failure-investigator.md
+++ b/.cursor/agents/ci-failure-investigator.md
@@ -25,12 +25,14 @@ When invoked:
 5. Recommend exact verification commands to confirm fixes.
 
 CausalPy-specific requirements:
+
 - Respect AGENTS.md conventions: CausalPy env via `$CONDA_EXE run -n CausalPy <command>`.
 - For commands importing PyMC/PyTensor/matplotlib or running pytest/doctest, explicitly note full permission requirements.
 - Prefer targeted reruns before full suite reruns.
 - If behavior changed, require proper pytest updates under `causalpy/tests/` (no throwaway scripts).
 
 Output format (strict):
+
 - Failing checks summary
 - Root-cause ranking (highest leverage first)
 - Minimal patch plan

--- a/.cursor/agents/merge-conflict-analyst.md
+++ b/.cursor/agents/merge-conflict-analyst.md
@@ -15,6 +15,7 @@ Operating mode:
 - Escalate ambiguous or high-risk conflicts to maintainer decision.
 
 When invoked:
+
 1. Inventory conflicted files and classify each as:
    - mechanical (format/import ordering/adjacent edits)
    - semantic (behavior/API/test/docs meaning may differ)
@@ -28,11 +29,13 @@ When invoked:
 4. After resolution, recommend focused verification commands and required tests.
 
 Hard escalation rules (must not auto-resolve):
+
 - `.ipynb` conflicts with many overlapping cell/output/metadata changes
 - conflicts affecting experiment/model contracts (`causalpy/experiments/`, `causalpy/pymc_models.py`, `causalpy/skl_models.py`) where intent is unclear
 - conflicts that require dropping one side's behavior without explicit maintainer approval
 
 Notebook-specific handling:
+
 - Prefer preserving semantic cell content and minimizing output/metadata churn.
 - If notebook conflict is messy, produce a maintainer report:
   - conflicting notebook paths
@@ -41,11 +44,13 @@ Notebook-specific handling:
   - recommended manual next action
 
 CausalPy requirements:
+
 - Respect AGENTS.md conventions and avoid destructive git operations.
 - Never discard unknown user changes.
 - If behavior changes, require pytest updates in `causalpy/tests/`.
 
 Output format (strict):
+
 - Conflict map (file -> risk class)
 - Proposed resolutions (ordered low-risk to high-risk)
 - Escalations requiring maintainer input

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,7 +30,7 @@ repos:
       - id: check-case-conflict
       - id: mixed-line-ending
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: v0.15.16
     hooks:
       # Run the linter
       - id: ruff
@@ -65,7 +65,7 @@ repos:
       - id: numpydoc-validation
         files: ^causalpy/experiments/.*\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.20.1
+    rev: v2.1.0
     hooks:
       - id: mypy
         args: [--ignore-missing-imports]
@@ -79,7 +79,7 @@ repos:
   # ``[tool.pymarkdown]`` of pyproject.toml. Notebook Markdown cells and the
   # generated docs build are intentionally out of scope.
   - repo: https://github.com/jackdewinter/pymarkdown
-    rev: v0.9.36
+    rev: v0.9.37
     hooks:
       - id: pymarkdown
         args: [scan]
@@ -87,6 +87,8 @@ repos:
         exclude: ^(docs/_build/|\.scratch/)
   # Regenerate environment.yml from pyproject.toml when deps change (run on commit; review diff).
   # Dev env uses python>=3.12; conda-only deps (make, pip, pymc-bart, marimo[mcp]) are in args.
+  # Stay on 0.22.x until pyproject2conda fixes the 0.23.x CondaRequirement regression
+  # (see check-environment-yml job in .github/workflows/ci.yml).
   - repo: https://github.com/usnistgov/pyproject2conda
     rev: v0.22.1
     hooks:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,6 +143,7 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
     ```
 
     This single command:
+
     - Installs CausalPy in editable mode (with `--no-deps` to avoid conflicts with conda-installed PyMC)
     - Installs all development extras (`dev`, `docs`, `test`, `lint`)
     - Sets up prek hooks
@@ -292,6 +293,7 @@ Contributions are welcome from the community. This section describes how contrib
 ### Current maintainers
 
 <!-- Update this list as the team evolves -->
+
 - [@drbenvincent](https://github.com/drbenvincent)
 - [@juanitorduz](https://github.com/juanitorduz)
 - [@NathanielF](https://github.com/NathanielF)
@@ -321,21 +323,25 @@ Contributions are welcome from the community. This section describes how contrib
 #### 1) Community participant (public access)
 
 **Who this is for**
+
 - Anyone engaging with the project: users, researchers, educators, and prospective contributors.
 
 **What you can do**
+
 - Open issues (bug reports, feature requests, questions).
 - Participate in discussions.
 - Submit PRs from forks (code, docs, tests, examples).
 - Review PRs by leaving comments and suggestions.
 
 **Expectations**
+
 - Follow the [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 - Prefer small, focused PRs.
 - Include tests and docs updates when appropriate.
 - Be responsive to reviewer feedback.
 
 **Signals you may be ready for elevated access**
+
 - Consistently helpful participation and good judgment.
 - High-quality issue reports (clear repro, version info).
 - A track record of merged contributions and constructive reviews.
@@ -345,28 +351,34 @@ Contributions are welcome from the community. This section describes how contrib
 #### 2) Triager (Triage)
 
 **Who this is for**
+
 - Contributors who help maintain project hygiene by managing issues and PR flow without changing code directly.
 
 **What you can do (typical)**
+
 - Apply and manage labels.
 - Ask for reproductions, logs, environment details.
 - Close duplicates, redirect questions to Discussions.
 - Keep PRs moving by requesting changes, tagging reviewers, and nudging for updates.
 
 **What you cannot do**
+
 - Merge PRs.
 - Change repository settings.
 
 **Expectations**
+
 - Use a consistent labeling taxonomy.
 - Be neutral and kind; focus on clarity.
 - Escalate ambiguous/controversial decisions to maintainers.
 
 **Suggested criteria**
+
 - Demonstrated helpfulness over time (e.g., 4–8 weeks of consistent triage activity).
 - Sound judgment on duplicates, scope, and priority.
 
 **Nomination and granting**
+
 - Maintainers can invite directly, or a contributor can request the role by [opening a GitHub issue](https://github.com/pymc-labs/CausalPy/issues/new).
 - Access is reviewed periodically; inactivity may result in stepping down.
 
@@ -375,24 +387,29 @@ Contributions are welcome from the community. This section describes how contrib
 #### 3) Collaborator (Write)
 
 **Who this is for**
+
 - Contributors who actively push changes and can be trusted with direct write access.
 
 **What you can do (typical)**
+
 - Push branches to the main repository.
 - Help maintain CI, docs, examples.
 - Perform routine maintenance tasks (refactors, dependency updates) within agreed scope.
 
 **Expectations**
+
 - Demonstrate good engineering hygiene: tests, docs, changelog discipline (as applicable).
 - Respect backwards compatibility and public API stability.
 - Participate in code review (both giving and receiving).
 
 **Suggested criteria**
+
 - Sustained contributions (e.g., multiple merged PRs across at least a few weeks/months).
 - High-quality reviews that improve code quality and catch issues.
 - Familiarity with project standards and tooling.
 
 **Safety mechanisms**
+
 - Branch protection remains enabled (required checks, review requirements).
 - Prefer PR-based changes even for collaborators.
 
@@ -401,25 +418,30 @@ Contributions are welcome from the community. This section describes how contrib
 #### 4) Maintainer (Maintain)
 
 **Who this is for**
+
 - People who help run the project: merging, release coordination, and repository management.
 
 **What you can do (typical)**
+
 - Merge PRs.
 - Manage labels and milestones.
 - Coordinate releases and ensure release notes are accurate.
 - Manage project boards (if used).
 
 **Expectations**
+
 - Consistent review and merge quality.
 - Ability to mediate disagreements and drive decisions.
 - Active stewardship of community norms.
 
 **Suggested criteria**
+
 - Track record of high-impact contributions and reliable collaboration.
 - Demonstrated leadership: mentoring, reviews, triage, roadmap contributions.
 - Comfortable with responsible disclosure and security processes (if applicable).
 
 **Onboarding**
+
 - Start with a limited scope (e.g., one module or docs/releases) and expand.
 
 ---
@@ -459,6 +481,7 @@ Admin access is reserved for project leads and is not part of the contributor pa
 ### Appendix: Quick rubric for promotion
 
 Consider promoting when a contributor reliably demonstrates:
+
 - **Quality:** produces correct changes with appropriate tests/docs.
 - **Judgment:** scopes work well and respects compatibility.
 - **Collaboration:** responds to review, helps others, communicates.

--- a/causalpy/skills/choosing-causalpy-methods/reference/decision_tree.md
+++ b/causalpy/skills/choosing-causalpy-methods/reference/decision_tree.md
@@ -5,40 +5,52 @@ Use this file as the canonical routing algorithm for choosing a CausalPy experim
 ## Routing Algorithm
 
 ```text
+
 1. Check required intake.
+
    If estimand, assignment mechanism, data topology, and control type are not known, ask for the single missing fact that most changes the route.
 
 2. Check for unsupported goals before force-fitting.
+
    If the user needs matching, mediation, survival models, causal forests/CATE, fuzzy RD, non-absorbing staggered treatment, augmented synthetic control, matrix completion, alternative staggered DiD estimators, or continuous/multi-arm treatment outside IV or kink settings, return the Not implemented in CausalPy output.
 
 3. If assignment is a known intervention time, route by data topology.
+
    If data is one outcome series with no donor units, compare InterruptedTimeSeries and PiecewiseITS.
    If data is one treated outcome series plus one or more comparison/control series used as formula predictors, route to InterruptedTimeSeries as Comparative Interrupted Time Series (CITS), then compare against SyntheticControl if the user wants constrained donor weighting.
    If data is a wide panel where columns are units and at least one untreated donor unit is available, compare SyntheticControl and SyntheticDifferenceInDifferences.
    If data is a long panel with treated and control groups, compare DifferenceInDifferences, StaggeredDifferenceInDifferences, and PanelRegression.
 
 4. If assignment is a common treated/control pre/post design, route to DifferenceInDifferences.
+
    Use this when treated and control groups share one intervention timing and the estimand is the group-by-post interaction. If adoption timing differs by unit, switch to StaggeredDifferenceInDifferences. If there is only one baseline and one post outcome per unit, compare PrePostNEGD.
 
 5. If assignment is staggered adoption, route to StaggeredDifferenceInDifferences only when treatment is absorbing.
+
    Use this for cohort or event-time ATT paths with unit-time panel data, no anticipation, and never-treated or not-yet-treated comparison information. Confirm each calendar period in the estimand has at least one untreated unit; otherwise return Not identifiable yet. If treatment can turn off or repeat, return Not implemented in CausalPy.
 
 6. If assignment is a cutoff or kink in a running variable, route by estimand.
+
    Use RegressionDiscontinuity for a sharp level jump at a cutoff. Use RegressionKink for a slope or treatment-intensity change at a kink point. If treatment probability changes but treatment is not sharp at the cutoff, return Not implemented in CausalPy unless the problem can be reframed as a general InstrumentalVariable analysis with clear caveats.
 
 7. If assignment depends on a credible instrument, route to InstrumentalVariable.
+
    Require a relevance story, exclusion restriction, and outcome/treatment/instrument data. If the user mainly has measured confounders rather than an instrument, compare InversePropensityWeighting and PanelRegression instead.
 
 8. If treatment is observed and confounded, route by treatment type and adjustment story.
+
    Use InversePropensityWeighting only for binary treatment with measured confounders and plausible overlap. Use PanelRegression only when the analysis target is fixed-effects coefficient estimation and the user understands the result is not automatically a causal design. If confounding is unmeasured and there is no valid instrument, return Not identifiable yet or Not implemented in CausalPy rather than forcing IPW.
 
 9. If data contains pre and post outcomes but not a repeated time panel, compare PrePostNEGD and DifferenceInDifferences.
+
    Use PrePostNEGD for baseline-adjusted nonequivalent group designs with one pretest and one posttest outcome. Use DifferenceInDifferences only when there are repeated observations over time that support a pre/post group trend comparison.
 
 10. Apply capability gates before finalizing.
+
     If the user requires OLS/sklearn, avoid Bayesian-only methods. If the user requires `effect_summary()` or a unified `plot()`, check the method capability matrix before selecting IV, IPW, or PanelRegression.
 
 11. Return one output contract.
+
     Return Matched, Ambiguous, Not identifiable yet, or Not implemented in CausalPy. Do not write analysis code as part of this skill unless the route is Matched and the user explicitly asks to proceed.
 ```
 

--- a/docs/source/knowledgebase/reporting_statistics.md
+++ b/docs/source/knowledgebase/reporting_statistics.md
@@ -50,6 +50,7 @@ When you use PyMC models, CausalPy performs Bayesian inference, yielding posteri
 - **Interpretation:** "The average estimated effect is X"
 
 **Median**
+
 - The middle value of the posterior distribution (50th percentile)
 - Divides the posterior probability mass in half
 - **When to use:** Preferred when the posterior is skewed; more robust to outliers
@@ -62,6 +63,7 @@ For symmetric posteriors, mean and median are nearly identical. For skewed poste
 ### Uncertainty Quantification
 
 **HDI (Highest Density Interval)**
+
 - A {term}`credible interval` containing the specified percentage of posterior probability (default: 95%)
 - Reported as `hdi_lower` and `hdi_upper` in summary tables
 - The narrowest interval containing the specified probability mass
@@ -85,12 +87,14 @@ mean: 2.5, 95% HDI: [1.2, 3.8]
 Bayesian hypothesis testing uses posterior probabilities directly, making the interpretation more intuitive than traditional p-values.
 
 **Directional Tests**
+
 - `p_gt_0`: {term}`Posterior probability` that the effect is greater than zero (positive effect)
 - `p_lt_0`: Posterior probability that the effect is less than zero (negative effect)
 - **Interpretation:** Direct probability statements about the hypothesis
 - **Example:** If `p_gt_0 = 0.95`, there's a 95% probability the effect is positive
 
 **Two-Sided Tests**
+
 - `p_two_sided`: Probability of observing an effect at least this extreme in either direction
   - **Calculation:** `2 × min(P(effect > 0), P(effect < 0))`
   - This mirrors the frequentist two-sided p-value approach
@@ -105,6 +109,7 @@ Unlike frequentist p-values, Bayesian posterior probabilities answer the questio
 :::
 
 **Decision guidance:**
+
 - `p_gt_0 > 0.95` or `p_lt_0 > 0.95`: Strong evidence for directional effect
 - `prob_of_effect > 0.95`: Strong evidence for any effect (two-sided)
 - Values close to 0.5: Weak or no evidence for the effect
@@ -112,12 +117,14 @@ Unlike frequentist p-values, Bayesian posterior probabilities answer the questio
 ### Effect Size Assessment
 
 **ROPE (Region of Practical Equivalence)**
+
 - Tests whether the effect exceeds a minimum meaningful threshold (`min_effect`)
 - Reported as `p_rope` in summary tables
 - **Purpose:** Distinguish statistical significance from practical significance
 - **Interpretation:** Probability that the effect exceeds the threshold you care about
 
 **How it works:**
+
 1. You specify `min_effect` (the smallest effect size you consider meaningful)
 2. For "increase" direction: `p_rope` = P(effect > min_effect)
 3. For "decrease" direction: `p_rope` = P(effect < -min_effect)
@@ -144,6 +151,7 @@ When you use scikit-learn models (OLS regression), CausalPy performs classical f
 ### Point Estimates
 
 **Mean / Coefficient Estimate**
+
 - The estimated causal effect from the regression model
 - For scalar effects (DiD, RD): the coefficient of interest
 - For time-series effects (ITS, SC): the average or cumulative impact
@@ -156,12 +164,14 @@ Unlike Bayesian estimates, frequentist point estimates don't come with a probabi
 ### Uncertainty Quantification
 
 **Confidence Intervals (CI)**
+
 - Reported as `ci_lower` and `ci_upper` in summary tables
 - Computed using t-distribution critical values at the specified significance level (default: α = 0.05 for 95% CI)
 - **Interpretation:** "If we repeated this experiment many times, 95% of such intervals would contain the true effect"
 - **Key difference from HDI:** This is a statement about the procedure, not about the parameter
 
 **Standard Errors**
+
 - Measure of uncertainty in the coefficient estimate
 - Used to construct confidence intervals and compute p-values
 - Derived from the residual variance and design matrix
@@ -182,22 +192,26 @@ mean: 2.5, 95% CI: [1.1, 3.9]
 ### Hypothesis Testing
 
 **p-values**
+
 - The probability of observing data at least as extreme as what we observed, assuming the null hypothesis (no effect) is true
 - Reported as `p_value` in summary tables
 - **Common threshold:** p < 0.05 is often used as evidence against the null hypothesis
 - **Interpretation:** Lower p-values indicate stronger evidence against no effect
 
 **Correct interpretation:**
+
 - p = 0.03: "If there were truly no effect, we'd observe data this extreme only 3% of the time"
 - **NOT:** "There's a 97% probability of an effect" (this is a Bayesian interpretation)
 
 **Common pitfalls to avoid:**
+
 1. ❌ "p = 0.06 means no effect" → The p-value doesn't prove the null hypothesis
 2. ❌ "p < 0.05 means the effect is important" → Statistical significance ≠ practical significance
 3. ❌ "p = 0.01 is better than p = 0.04" → Both provide evidence against the null; the effect size matters more
 4. ❌ "p > 0.05 proves no effect" → Absence of evidence is not evidence of absence
 
 **Decision guidance:**
+
 - p < 0.05: Conventional threshold for "statistical significance"
 - p < 0.01: Stronger evidence against the null
 - p > 0.05: Insufficient evidence to reject the null (but doesn't prove no effect)
@@ -207,6 +221,7 @@ Always report the actual p-value and effect size, not just whether p < 0.05. The
 :::
 
 **t-statistics and degrees of freedom**
+
 - t-statistic = coefficient / standard error
 - Measures how many standard errors the estimate is from zero
 - Degrees of freedom (df) = n - p, where n = sample size, p = number of parameters
@@ -245,11 +260,13 @@ Both approaches are valid and will often lead to similar conclusions, especially
 For experiments with a single causal effect parameter:
 
 **Bayesian output:**
+
 - One row with: mean, median, hdi_lower, hdi_upper
 - Tail probabilities: p_gt_0 (or p_lt_0, or p_two_sided + prob_of_effect)
 - Optional: p_rope (if min_effect specified)
 
 **Frequentist output:**
+
 - One row with: mean, ci_lower, ci_upper, p_value
 
 ### Time-Series Effects (ITS, Synthetic Control)
@@ -257,10 +274,12 @@ For experiments with a single causal effect parameter:
 For experiments with multiple post-treatment time points:
 
 **Two aggregation levels:**
+
 1. **Average effect:** Mean effect across the post-treatment window
 2. **Cumulative effect:** Sum of effects across the post-treatment window
 
 **Additional statistics:**
+
 - **Relative effects:** Percentage change relative to counterfactual
   - `relative_mean`: Effect size as percentage of counterfactual
   - `relative_hdi_lower` / `relative_hdi_upper` (Bayesian)
@@ -356,7 +375,9 @@ For deeper understanding of these statistical concepts:
 - **Practical application:** Explore the example notebooks in our documentation showing these concepts in action
 
 :::{seealso}
+
 - :doc:`glossary` - Quick reference for statistical terms
 - :doc:`causal_written_resources` - Books and articles on causal inference
 - API documentation for the `effect_summary()` method
+
 :::

--- a/docs/source/notebooks/sensitivity_checks.md
+++ b/docs/source/notebooks/sensitivity_checks.md
@@ -169,9 +169,11 @@ Sensitivity checks are **diagnostics**, not definitive verdicts. A passing check
 For the pipeline mechanics, see {doc}`pipeline_workflow`. For HTML reporting of check results, see {doc}`report_demo`. More method-specific sensitivity walkthroughs will be added over time; where they already exist, they are linked above.
 
 :::{seealso}
+
 - {doc}`pipeline_workflow` --- end-to-end pipeline tutorial
 - {doc}`report_demo` --- HTML report generation
 - {doc}`staggered_did_pymc` --- staggered DiD example with `PreTreatmentPlaceboCheck`
 - {doc}`rkink_pymc` --- regression kink example with `BandwidthSensitivity`
 - {doc}`../knowledgebase/reporting_statistics` --- statistical concepts used in CausalPy reporting
+
 :::

--- a/scripts/run_notebooks/README.md
+++ b/scripts/run_notebooks/README.md
@@ -45,7 +45,9 @@ The notebook runner mirrors the CI setup and expects a full docs/test environmen
 ## Notes
 
 - The runner executes using the `python3` Jupyter kernel. Ensure your environment
+
   provides that kernel (e.g., from `ipykernel` installed via the docs extras).
+
 - The CI workflow uses Python 3.12 and installs the same extras.
 
 ## Usage
@@ -70,6 +72,7 @@ python scripts/run_notebooks/runner.py --parallel
 ## CI Integration
 
 The GitHub Actions workflow (`.github/workflows/test_notebook.yml`) runs this script in parallel:
+
 - Job 1: PyMC notebooks
 - Job 2: Sklearn notebooks
 - Job 3: Other notebooks


### PR DESCRIPTION
## Summary
- Supersedes pre-commit.ci autoupdate PR #869 with a maintainer-reviewed bump of ruff (`v0.15.16`), pymarkdown (`v0.9.37`), and mypy (`v2.1.0`).
- Fix MD032 (blank lines around lists) across the Markdown corpus so pymarkdown v0.9.37 passes on the full tree — the reason #869's `pre-commit.ci` check was red while GitHub `prek` stayed green (prek only scans changed files; #869 only touched `.pre-commit-config.yaml`).
- **Keep pyproject2conda on `v0.22.1`**: `v0.23.x` has a known regression (`CondaRequirement` / `channel` AttributeError) documented in `.github/workflows/ci.yml`; #869's proposed bump would break `check-environment-yml`.

## Test plan
- [x] `prek run --all-files` locally (including mypy 2.x and pymarkdown 0.9.37)
- [ ] CI green on this PR
- [ ] Close #869 after merge (weekly pre-commit.ci autoupdate should then be a no-op or minor-only)


Made with [Cursor](https://cursor.com)