### PR TITLE
refactor: centralize PyMC/sklearn dispatch in ModelAdapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ docs/source/api/generated/
 
 # Local scratch space (not tracked)
 .scratch/
+coverage.xml

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -23,18 +23,22 @@ CausalPy implements 10+ quasi-experimental causal inference methods over two sta
 
 ## Two-Backend Model
 
-Dispatch is via `isinstance` checks throughout `BaseExperiment` and experiment subclasses:
+Backend dispatch is centralized in `causalpy/experiments/model_adapter.py`. `BaseExperiment.__init__` calls `make_model_adapter()`, which handles sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class()`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols` validation. Each experiment stores `self._model_backend` (private) and keeps `self.model` as the public handle.
+
+Experiments branch on backend via the adapter rather than scattered `isinstance` checks:
 
 ```python
-if isinstance(self.model, PyMCModel):
-    # Bayesian path — xarray DataArrays, InferenceData
-elif isinstance(self.model, RegressorMixin):
-    # OLS path — numpy arrays
+if self._model_backend.is_bayesian:
+    # Bayesian path — xarray DataArrays, InferenceData, coords
+    self._model_backend.fit(X=X, y=y, coords=COORDS)
+elif self._model_backend.is_ols:
+    # OLS path — numpy arrays (y shape preserved per experiment)
+    self._model_backend.fit(X=X, y=y)
 ```
 
-`PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` (mutates the instance in place).
+`PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` during adapter construction.
 
-Every experiment declares `supports_ols` and `supports_bayes`; `BaseExperiment.__init__` validates the model type. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model).
+Every experiment declares `supports_ols` and `supports_bayes`; validation runs in `make_model_adapter()`. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model). Experiments with non-standard fit signatures (e.g. `InstrumentalVariable`, `InversePropensityWeighting`) call `self.model.fit(...)` directly with their custom arguments.
 
 ## Experiment Lifecycle
 
@@ -77,7 +81,7 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 | **Intercept handling** | Patsy includes intercept by default. sklearn models must use `fit_intercept=False`. |
 | **Eager fitting** | MCMC runs during `__init__`. No lazy `.fit()` on the experiment. |
 | **HDI_PROB** | Project default is 0.94 (ArviZ default), not 0.95. |
-| **create_causalpy_compatible_class** | Mutates the passed sklearn instance in place; does not return a new object. |
+| **create_causalpy_compatible_class** | Applied during `make_model_adapter()` for sklearn backends; clones the user instance before patching. |
 
 ## Adding New Code
 

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -18,7 +18,6 @@ Base class for quasi experimental designs.
 from __future__ import annotations
 
 import contextlib
-import copy
 import warnings
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -29,12 +28,12 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import xarray as xr
-from sklearn.base import RegressorMixin, clone
+from sklearn.base import RegressorMixin
 
+from causalpy.experiments.model_adapter import ModelAdapter, make_model_adapter
 from causalpy.maketables_adapters import get_maketables_adapter
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
-from causalpy.skl_models import create_causalpy_compatible_class
 
 
 def _apply_legend_kwargs(legend: Any, kwargs: dict[str, Any]) -> None:
@@ -185,46 +184,17 @@ class BaseExperiment(ABC):
             }
         )
 
+    _model_backend: ModelAdapter
+
     def __init__(self, model: PyMCModel | RegressorMixin | None = None) -> None:
-        # Ensure we've made any provided Scikit Learn model (as identified as being type
-        # RegressorMixin) compatible with CausalPy by appending our custom methods.
-        if isinstance(model, RegressorMixin):
-            # Clone to avoid mutating the caller's estimator instance (#664).
-            try:
-                model = clone(model)
-            except TypeError:
-                # Models without get_params() can't be sklearn-cloned;
-                # fall back to a deep copy.
-                model = copy.deepcopy(model)
-            model = create_causalpy_compatible_class(model)
-            # Patsy includes the intercept as a design-matrix column, so
-            # sklearn models must not add their own intercept.
-            if getattr(model, "fit_intercept", False):
-                warnings.warn(
-                    f"{type(model).__name__} had fit_intercept=True, but CausalPy "
-                    "requires fit_intercept=False because the intercept is already "
-                    "included in the design matrix by patsy. A cloned copy of the "
-                    "model with fit_intercept=False will be used; the original "
-                    "instance is unchanged.",
-                    UserWarning,
-                    stacklevel=2,
-                )
-                model.fit_intercept = False
-
-        if model is None and self._default_model_class is not None:
-            model = self._default_model_class()
-
-        if model is not None:
-            self.model = model
-
-        if getattr(self, "model", None) is None:
-            raise ValueError("model not set or passed.")
-
-        if isinstance(self.model, PyMCModel) and not self.supports_bayes:
-            raise ValueError("Bayesian models not supported.")
-
-        if isinstance(self.model, RegressorMixin) and not self.supports_ols:
-            raise ValueError("OLS models not supported.")
+        adapter = make_model_adapter(
+            model,
+            default_model_class=self._default_model_class,
+            supports_bayes=self.supports_bayes,
+            supports_ols=self.supports_ols,
+        )
+        self._model_backend = adapter
+        self.model = adapter.model
 
     def fit(self, *args: Any, **kwargs: Any) -> None:
         """Fit the underlying model.
@@ -250,7 +220,7 @@ class BaseExperiment(ABC):
     @property
     def idata(self) -> az.InferenceData:
         """Return the InferenceData object of the model. Only relevant for PyMC models."""
-        return self.model.idata
+        return self._model_backend.idata
 
     def print_coefficients(self, round_to: int | None = None) -> None:
         """Ask the model to print its coefficients.
@@ -261,7 +231,7 @@ class BaseExperiment(ABC):
             Number of significant figures to round to. Defaults to None,
             in which case 2 significant figures are used.
         """
-        self.model.print_coefficients(self.labels, round_to)
+        self._model_backend.print_coefficients(self.labels, round_to)
 
     def set_maketables_options(self, *, hdi_prob: float | None = None) -> None:
         """Set optional maketables rendering options for this experiment.
@@ -370,9 +340,9 @@ class BaseExperiment(ABC):
             ``_bayesian_plot`` / ``_ols_plot``.
         """
         with plt.style.context(az.style.library["arviz-darkgrid"]):
-            if isinstance(self.model, PyMCModel):
+            if self._model_backend.is_bayesian:
                 fig, ax = self._bayesian_plot(**draw_kwargs)
-            elif isinstance(self.model, RegressorMixin):
+            elif self._model_backend.is_ols:
                 fig, ax = self._ols_plot(**draw_kwargs)
             else:
                 raise ValueError("Unsupported model type")
@@ -425,12 +395,11 @@ class BaseExperiment(ABC):
         **kwargs
             Keyword arguments forwarded to the model-specific implementation.
         """
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             return self.get_plot_data_bayesian(*args, **kwargs)
-        elif isinstance(self.model, RegressorMixin):
+        if self._model_backend.is_ols:
             return self.get_plot_data_ols(*args, **kwargs)
-        else:
-            raise ValueError("Unsupported model type")
+        raise ValueError("Unsupported model type")
 
     def get_plot_data_bayesian(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
         """Return plot data for Bayesian models. Override in subclasses that support Bayesian.

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -150,17 +150,15 @@ class DifferenceInDifferences(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(X.shape[0]),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X, y=y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=X, y=y)
+            self._model_backend.fit(X=X, y=y, coords=COORDS)
         else:
-            raise ValueError("Model type not recognized")
+            self._model_backend.fit(X=X, y=y)
 
         # predicted outcome for control group
         self.x_pred_control = (
@@ -177,7 +175,7 @@ class DifferenceInDifferences(BaseExperiment):
         if self.x_pred_control.empty:
             raise ValueError("x_pred_control is empty")
         (new_x,) = build_design_matrices([self._x_design_info], self.x_pred_control)
-        self.y_pred_control = self.model.predict(np.asarray(new_x))
+        self.y_pred_control = self._model_backend.predict(np.asarray(new_x))
 
         # predicted outcome for treatment group
         self.x_pred_treatment = (
@@ -194,7 +192,7 @@ class DifferenceInDifferences(BaseExperiment):
         if self.x_pred_treatment.empty:
             raise ValueError("x_pred_treatment is empty")
         (new_x,) = build_design_matrices([self._x_design_info], self.x_pred_treatment)
-        self.y_pred_treatment = self.model.predict(np.asarray(new_x))
+        self.y_pred_treatment = self._model_backend.predict(np.asarray(new_x))
 
         # predicted outcome for counterfactual. This is given by removing the influence
         # of the interaction term between the group and the post_treatment variable
@@ -224,10 +222,10 @@ class DifferenceInDifferences(BaseExperiment):
                 and self.group_variable_name in label
             ):
                 new_x.iloc[:, i] = 0
-        self.y_pred_counterfactual = self.model.predict(np.asarray(new_x))
+        self.y_pred_counterfactual = self._model_backend.predict(np.asarray(new_x))
 
         # calculate causal impact
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             assert self.model.idata is not None
             # This is the coefficient on the interaction term
             coeff_names = self.model.idata.posterior.coords["coeffs"].data
@@ -239,10 +237,12 @@ class DifferenceInDifferences(BaseExperiment):
                     self.causal_impact = self.model.idata.posterior["beta"].isel(
                         {"coeffs": i}
                     )
-        elif isinstance(self.model, RegressorMixin):
+        elif self._model_backend.is_ols:
             # This is the coefficient on the interaction term
             # Store the coefficient into dictionary {intercept:value}
-            coef_map = dict(zip(self.labels, self.model.get_coeffs(), strict=False))
+            coef_map = dict(
+                zip(self.labels, self._model_backend.coefficients(), strict=False)
+            )
             # Create and find the interaction term based on the values user provided
             interaction_term = (
                 f"{self.group_variable_name}:{self.post_treatment_variable_name}"
@@ -676,9 +676,7 @@ class DifferenceInDifferences(BaseExperiment):
         EffectSummary
             Object with .table (DataFrame) and .text (str) attributes
         """
-        from causalpy.pymc_models import PyMCModel
-
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
 
         if is_pymc:
             return _effect_summary_did(

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -194,36 +194,35 @@ class InterruptedTimeSeries(BaseExperiment):
         post_X = self.post_design["X"]
         post_y = self.post_design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS: dict[str, Any] = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(pre_X.shape[0]),
                 "treated_units": ["unit_0"],
                 "datetime_index": self.datapre.index,
             }
-            self.model.fit(X=pre_X, y=pre_y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=pre_X, y=pre_y.isel(treated_units=0))
+            self._model_backend.fit(X=pre_X, y=pre_y, coords=COORDS)
         else:
-            raise ValueError("Model type not recognized")
+            self._model_backend.fit(X=pre_X, y=pre_y.isel(treated_units=0))
 
-        if isinstance(self.model, PyMCModel):
-            self.score = self.model.score(X=pre_X, y=pre_y)
-        elif isinstance(self.model, RegressorMixin):
-            self.score = self.model.score(X=pre_X, y=pre_y.isel(treated_units=0))
+        if self._model_backend.is_bayesian:
+            self.score = self._model_backend.score(X=pre_X, y=pre_y)
+        else:
+            self.score = self._model_backend.score(
+                X=pre_X, y=pre_y.isel(treated_units=0)
+            )
 
-        if isinstance(self.model, PyMCModel | RegressorMixin):
-            self.pre_pred = self.model.predict(X=pre_X)
+        self.pre_pred = self._model_backend.predict(X=pre_X)
 
-        if isinstance(self.model, PyMCModel):
-            self.post_pred = self.model.predict(X=post_X, out_of_sample=True)
-        elif isinstance(self.model, RegressorMixin):
-            self.post_pred = self.model.predict(X=post_X)
+        if self._model_backend.is_bayesian:
+            self.post_pred = self._model_backend.predict(X=post_X, out_of_sample=True)
+        else:
+            self.post_pred = self._model_backend.predict(X=post_X)
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             self.pre_impact = self.model.calculate_impact(pre_y, self.pre_pred)
             self.post_impact = self.model.calculate_impact(post_y, self.post_pred)
-        elif isinstance(self.model, RegressorMixin):
+        else:
             self.pre_impact = self.model.calculate_impact(
                 pre_y.isel(treated_units=0), self.pre_pred
             )
@@ -340,7 +339,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
         # Split predictions and impacts
         # Handle both PyMC (xarray) and OLS (numpy) cases
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
 
         if is_pymc:
             # PyMC: use xarray selection
@@ -449,7 +448,7 @@ class InterruptedTimeSeries(BaseExperiment):
         """
         from causalpy.reporting import _extract_hdi_bounds
 
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
         time_dim = "obs_ind"
         hdi_prob = 1 - alpha
         prob_persisted: float | None
@@ -1030,7 +1029,7 @@ class InterruptedTimeSeries(BaseExperiment):
             Probability mass of the highest density interval. Defaults to the
             project-wide :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
         """
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             hdi_pct = int(round(hdi_prob * 100))
 
             pred_lower_col = f"pred_hdi_lower_{hdi_pct}"
@@ -1221,7 +1220,7 @@ class InterruptedTimeSeries(BaseExperiment):
                 "This method is only available for three-period designs."
             )
 
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
         time_dim = "obs_ind"
 
         if is_pymc:
@@ -1404,7 +1403,7 @@ class InterruptedTimeSeries(BaseExperiment):
             _generate_table_ols,
         )
 
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
 
         # Handle period parameter for three-period designs
         if period is not None:

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -1,0 +1,402 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Backend adapters for experiment model fitting and prediction."""
+
+from __future__ import annotations
+
+import copy
+import warnings
+from abc import ABC, abstractmethod
+from typing import Any, Literal
+
+import arviz as az
+import numpy as np
+from sklearn.base import RegressorMixin, clone
+
+from causalpy.pymc_models import PyMCModel
+from causalpy.skl_models import create_causalpy_compatible_class
+
+BackendKind = Literal["pymc", "sklearn"]
+
+
+class ModelAdapter(ABC):
+    """Experiment-agnostic wrapper around a CausalPy statistical backend."""
+
+    @property
+    @abstractmethod
+    def model(self) -> PyMCModel | RegressorMixin:
+        """The underlying model instance."""
+
+    @property
+    @abstractmethod
+    def kind(self) -> BackendKind:
+        """Backend identifier."""
+
+    @property
+    def is_bayesian(self) -> bool:
+        """Whether the backend is Bayesian (PyMC)."""
+        return self.kind == "pymc"
+
+    @property
+    def is_ols(self) -> bool:
+        """Whether the backend is OLS/sklearn."""
+        return self.kind == "sklearn"
+
+    @property
+    @abstractmethod
+    def idata(self) -> az.InferenceData:
+        """Return InferenceData for Bayesian models."""
+
+    @abstractmethod
+    def fit(
+        self,
+        X: Any,
+        y: Any,
+        *,
+        coords: dict[str, Any] | None = None,
+    ) -> Any:
+        """Fit the model with backend-appropriate conventions.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix.
+        y : array-like or xarray.DataArray
+            Outcome vector or matrix.
+        coords : dict, optional
+            Coordinate metadata for PyMC models. Ignored by sklearn backends.
+        """
+
+    @abstractmethod
+    def predict(
+        self,
+        X: Any,
+        *,
+        out_of_sample: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Predict with backend-appropriate conventions.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix for which to generate predictions.
+        out_of_sample : bool, default False
+            Whether predictions are out-of-sample. Used by PyMC backends only.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+
+    @abstractmethod
+    def score(self, X: Any, y: Any, **kwargs: Any) -> Any:
+        """Score predictions against observed outcomes.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix.
+        y : array-like or xarray.DataArray
+            Observed outcomes.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+
+    @abstractmethod
+    def coefficients(self) -> np.ndarray:
+        """Return point estimates of model coefficients."""
+
+    @abstractmethod
+    def print_coefficients(
+        self, labels: list[str], round_to: int | None = None
+    ) -> None:
+        """Print model coefficients with labels.
+
+        Parameters
+        ----------
+        labels : list of str
+            Coefficient names aligned with the fitted model.
+        round_to : int, optional
+            Number of significant figures to round to.
+        """
+
+
+class PyMCModelAdapter(ModelAdapter):
+    """Adapter for :class:`~causalpy.pymc_models.PyMCModel` backends.
+
+    Parameters
+    ----------
+    model : PyMCModel
+        Fitted or unfitted PyMC backend model.
+    """
+
+    def __init__(self, model: PyMCModel) -> None:
+        self._model = model
+
+    @property
+    def model(self) -> PyMCModel:
+        """The underlying PyMC model."""
+        return self._model
+
+    @property
+    def kind(self) -> BackendKind:
+        """Backend identifier."""
+        return "pymc"
+
+    @property
+    def idata(self) -> az.InferenceData:
+        """Return the model's InferenceData object."""
+        return self._model.idata
+
+    def fit(
+        self,
+        X: Any,
+        y: Any,
+        *,
+        coords: dict[str, Any] | None = None,
+    ) -> az.InferenceData:
+        """Fit the PyMC model.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix.
+        y : array-like or xarray.DataArray
+            Outcome vector or matrix.
+        coords : dict, optional
+            Coordinate metadata for the PyMC model.
+        """
+        return self._model.fit(X=X, y=y, coords=coords)
+
+    def predict(
+        self,
+        X: Any,
+        *,
+        out_of_sample: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Predict using the PyMC model.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix for which to generate predictions.
+        out_of_sample : bool, default False
+            Whether predictions are out-of-sample.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.predict(X=X, out_of_sample=out_of_sample, **kwargs)
+
+    def score(self, X: Any, y: Any, **kwargs: Any) -> Any:
+        """Score predictions from the PyMC model.
+
+        Parameters
+        ----------
+        X : array-like or xarray.DataArray
+            Predictor matrix.
+        y : array-like or xarray.DataArray
+            Observed outcomes.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.score(X=X, y=y, **kwargs)
+
+    def coefficients(self) -> np.ndarray:
+        """Return posterior mean coefficients."""
+        if self._model.idata is None:
+            raise RuntimeError("Model has not been fit yet.")
+        beta = self._model.idata.posterior["beta"]
+        return beta.mean(dim=["chain", "draw"]).values
+
+    def print_coefficients(
+        self, labels: list[str], round_to: int | None = None
+    ) -> None:
+        """Print PyMC model coefficients.
+
+        Parameters
+        ----------
+        labels : list of str
+            Coefficient names aligned with the fitted model.
+        round_to : int, optional
+            Number of significant figures to round to.
+        """
+        self._model.print_coefficients(labels, round_to)
+
+
+class SklearnModelAdapter(ModelAdapter):
+    """Adapter for sklearn :class:`~sklearn.base.RegressorMixin` backends.
+
+    Parameters
+    ----------
+    model : RegressorMixin
+        CausalPy-compatible sklearn backend model.
+    """
+
+    def __init__(self, model: RegressorMixin) -> None:
+        self._model = model
+
+    @property
+    def model(self) -> RegressorMixin:
+        """The underlying sklearn model."""
+        return self._model
+
+    @property
+    def kind(self) -> BackendKind:
+        """Backend identifier."""
+        return "sklearn"
+
+    @property
+    def idata(self) -> az.InferenceData:
+        """OLS models do not expose InferenceData."""
+        raise AttributeError("OLS models do not have idata.")
+
+    def fit(
+        self,
+        X: Any,
+        y: Any,
+        *,
+        coords: dict[str, Any] | None = None,
+    ) -> Any:
+        """Fit the sklearn model.
+
+        Parameters
+        ----------
+        X : array-like
+            Predictor matrix.
+        y : array-like
+            Outcome vector or matrix.
+        coords : dict, optional
+            Ignored for sklearn backends.
+        """
+        return self._model.fit(X=X, y=y)
+
+    def predict(
+        self,
+        X: Any,
+        *,
+        out_of_sample: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Predict using the sklearn model.
+
+        Parameters
+        ----------
+        X : array-like
+            Predictor matrix for which to generate predictions.
+        out_of_sample : bool, default False
+            Ignored for sklearn backends.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.predict(X=X, **kwargs)
+
+    def score(self, X: Any, y: Any, **kwargs: Any) -> Any:
+        """Score predictions from the sklearn model.
+
+        Parameters
+        ----------
+        X : array-like
+            Predictor matrix.
+        y : array-like
+            Observed outcomes.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.score(X=X, y=y, **kwargs)
+
+    def coefficients(self) -> np.ndarray:
+        """Return fitted sklearn coefficients."""
+        return self._model.get_coeffs()
+
+    def print_coefficients(
+        self, labels: list[str], round_to: int | None = None
+    ) -> None:
+        """Print sklearn model coefficients.
+
+        Parameters
+        ----------
+        labels : list of str
+            Coefficient names aligned with the fitted model.
+        round_to : int, optional
+            Number of significant figures to round to.
+        """
+        self._model.print_coefficients(labels, round_to)
+
+
+def _prepare_sklearn_model(model: RegressorMixin) -> RegressorMixin:
+    """Clone, augment, and validate a sklearn estimator for CausalPy."""
+    try:
+        model = clone(model)
+    except TypeError:
+        model = copy.deepcopy(model)
+    model = create_causalpy_compatible_class(model)
+    if getattr(model, "fit_intercept", False):
+        warnings.warn(
+            f"{type(model).__name__} had fit_intercept=True, but CausalPy "
+            "requires fit_intercept=False because the intercept is already "
+            "included in the design matrix by patsy. A cloned copy of the "
+            "model with fit_intercept=False will be used; the original "
+            "instance is unchanged.",
+            UserWarning,
+            stacklevel=3,
+        )
+        model.fit_intercept = False
+    return model
+
+
+def make_model_adapter(
+    model: PyMCModel | RegressorMixin | None,
+    *,
+    default_model_class: type[PyMCModel] | None,
+    supports_bayes: bool,
+    supports_ols: bool,
+) -> ModelAdapter:
+    """Resolve, validate, and wrap a model in a backend adapter.
+
+    Parameters
+    ----------
+    model : PyMCModel, RegressorMixin, or None
+        User-supplied model instance, or ``None`` to use the default.
+    default_model_class : type[PyMCModel] or None
+        PyMC model class used when ``model`` is ``None``.
+    supports_bayes : bool
+        Whether the experiment supports Bayesian backends.
+    supports_ols : bool
+        Whether the experiment supports OLS/sklearn backends.
+
+    Returns
+    -------
+    ModelAdapter
+        Backend-specific adapter wrapping the resolved model.
+    """
+    if isinstance(model, RegressorMixin):
+        model = _prepare_sklearn_model(model)
+
+    if model is None and default_model_class is not None:
+        model = default_model_class()
+
+    if model is None:
+        raise ValueError("model not set or passed.")
+
+    if isinstance(model, PyMCModel):
+        if not supports_bayes:
+            raise ValueError("Bayesian models not supported.")
+        return PyMCModelAdapter(model)
+
+    if isinstance(model, RegressorMixin):
+        if not supports_ols:
+            raise ValueError("OLS models not supported.")
+        return SklearnModelAdapter(model)
+
+    raise ValueError("Unsupported model type")

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -295,15 +295,15 @@ class PanelRegression(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(X.shape[0]),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X, y=y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=X, y=y)
+            self._model_backend.fit(X=X, y=y, coords=COORDS)
+        else:
+            self._model_backend.fit(X=X, y=y)
 
     def _demean_transform(self, data: pd.DataFrame, group_var: str) -> pd.DataFrame:
         """Apply demeaned transformation (demean by group).
@@ -420,7 +420,7 @@ class PanelRegression(BaseExperiment):
             )
 
         print("\nModel Coefficients:")
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             # PyMC print_coefficients uses coordinate-based lookup so a
             # filtered label list works correctly.
             self.model.print_coefficients(coeff_labels, round_to)
@@ -589,7 +589,7 @@ class PanelRegression(BaseExperiment):
 
         coeff_names = var_names if var_names is not None else self._get_non_fe_labels()
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             # Bayesian: use az.plot_forest directly
             axes = az.plot_forest(
                 self.model.idata,
@@ -632,7 +632,7 @@ class PanelRegression(BaseExperiment):
             DataFrame with fitted values and credible intervals
         """
         # Get posterior predictions
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             mu = self.model.idata.posterior["mu"]  # type: ignore[union-attr]
             pred_mean = mu.mean(dim=["chain", "draw"]).values.flatten()
             pred_lower = mu.quantile(0.025, dim=["chain", "draw"]).values.flatten()
@@ -669,7 +669,7 @@ class PanelRegression(BaseExperiment):
         pd.DataFrame
             DataFrame with fitted values
         """
-        if isinstance(self.model, RegressorMixin):
+        if self._model_backend.is_ols:
             y_fitted = np.squeeze(self.model.predict(self.design["X"]))
         else:
             raise ValueError("Model is not an OLS model")
@@ -754,7 +754,7 @@ class PanelRegression(BaseExperiment):
 
         fig, ax = plt.subplots(figsize=(10, 6))
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             # Bayesian: get posterior means
             beta = self.model.idata.posterior["beta"]  # type: ignore[union-attr]
             unit_fe_indices = [self.labels.index(name) for name in unit_fe_names]
@@ -848,7 +848,7 @@ class PanelRegression(BaseExperiment):
             raise ValueError("interval_type must be 'mean' or 'predictive'")
 
         # Check if model is Bayesian
-        is_bayesian = isinstance(self.model, PyMCModel)
+        is_bayesian = self._model_backend.is_bayesian
 
         # Get posterior for HDI plotting (Bayesian only)
         if is_bayesian:
@@ -1007,7 +1007,7 @@ class PanelRegression(BaseExperiment):
             Figure and axes objects
         """
         # Get plot data
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             plot_data = self.get_plot_data_bayesian()
         else:
             plot_data = self.get_plot_data_ols()

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -200,24 +200,22 @@ class PiecewiseITS(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS: dict[str, Any] = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(X.shape[0]),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X, y=y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=X, y=y.isel(treated_units=0))
+            self._model_backend.fit(X=X, y=y, coords=COORDS)
         else:
-            raise ValueError("Model type not recognized")
+            self._model_backend.fit(X=X, y=y.isel(treated_units=0))
 
-        self.y_pred = self.model.predict(X=X)
+        self.y_pred = self._model_backend.predict(X=X)
 
-        if isinstance(self.model, PyMCModel):
-            self.score = self.model.score(X=X, y=y)
-        elif isinstance(self.model, RegressorMixin):
-            self.score = self.model.score(X=X, y=y.isel(treated_units=0))
+        if self._model_backend.is_bayesian:
+            self.score = self._model_backend.score(X=X, y=y)
+        else:
+            self.score = self._model_backend.score(X=X, y=y.isel(treated_units=0))
 
         # Compute counterfactual and effects
         self._compute_counterfactual_and_effects()
@@ -324,8 +322,8 @@ class PiecewiseITS(BaseExperiment):
             X_cf[:, idx] = 0
 
         # Compute counterfactual predictions
-        if isinstance(self.model, PyMCModel):
-            self.y_counterfactual = self.model.predict(X=X_cf)
+        if self._model_backend.is_bayesian:
+            self.y_counterfactual = self._model_backend.predict(X=X_cf)
 
             # Extract mu for fitted and counterfactual
             y_pred_mu = self.y_pred["posterior_predictive"]["mu"]
@@ -343,8 +341,8 @@ class PiecewiseITS(BaseExperiment):
             # Cumulative effect
             self.cumulative_effect = self.effect.cumsum(dim="obs_ind")
 
-        elif isinstance(self.model, RegressorMixin):
-            self.y_counterfactual = self.model.predict(X=X_cf)
+        elif self._model_backend.is_ols:
+            self.y_counterfactual = self._model_backend.predict(X=X_cf)
 
             # Compute effect
             self.effect = np.squeeze(self.y_pred) - np.squeeze(self.y_counterfactual)
@@ -387,7 +385,7 @@ class PiecewiseITS(BaseExperiment):
         post_indices = np.where(np.asarray(post_mask))[0]
 
         # Create post_impact - the effects after the first interruption
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             # For PyMC models, effect is an xarray.DataArray
             # Select using obs_ind coordinate
             self.post_impact = self.effect.isel(obs_ind=post_indices)
@@ -412,7 +410,7 @@ class PiecewiseITS(BaseExperiment):
                 obs_ind=self.datapost.index
             )
 
-        elif isinstance(self.model, RegressorMixin):
+        elif self._model_backend.is_ols:
             # For OLS models, effect and counterfactual are numpy arrays
             self.post_impact = self.effect[post_indices]
             self.post_pred = np.squeeze(self.y_counterfactual)[post_indices]
@@ -852,7 +850,7 @@ class PiecewiseITS(BaseExperiment):
             self, window_coords, treated_unit=treated_unit
         )
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             hdi_prob = 1 - alpha
             stats = _compute_statistics(
                 windowed_impact,

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -22,7 +22,6 @@ import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
-from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
@@ -140,14 +139,14 @@ class PrePostNEGD(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(X.shape[0]),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X, y=y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
+            self._model_backend.fit(X=X, y=y, coords=COORDS)
+        elif self._model_backend.is_ols:
             raise NotImplementedError("Not implemented for OLS model")
         else:
             raise ValueError("Model type not recognized")

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -177,17 +177,15 @@ class RegressionDiscontinuity(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS = {
                 "coeffs": self.labels,
                 "obs_ind": np.arange(X.shape[0]),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X, y=y, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=X, y=y)
+            self._model_backend.fit(X=X, y=y, coords=COORDS)
         else:
-            raise ValueError("Model type not recognized")
+            self._model_backend.fit(X=X, y=y)
 
         self.score = self.model.score(X=X, y=y)
 
@@ -227,7 +225,7 @@ class RegressionDiscontinuity(BaseExperiment):
         self.pred_discon = self.model.predict(X=np.asarray(new_x))
 
         # ******** THIS IS SUBOPTIMAL AT THE MOMENT ************************************
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             self.discontinuity_at_threshold = (
                 self.pred_discon["posterior_predictive"].sel(obs_ind=1)["mu"]
                 - self.pred_discon["posterior_predictive"].sel(obs_ind=0)["mu"]

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -135,9 +135,9 @@ class RegressionKink(BaseExperiment):
             "obs_ind": np.arange(X.shape[0]),
             "treated_units": ["unit_0"],
         }
-        self.model.fit(X=X, y=y, coords=COORDS)
+        self._model_backend.fit(X=X, y=y, coords=COORDS)
 
-        self.score = self.model.score(X=X, y=y)
+        self.score = self._model_backend.score(X=X, y=y)
 
         # get the model predictions of the observed data
         if self.bandwidth is not np.inf:
@@ -154,7 +154,7 @@ class RegressionKink(BaseExperiment):
             {self.running_variable_name: xi, "treated": self._is_treated(xi)}
         )
         (new_x,) = build_design_matrices([self._x_design_info], self.x_pred)
-        self.pred = self.model.predict(X=np.asarray(new_x))
+        self.pred = self._model_backend.predict(X=np.asarray(new_x))
 
         # evaluate gradient change around kink point
         mu_kink_left, mu_kink, mu_kink_right = self._probe_kink_point()

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -446,7 +446,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         # Convert to xarray for PyMC models
         n_train = self.X_train.shape[0]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             X_train_xr = xr.DataArray(
                 self.X_train,
                 dims=["obs_ind", "coeffs"],
@@ -465,17 +465,15 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 "obs_ind": np.arange(n_train),
                 "treated_units": ["unit_0"],
             }
-            self.model.fit(X=X_train_xr, y=y_train_xr, coords=COORDS)
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(X=self.X_train, y=self.y_train)
+            self._model_backend.fit(X=X_train_xr, y=y_train_xr, coords=COORDS)
         else:
-            raise ValueError("Model type not recognized")
+            self._model_backend.fit(X=self.X_train, y=self.y_train)
 
     def _predict_counterfactuals(self) -> None:
         """Predict counterfactual outcomes for all observations."""
         n_full = self.X_full.shape[0]
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             X_full_xr = xr.DataArray(
                 self.X_full,
                 dims=["obs_ind", "coeffs"],
@@ -484,7 +482,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                     "coeffs": self.labels,
                 },
             )
-            self.y_pred = self.model.predict(X=X_full_xr)
+            self.y_pred = self._model_backend.predict(X=X_full_xr)
 
             # Extract posterior mean for y_hat0
             y_hat0_mean = (
@@ -494,11 +492,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 .values
             )
             self.data["y_hat0"] = y_hat0_mean
-        elif isinstance(self.model, RegressorMixin):
-            self.y_pred = self.model.predict(self.X_full)
-            self.data["y_hat0"] = np.squeeze(self.y_pred)
         else:
-            raise ValueError("Model type not recognized")
+            self.y_pred = self._model_backend.predict(self.X_full)
+            self.data["y_hat0"] = np.squeeze(self.y_pred)
 
     def _compute_treatment_effects(self) -> None:
         """Compute treatment effects tau_hat = y - y_hat0 for treated observations."""
@@ -537,7 +533,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         is_pre_treatment = self.data["event_time"] < 0
         pretreatment_data = self.data[is_eventually_treated & is_pre_treatment].copy()
 
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             self._aggregate_effects_bayesian(treated_data, pretreatment_data)
         else:
             self._aggregate_effects_ols(treated_data, pretreatment_data)
@@ -1303,7 +1299,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     def _get_group_time_placebo_data(self) -> pd.DataFrame:
         """Return cohort-time placebo estimates for eventually-treated units."""
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             return self._get_group_time_placebo_data_bayesian()
         return self._get_group_time_placebo_data_ols()
 

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -275,7 +275,7 @@ class SyntheticControl(BaseExperiment):
     def algorithm(self) -> None:
         """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
         # fit the model to the observed (pre-intervention) data
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             COORDS = {
                 # key must stay as "coeffs" unless we can find a way to auto identify
                 # the predictor dimension name. "coeffs" is assumed by
@@ -284,30 +284,28 @@ class SyntheticControl(BaseExperiment):
                 "treated_units": self.treated_units,
                 "obs_ind": np.arange(self.datapre.shape[0]),
             }
-            self.model.fit(
+            self._model_backend.fit(
                 X=self.pre_design["control"],
                 y=self.pre_design["treated"],
                 coords=COORDS,
             )
-        elif isinstance(self.model, RegressorMixin):
-            self.model.fit(
+        else:
+            self._model_backend.fit(
                 X=self.pre_design["control"].data,
                 y=self.pre_design["treated"].isel(treated_units=0).data,
             )
-        else:
-            raise ValueError("Model type not recognized")
 
         # score the goodness of fit to the pre-intervention data
-        self.score = self.model.score(
+        self.score = self._model_backend.score(
             X=self.pre_design["control"],
             y=self.pre_design["treated"],
         )
 
         # get the model predictions of the observed (pre-intervention) data
-        self.pre_pred = self.model.predict(X=self.pre_design["control"])
+        self.pre_pred = self._model_backend.predict(X=self.pre_design["control"])
 
         # calculate the counterfactual
-        self.post_pred = self.model.predict(X=self.post_design["control"])
+        self.post_pred = self._model_backend.predict(X=self.post_design["control"])
         self.pre_impact = self.model.calculate_impact(
             self.pre_design["treated"], self.pre_pred
         )
@@ -359,7 +357,7 @@ class SyntheticControl(BaseExperiment):
             observed = (
                 self.pre_design["treated"].sel(treated_units=unit).values.flatten()
             )
-            if isinstance(self.model, PyMCModel):
+            if self._model_backend.is_bayesian:
                 predicted = (
                     self.pre_pred["posterior_predictive"]["mu"]
                     .sel(treated_units=unit)
@@ -795,7 +793,7 @@ class SyntheticControl(BaseExperiment):
             Which treated unit to extract data for. Must be a string name
             of the treated unit. If ``None``, uses the first treated unit.
         """
-        if not isinstance(self.model, PyMCModel):
+        if not self._model_backend.is_bayesian:
             raise ValueError("Unsupported model type")
 
         hdi_pct = int(round(hdi_prob * 100))
@@ -879,7 +877,7 @@ class SyntheticControl(BaseExperiment):
 
     def _get_score_title(self, treated_unit: str, round_to: int | None = 2) -> str:
         """Generate appropriate score title for the specified treated unit"""
-        if isinstance(self.model, PyMCModel):
+        if self._model_backend.is_bayesian:
             # Bayesian model - get unit-specific R² scores using unified format
             unit_index = self.treated_units.index(treated_unit)
             r2_val = round_num(
@@ -968,7 +966,7 @@ class SyntheticControl(BaseExperiment):
                 stacklevel=2,
             )
 
-        is_pymc = isinstance(self.model, PyMCModel)
+        is_pymc = self._model_backend.is_bayesian
 
         # Extract windowed impact data
         windowed_impact, window_coords = _extract_window(

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -247,7 +247,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         6. :meth:`_build_reporting_objects` constructs the xarray objects
            required by the reporting helpers.
         """
-        if isinstance(self.model, RegressorMixin):
+        if self._model_backend.is_ols:
             raise NotImplementedError(
                 "OLS estimation for SyntheticDifferenceInDifferences is not yet "
                 "implemented. Please use a PyMC model."
@@ -258,7 +258,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         T_pre = self.datapre.shape[0]
 
         X, y, coords = self._build_weight_fitter_inputs(Y_co, y_tr, T_pre)
-        self.model.fit(X=X, y=y, coords=coords)
+        self._model_backend.fit(X=X, y=y, coords=coords)
         if self.model.idata is None:
             raise AttributeError("Model fitting failed to produce idata")
 

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -690,7 +690,7 @@ def test_rd_unrecognized_model_type():
 
         pass
 
-    with pytest.raises(ValueError, match="Model type not recognized"):
+    with pytest.raises(ValueError, match="Unsupported model type"):
         cp.RegressionDiscontinuity(
             df,
             formula="y ~ 1 + x + treated + x:treated",

--- a/causalpy/tests/test_model_adapter.py
+++ b/causalpy/tests/test_model_adapter.py
@@ -1,0 +1,197 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for experiment backend model adapters."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+from sklearn.linear_model import LinearRegression
+
+from causalpy.experiments.model_adapter import (
+    PyMCModelAdapter,
+    SklearnModelAdapter,
+    make_model_adapter,
+)
+from causalpy.pymc_models import LinearRegression as PyMCLinearRegression
+from causalpy.skl_models import create_causalpy_compatible_class
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
+
+
+def test_make_model_adapter_default_pymc():
+    adapter = make_model_adapter(
+        None,
+        default_model_class=PyMCLinearRegression,
+        supports_bayes=True,
+        supports_ols=True,
+    )
+    assert isinstance(adapter, PyMCModelAdapter)
+    assert adapter.is_bayesian
+    assert not adapter.is_ols
+    assert adapter.kind == "pymc"
+
+
+def test_make_model_adapter_explicit_pymc():
+    model = PyMCLinearRegression()
+    adapter = make_model_adapter(
+        model,
+        default_model_class=PyMCLinearRegression,
+        supports_bayes=True,
+        supports_ols=True,
+    )
+    assert adapter.model is model
+    assert adapter.is_bayesian
+
+
+def test_make_model_adapter_sklearn_coercion_and_fit_intercept_warning():
+    model = LinearRegression(fit_intercept=True)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        adapter = make_model_adapter(
+            model,
+            default_model_class=PyMCLinearRegression,
+            supports_bayes=True,
+            supports_ols=True,
+        )
+
+    assert isinstance(adapter, SklearnModelAdapter)
+    assert model.fit_intercept is True
+    assert adapter.model.fit_intercept is False
+    assert adapter.is_ols
+    assert not adapter.is_bayesian
+    assert any("fit_intercept" in str(w.message) for w in caught)
+
+
+def test_make_model_adapter_bayes_not_supported():
+    with pytest.raises(ValueError, match="Bayesian models not supported"):
+        make_model_adapter(
+            PyMCLinearRegression(),
+            default_model_class=None,
+            supports_bayes=False,
+            supports_ols=True,
+        )
+
+
+def test_make_model_adapter_ols_not_supported():
+    with pytest.raises(ValueError, match="OLS models not supported"):
+        make_model_adapter(
+            LinearRegression(fit_intercept=False),
+            default_model_class=None,
+            supports_bayes=True,
+            supports_ols=False,
+        )
+
+
+def test_make_model_adapter_no_model_no_default_raises():
+    with pytest.raises(ValueError, match="model not set or passed"):
+        make_model_adapter(
+            None,
+            default_model_class=None,
+            supports_bayes=True,
+            supports_ols=True,
+        )
+
+
+def test_sklearn_adapter_idata_raises():
+    adapter = make_model_adapter(
+        LinearRegression(fit_intercept=False),
+        default_model_class=None,
+        supports_bayes=True,
+        supports_ols=True,
+    )
+    with pytest.raises(AttributeError, match="OLS models do not have idata"):
+        _ = adapter.idata
+
+
+def test_sklearn_adapter_fit_predict_score():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(scale=0.1, size=20)
+    adapter = SklearnModelAdapter(
+        create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    )
+    adapter.fit(X, y)
+    preds = adapter.predict(X)
+    score = adapter.score(X, y)
+    coeffs = adapter.coefficients()
+
+    assert preds.shape == (20,)
+    assert isinstance(score, float)
+    assert coeffs.shape == (2,)
+
+
+def test_pymc_adapter_fit_predict_score(mock_pymc_sample):
+    rng = np.random.default_rng(0)
+    import xarray as xr
+
+    X = xr.DataArray(
+        rng.normal(size=(10, 2)),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": np.arange(10), "coeffs": ["a", "b"]},
+    )
+    y = xr.DataArray(
+        rng.normal(size=(10, 1)),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(10), "treated_units": ["unit_0"]},
+    )
+    coords = {
+        "coeffs": ["a", "b"],
+        "obs_ind": np.arange(10),
+        "treated_units": ["unit_0"],
+    }
+    adapter = PyMCModelAdapter(PyMCLinearRegression(sample_kwargs=sample_kwargs))
+    adapter.fit(X, y, coords=coords)
+    assert adapter.idata is not None
+    preds = adapter.predict(X)
+    score = adapter.score(X, y)
+    coeffs = adapter.coefficients()
+
+    assert preds is not None
+    assert score is not None
+    assert np.squeeze(coeffs).shape == (2,)
+
+
+def test_panel_regression_requires_explicit_model():
+    """PanelRegression has no default model class."""
+    import pandas as pd
+
+    import causalpy as cp
+
+    df = pd.DataFrame({"unit": ["a"], "time": [0], "y": [1.0], "x1": [1.0]})
+    with pytest.raises(ValueError, match="model not set or passed"):
+        cp.PanelRegression(
+            df,
+            formula="y ~ x1",
+            unit_fe_variable="unit",
+            time_fe_variable="time",
+            model=None,
+        )
+
+
+def test_base_experiment_exposes_model_backend(did_data):
+    """Concrete experiments expose _model_backend after construction."""
+    import causalpy as cp
+
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(fit_intercept=False),
+    )
+    assert result._model_backend.is_ols
+    assert result.model is result._model_backend.model

--- a/causalpy/tests/test_piecewise_its.py
+++ b/causalpy/tests/test_piecewise_its.py
@@ -1329,7 +1329,7 @@ def test_piecewise_its_unrecognized_model_type():
     class FakeModel:
         pass
 
-    with pytest.raises(ValueError, match="Model type not recognized"):
+    with pytest.raises(ValueError, match="Unsupported model type"):
         cp.PiecewiseITS(
             df,
             formula="y ~ 1 + t + step(t, 50)",

--- a/causalpy/tests/test_sdid_helpers.py
+++ b/causalpy/tests/test_sdid_helpers.py
@@ -20,6 +20,7 @@ individual steps without paying the cost of a full MCMC run.
 """
 
 from types import SimpleNamespace
+from typing import Any, Protocol
 
 import arviz as az
 import numpy as np
@@ -33,13 +34,33 @@ from causalpy.experiments.synthetic_difference_in_differences import (
 )
 
 
+class _StubFittableModel(Protocol):
+    """Minimal model protocol for SDiD stub tests."""
+
+    idata: Any
+
+    def fit(self, X: Any, y: Any, *, coords: Any = None) -> Any: ...
+
+
+class _StubModelAdapter:
+    """Minimal adapter for SDiD unit-test stubs that bypass ``__init__``."""
+
+    def __init__(self, model: _StubFittableModel) -> None:
+        self.model = model
+        self.is_ols = False
+        self.is_bayesian = False
+
+    def fit(self, X: Any, y: Any, *, coords: Any | None = None) -> Any:
+        return self.model.fit(X=X, y=y, coords=coords)
+
+
 def _make_experiment_stub(
     *,
     control_units: list[str] | None = None,
     treated_units: list[str] | None = None,
     data: pd.DataFrame | None = None,
     treatment_time: int | None = None,
-    model: object | None = None,
+    model: _StubFittableModel | None = None,
 ) -> SyntheticDifferenceInDifferences:
     """Construct an SDiD instance without running ``__init__``/``algorithm``.
 
@@ -57,6 +78,7 @@ def _make_experiment_stub(
         stub.treatment_time = treatment_time
     if model is not None:
         stub.model = model
+        stub._model_backend = _StubModelAdapter(model)  # type: ignore[assignment]
     return stub
 
 

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -1695,7 +1695,7 @@ def test_staggered_did_unrecognized_model_type_fit():
         seed=42,
     )
 
-    with pytest.raises(ValueError, match="Model type not recognized"):
+    with pytest.raises(ValueError, match="Unsupported model type"):
         cp.StaggeredDifferenceInDifferences(
             df,
             formula="y ~ 1 + C(unit) + C(time)",


### PR DESCRIPTION
## Summary

- Introduce `causalpy/experiments/model_adapter.py` with `ModelAdapter`, `PyMCModelAdapter`, `SklearnModelAdapter`, and `make_model_adapter()` to own sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols` validation.
- Wire `BaseExperiment` and all formula/matrix experiment classes through private `self._model_backend`, replacing scattered `isinstance(self.model, PyMCModel | RegressorMixin)` checks while keeping public `self.model` unchanged.
- Update `ARCHITECTURE.md` backend-dispatch documentation; add `test_model_adapter.py` for adapter unit tests; gitignore local `coverage.xml` from patch-coverage runs.

This is Phase 1 of the experiment-layer refactor: a stable backend seam for follow-up work (`fit_design()` / COORDS helpers) without changing user-facing APIs or per-experiment y/coords semantics.

## Test plan

- [x] `prek run --all-files`
- [x] `make test-patch-cov` (1113 passed, 98% patch coverage)
- [x] `test_model_adapter.py` — coercion, validation, fit/predict/score
- [x] Existing integration tests (`test_sklearn_clone_fit_intercept`, OLS example suite) unchanged behavior


Made with [Cursor](https://cursor.com)