### PR TITLE
refactor: normalize sklearn fit inputs and collapse backend branches

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -25,20 +25,21 @@ CausalPy implements 10+ quasi-experimental causal inference methods over two sta
 
 Backend dispatch is centralized in `causalpy/experiments/model_adapter.py`. `BaseExperiment.__init__` calls `make_model_adapter()`, which handles sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class()`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols` validation. Each experiment stores `self._model_backend` (private) and keeps `self.model` as the public handle.
 
-Experiments branch on backend via the adapter rather than scattered `isinstance` checks:
+Standard regression experiments call `self._model_backend.fit(X, y, coords=build_coords(...))` unconditionally. `build_coords()` assembles the PyMC `coeffs` / `obs_ind` / `treated_units` dict; sklearn backends ignore `coords`. `SklearnModelAdapter` normalizes inputs before delegating to sklearn: xarray `DataArray` values become numpy arrays, and a single-column `treated_units` outcome is squeezed to 1D so call sites do not need per-experiment `.isel(treated_units=0)` branches.
 
 ```python
-if self._model_backend.is_bayesian:
-    # Bayesian path — xarray DataArrays, InferenceData, coords
-    self._model_backend.fit(X=X, y=y, coords=COORDS)
-elif self._model_backend.is_ols:
-    # OLS path — numpy arrays (y shape preserved per experiment)
-    self._model_backend.fit(X=X, y=y)
+from causalpy.experiments.model_adapter import build_coords
+
+self._model_backend.fit(
+    X=X,
+    y=y,
+    coords=build_coords(self.labels, X.shape[0]),
+)
 ```
 
-`PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` during adapter construction.
+Experiments with non-standard fit signatures bypass this path and call `self.model.fit(...)` directly with custom arguments: `InstrumentalVariable` (two-stage IV), `InversePropensityWeighting` (propensity `fit(X, t, coords)`), and `SyntheticDifferenceInDifferences` (dict-shaped weight-fitter inputs). Those models are not forced through `build_coords` or sklearn y-normalization.
 
-Every experiment declares `supports_ols` and `supports_bayes`; validation runs in `make_model_adapter()`. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model). Experiments with non-standard fit signatures (e.g. `InstrumentalVariable`, `InversePropensityWeighting`) call `self.model.fit(...)` directly with their custom arguments.
+`PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` during adapter construction. Every experiment declares `supports_ols` and `supports_bayes`; validation runs in `make_model_adapter()`. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model).
 
 ## Experiment Lifecycle
 

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -29,6 +29,7 @@ from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
 )
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (
@@ -150,15 +151,11 @@ class DifferenceInDifferences(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(X.shape[0]),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X, y=y, coords=COORDS)
-        else:
-            self._model_backend.fit(X=X, y=y)
+        self._model_backend.fit(
+            X=X,
+            y=y,
+            coords=build_coords(self.labels, X.shape[0]),
+        )
 
         # predicted outcome for control group
         self.x_pred_control = (

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -26,6 +26,7 @@ from sklearn.base import RegressorMixin
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -194,30 +195,20 @@ class InterruptedTimeSeries(BaseExperiment):
         post_X = self.post_design["X"]
         post_y = self.post_design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS: dict[str, Any] = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(pre_X.shape[0]),
-                "treated_units": ["unit_0"],
-                "datetime_index": self.datapre.index,
-            }
-            self._model_backend.fit(X=pre_X, y=pre_y, coords=COORDS)
-        else:
-            self._model_backend.fit(X=pre_X, y=pre_y.isel(treated_units=0))
+        self._model_backend.fit(
+            X=pre_X,
+            y=pre_y,
+            coords=build_coords(
+                self.labels,
+                pre_X.shape[0],
+                datetime_index=self.datapre.index,
+            ),
+        )
 
-        if self._model_backend.is_bayesian:
-            self.score = self._model_backend.score(X=pre_X, y=pre_y)
-        else:
-            self.score = self._model_backend.score(
-                X=pre_X, y=pre_y.isel(treated_units=0)
-            )
+        self.score = self._model_backend.score(X=pre_X, y=pre_y)
 
         self.pre_pred = self._model_backend.predict(X=pre_X)
-
-        if self._model_backend.is_bayesian:
-            self.post_pred = self._model_backend.predict(X=post_X, out_of_sample=True)
-        else:
-            self.post_pred = self._model_backend.predict(X=post_X)
+        self.post_pred = self._model_backend.predict(X=post_X, out_of_sample=True)
 
         if self._model_backend.is_bayesian:
             self.pre_impact = self.model.calculate_impact(pre_y, self.pre_pred)

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -70,8 +70,10 @@ def _sklearn_array(value: Any) -> np.ndarray:
 def _sklearn_y(y: Any) -> np.ndarray:
     """Coerce outcome arrays to sklearn's preferred 1D shape when possible.
 
-    ponytail: only collapses a single trailing treated-units column; multi-output
-    ``y`` with more than one column is passed through unchanged.
+    ponytail: collapses a single trailing treated-units column to 1D. Genuine
+    multi-output ``y`` (>1 column) is passed through unchanged; experiments whose
+    sklearn backend cannot fit multiple outcomes (e.g. synthetic control's
+    ``WeightedProportion``) must reject that case upstream at construction.
     """
     arr = _sklearn_array(y)
     if arr.ndim == 2 and arr.shape[1] == 1:

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -70,9 +70,9 @@ def _sklearn_array(value: Any) -> np.ndarray:
 def _sklearn_y(y: Any) -> np.ndarray:
     """Coerce outcome arrays to sklearn's preferred 1D shape when possible.
 
-    ponytail: collapses a single trailing treated-units column to 1D. Genuine
-    multi-output ``y`` (>1 column) is passed through unchanged; experiments whose
-    sklearn backend cannot fit multiple outcomes (e.g. synthetic control's
+    Collapses a single trailing treated-units column to 1D. Genuine multi-output
+    ``y`` (>1 column) is passed through unchanged; experiments whose sklearn
+    backend cannot fit multiple outcomes (e.g. synthetic control's
     ``WeightedProportion``) must reject that case upstream at construction.
     """
     arr = _sklearn_array(y)

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -22,12 +22,61 @@ from typing import Any, Literal
 
 import arviz as az
 import numpy as np
+import xarray as xr
 from sklearn.base import RegressorMixin, clone
 
 from causalpy.pymc_models import PyMCModel
 from causalpy.skl_models import create_causalpy_compatible_class
 
 BackendKind = Literal["pymc", "sklearn"]
+
+
+def build_coords(
+    coeffs: list[str] | tuple[str, ...],
+    n_obs: int,
+    *,
+    treated_units: tuple[str, ...] | list[str] = ("unit_0",),
+    **extra: Any,
+) -> dict[str, Any]:
+    """Build the standard PyMC coordinate dict for regression experiments.
+
+    Parameters
+    ----------
+    coeffs : list of str or tuple of str
+        Coefficient / predictor names for the ``coeffs`` coord.
+    n_obs : int
+        Number of observations; used to build ``obs_ind`` as ``np.arange(n_obs)``.
+    treated_units : list of str or tuple of str, default ``("unit_0",)``
+        Names for the treated-unit dimension of ``y``.
+    **extra
+        Additional coordinate entries merged into the result (e.g.
+        ``datetime_index`` for ITS).
+    """
+    return {
+        "coeffs": list(coeffs),
+        "obs_ind": np.arange(n_obs),
+        "treated_units": list(treated_units),
+        **extra,
+    }
+
+
+def _sklearn_array(value: Any) -> np.ndarray:
+    """Coerce xarray or array-like inputs to a numpy array for sklearn."""
+    if isinstance(value, xr.DataArray):
+        return np.asarray(value.data)
+    return np.asarray(value)
+
+
+def _sklearn_y(y: Any) -> np.ndarray:
+    """Coerce outcome arrays to sklearn's preferred 1D shape when possible.
+
+    ponytail: only collapses a single trailing treated-units column; multi-output
+    ``y`` with more than one column is passed through unchanged.
+    """
+    arr = _sklearn_array(y)
+    if arr.ndim == 2 and arr.shape[1] == 1:
+        return np.squeeze(arr, axis=1)
+    return arr
 
 
 class ModelAdapter(ABC):
@@ -279,7 +328,7 @@ class SklearnModelAdapter(ModelAdapter):
         coords : dict, optional
             Ignored for sklearn backends.
         """
-        return self._model.fit(X=X, y=y)
+        return self._model.fit(X=_sklearn_array(X), y=_sklearn_y(y))
 
     def predict(
         self,
@@ -299,7 +348,7 @@ class SklearnModelAdapter(ModelAdapter):
         **kwargs
             Additional keyword arguments forwarded to the underlying model.
         """
-        return self._model.predict(X=X, **kwargs)
+        return self._model.predict(X=_sklearn_array(X), **kwargs)
 
     def score(self, X: Any, y: Any, **kwargs: Any) -> Any:
         """Score predictions from the sklearn model.
@@ -313,7 +362,7 @@ class SklearnModelAdapter(ModelAdapter):
         **kwargs
             Additional keyword arguments forwarded to the underlying model.
         """
-        return self._model.score(X=X, y=y, **kwargs)
+        return self._model.score(X=_sklearn_array(X), y=_sklearn_y(y), **kwargs)
 
     def coefficients(self) -> np.ndarray:
         """Return fitted sklearn coefficients."""

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -26,6 +26,7 @@ from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import round_num
@@ -295,15 +296,11 @@ class PanelRegression(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(X.shape[0]),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X, y=y, coords=COORDS)
-        else:
-            self._model_backend.fit(X=X, y=y)
+        self._model_backend.fit(
+            X=X,
+            y=y,
+            coords=build_coords(self.labels, X.shape[0]),
+        )
 
     def _demean_transform(self, data: pd.DataFrame, group_var: str) -> pd.DataFrame:
         """Apply demeaned transformation (demean by group).

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -26,6 +26,7 @@ from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -200,22 +201,14 @@ class PiecewiseITS(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS: dict[str, Any] = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(X.shape[0]),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X, y=y, coords=COORDS)
-        else:
-            self._model_backend.fit(X=X, y=y.isel(treated_units=0))
+        self._model_backend.fit(
+            X=X,
+            y=y,
+            coords=build_coords(self.labels, X.shape[0]),
+        )
 
         self.y_pred = self._model_backend.predict(X=X)
-
-        if self._model_backend.is_bayesian:
-            self.score = self._model_backend.score(X=X, y=y)
-        else:
-            self.score = self._model_backend.score(X=X, y=y.isel(treated_units=0))
+        self.score = self._model_backend.score(X=X, y=y)
 
         # Compute counterfactual and effects
         self._compute_counterfactual_and_effects()

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -27,6 +27,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
 )
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import plot_xY
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
@@ -139,17 +140,16 @@ class PrePostNEGD(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(X.shape[0]),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X, y=y, coords=COORDS)
-        elif self._model_backend.is_ols:
+        if self._model_backend.is_ols:
             raise NotImplementedError("Not implemented for OLS model")
-        else:
+        if not self._model_backend.is_bayesian:
             raise ValueError("Model type not recognized")
+
+        self._model_backend.fit(
+            X=X,
+            y=y,
+            coords=build_coords(self.labels, X.shape[0]),
+        )
 
         assert self.model.idata is not None
         # Calculate the posterior predictive for the treatment and control for an

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -22,6 +22,7 @@ import seaborn as sns
 from matplotlib import pyplot as plt
 from patsy import build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
     DataException,
     FormulaException,
@@ -177,17 +178,13 @@ class RegressionDiscontinuity(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        if self._model_backend.is_bayesian:
-            COORDS = {
-                "coeffs": self.labels,
-                "obs_ind": np.arange(X.shape[0]),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X, y=y, coords=COORDS)
-        else:
-            self._model_backend.fit(X=X, y=y)
+        self._model_backend.fit(
+            X=X,
+            y=y,
+            coords=build_coords(self.labels, X.shape[0]),
+        )
 
-        self.score = self.model.score(X=X, y=y)
+        self.score = self._model_backend.score(X=X, y=y)
 
         # get the model predictions of the observed data
         if self.bandwidth is not np.inf:
@@ -204,7 +201,7 @@ class RegressionDiscontinuity(BaseExperiment):
             {self.running_variable_name: xi, "treated": self._is_treated(xi)}
         )
         (new_x,) = build_design_matrices([self._x_design_info], self.x_pred)
-        self.pred = self.model.predict(X=np.asarray(new_x))
+        self.pred = self._model_backend.predict(X=np.asarray(new_x))
 
         # calculate discontinuity by evaluating the difference in model expectation on
         # either side of the discontinuity

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -23,6 +23,7 @@ import pandas as pd
 import seaborn as sns
 from patsy import build_design_matrices, dmatrices
 import xarray as xr
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import plot_xY
 
 from causalpy.pymc_models import LinearRegression, PyMCModel
@@ -130,11 +131,7 @@ class RegressionKink(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
-        COORDS = {
-            "coeffs": self.labels,
-            "obs_ind": np.arange(X.shape[0]),
-            "treated_units": ["unit_0"],
-        }
+        COORDS = build_coords(self.labels, X.shape[0])
         self._model_backend.fit(X=X, y=y, coords=COORDS)
 
         self.score = self._model_backend.score(X=X, y=y)

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -30,6 +30,7 @@ from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 
@@ -443,48 +444,40 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     def _fit_model(self) -> None:
         """Fit the model on untreated observations only."""
-        # Convert to xarray for PyMC models
         n_train = self.X_train.shape[0]
-
-        if self._model_backend.is_bayesian:
-            X_train_xr = xr.DataArray(
-                self.X_train,
-                dims=["obs_ind", "coeffs"],
-                coords={
-                    "obs_ind": np.arange(n_train),
-                    "coeffs": self.labels,
-                },
-            )
-            y_train_xr = xr.DataArray(
-                self.y_train,
-                dims=["obs_ind", "treated_units"],
-                coords={"obs_ind": np.arange(n_train), "treated_units": ["unit_0"]},
-            )
-            COORDS = {
-                "coeffs": self.labels,
+        X_train_xr = xr.DataArray(
+            self.X_train,
+            dims=["obs_ind", "coeffs"],
+            coords={
                 "obs_ind": np.arange(n_train),
-                "treated_units": ["unit_0"],
-            }
-            self._model_backend.fit(X=X_train_xr, y=y_train_xr, coords=COORDS)
-        else:
-            self._model_backend.fit(X=self.X_train, y=self.y_train)
+                "coeffs": self.labels,
+            },
+        )
+        y_train_xr = xr.DataArray(
+            self.y_train,
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": np.arange(n_train), "treated_units": ["unit_0"]},
+        )
+        self._model_backend.fit(
+            X=X_train_xr,
+            y=y_train_xr,
+            coords=build_coords(self.labels, n_train),
+        )
 
     def _predict_counterfactuals(self) -> None:
         """Predict counterfactual outcomes for all observations."""
         n_full = self.X_full.shape[0]
+        X_full_xr = xr.DataArray(
+            self.X_full,
+            dims=["obs_ind", "coeffs"],
+            coords={
+                "obs_ind": np.arange(n_full),
+                "coeffs": self.labels,
+            },
+        )
+        self.y_pred = self._model_backend.predict(X=X_full_xr)
 
         if self._model_backend.is_bayesian:
-            X_full_xr = xr.DataArray(
-                self.X_full,
-                dims=["obs_ind", "coeffs"],
-                coords={
-                    "obs_ind": np.arange(n_full),
-                    "coeffs": self.labels,
-                },
-            )
-            self.y_pred = self._model_backend.predict(X=X_full_xr)
-
-            # Extract posterior mean for y_hat0
             y_hat0_mean = (
                 self.y_pred["posterior_predictive"]
                 .mu.mean(dim=["chain", "draw"])
@@ -493,7 +486,6 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             )
             self.data["y_hat0"] = y_hat0_mean
         else:
-            self.y_pred = self._model_backend.predict(self.X_full)
             self.data["y_hat0"] = np.squeeze(self.y_pred)
 
     def _compute_treatment_effects(self) -> None:

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -26,6 +26,7 @@ from sklearn.base import RegressorMixin
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import get_hdi_to_df, plot_xY
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
@@ -275,25 +276,15 @@ class SyntheticControl(BaseExperiment):
     def algorithm(self) -> None:
         """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
         # fit the model to the observed (pre-intervention) data
-        if self._model_backend.is_bayesian:
-            COORDS = {
-                # key must stay as "coeffs" unless we can find a way to auto identify
-                # the predictor dimension name. "coeffs" is assumed by
-                # PyMCModel.print_coefficients for example.
-                "coeffs": self.control_units,
-                "treated_units": self.treated_units,
-                "obs_ind": np.arange(self.datapre.shape[0]),
-            }
-            self._model_backend.fit(
-                X=self.pre_design["control"],
-                y=self.pre_design["treated"],
-                coords=COORDS,
-            )
-        else:
-            self._model_backend.fit(
-                X=self.pre_design["control"].data,
-                y=self.pre_design["treated"].isel(treated_units=0).data,
-            )
+        self._model_backend.fit(
+            X=self.pre_design["control"],
+            y=self.pre_design["treated"],
+            coords=build_coords(
+                self.control_units,
+                self.datapre.shape[0],
+                treated_units=self.treated_units,
+            ),
+        )
 
         # score the goodness of fit to the pre-intervention data
         self.score = self._model_backend.score(

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -116,6 +116,13 @@ class SyntheticControl(BaseExperiment):
         self.control_units = control_units
         self.labels = control_units
         self.treated_units = treated_units
+        if self._model_backend.is_ols and len(treated_units) > 1:
+            raise ValueError(
+                "OLS/sklearn synthetic control supports only a single treated "
+                f"unit, but {len(treated_units)} were given: {treated_units}. "
+                "Use a PyMC model (e.g. WeightedSumFitter) for multiple treated "
+                "units, or run a separate experiment per treated unit."
+            )
         if not (-1 <= min_donor_correlation <= 1):
             raise ValueError(
                 f"min_donor_correlation must be between -1 and 1, "

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -298,6 +298,18 @@ def test_sc_input_error(sc_data):
         )
 
 
+def test_sc_ols_multiple_treated_units_error(sc_data):
+    """OLS/sklearn synthetic control supports only a single treated unit."""
+    with pytest.raises(ValueError, match="single treated"):
+        _ = cp.SyntheticControl(
+            sc_data,
+            70,
+            control_units=["a", "b", "c", "d", "e"],
+            treated_units=["actual", "f"],
+            model=cp.skl_models.WeightedProportion(),
+        )
+
+
 def test_sc_brexit_input_error():
     """Confirm a BadIndexException is raised if the data index is datetime and the
     treatment time is not pd.Timestamp."""

--- a/causalpy/tests/test_model_adapter_normalization.py
+++ b/causalpy/tests/test_model_adapter_normalization.py
@@ -1,0 +1,108 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for sklearn input normalization and build_coords."""
+
+from __future__ import annotations
+
+import numpy as np
+import xarray as xr
+from sklearn.linear_model import LinearRegression
+
+from causalpy.experiments.model_adapter import (
+    SklearnModelAdapter,
+    build_coords,
+)
+from causalpy.skl_models import create_causalpy_compatible_class
+
+
+def test_build_coords_defaults():
+    coords = build_coords(["a", "b"], 5)
+    assert coords["coeffs"] == ["a", "b"]
+    assert list(coords["obs_ind"]) == [0, 1, 2, 3, 4]
+    assert coords["treated_units"] == ["unit_0"]
+
+
+def test_build_coords_extra_and_treated_units():
+    coords = build_coords(
+        ["x"],
+        3,
+        treated_units=["u1", "u2"],
+        datetime_index=[1, 2, 3],
+    )
+    assert coords["treated_units"] == ["u1", "u2"]
+    assert coords["datetime_index"] == [1, 2, 3]
+
+
+def test_sklearn_adapter_2d_y_matches_1d_slice():
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(20, 2))
+    y_1d = X @ np.array([1.0, -0.5]) + rng.normal(scale=0.1, size=20)
+    y_2d = y_1d.reshape(-1, 1)
+
+    model = create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    adapter_1d = SklearnModelAdapter(model)
+    adapter_2d = SklearnModelAdapter(
+        create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    )
+
+    adapter_1d.fit(X, y_1d)
+    adapter_2d.fit(X, y_2d)
+
+    assert np.allclose(adapter_1d.coefficients(), adapter_2d.coefficients())
+    assert adapter_1d.score(X, y_1d) == adapter_2d.score(X, y_2d)
+    assert np.allclose(adapter_1d.predict(X), adapter_2d.predict(X))
+
+
+def test_sklearn_adapter_xarray_inputs_match_numpy():
+    rng = np.random.default_rng(1)
+    X_np = rng.normal(size=(15, 2))
+    y_np = X_np @ np.array([0.5, 1.0]) + rng.normal(scale=0.1, size=15)
+
+    X_xr = xr.DataArray(
+        X_np,
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": np.arange(15), "coeffs": ["a", "b"]},
+    )
+    y_xr = xr.DataArray(
+        y_np.reshape(-1, 1),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(15), "treated_units": ["unit_0"]},
+    )
+
+    adapter_np = SklearnModelAdapter(
+        create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    )
+    adapter_xr = SklearnModelAdapter(
+        create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    )
+
+    adapter_np.fit(X_np, y_np)
+    adapter_xr.fit(X_xr, y_xr)
+
+    assert np.allclose(adapter_np.coefficients(), adapter_xr.coefficients())
+    assert adapter_np.score(X_np, y_np) == adapter_xr.score(X_xr, y_xr)
+    assert np.allclose(adapter_np.predict(X_np), adapter_xr.predict(X_xr))
+
+
+def test_sklearn_adapter_predict_ignores_out_of_sample():
+    rng = np.random.default_rng(2)
+    X = rng.normal(size=(10, 1))
+    y = rng.normal(size=10)
+    adapter = SklearnModelAdapter(
+        create_causalpy_compatible_class(LinearRegression(fit_intercept=False))
+    )
+    adapter.fit(X, y)
+    preds_default = adapter.predict(X)
+    preds_oos = adapter.predict(X, out_of_sample=True)
+    assert np.allclose(preds_default, preds_oos)


### PR DESCRIPTION
## Headline: backend branching leaves `algorithm()`

#961 gave every experiment `_model_backend` instead of scattering `isinstance(self.model, PyMCModel)` checks. **This PR removes the next layer of duplication**: the `if self._model_backend.is_bayesian: … else: …` blocks that still lived inside `algorithm()` for fit, score, and predict.

**12 backend-type branches deleted** across nine experiment modules. Standard regression lifecycle code now reads the same for Bayes and OLS:

```python
self._model_backend.fit(X=X, y=y, coords=build_coords(self.labels, X.shape[0]))
self._model_backend.score(X=X, y=y)
self._model_backend.predict(X=post_X, out_of_sample=True)  # sklearn ignores out_of_sample
```

Backend differences moved to **one place** (`SklearnModelAdapter` in `model_adapter.py`), not copy-pasted into DiD, ITS, SC, etc.

### Before → after (typical experiment)

```python
# before — every new formula experiment had to remember this
if self._model_backend.is_bayesian:
    COORDS = {"coeffs": self.labels, "obs_ind": np.arange(X.shape[0]), "treated_units": ["unit_0"]}
    self._model_backend.fit(X=X, y=y, coords=COORDS)
else:
    self._model_backend.fit(X=X, y=y.isel(treated_units=0))  # or .data, or plain y — per class

# after
self._model_backend.fit(X=X, y=y, coords=build_coords(self.labels, X.shape[0]))
```

Remaining `is_bayesian` checks in experiment files are for **post-fit semantics** (posterior extraction, `calculate_impact` y-shape, plot paths) — not for the fit/score/predict plumbing.

## What changed

- **`SklearnModelAdapter` normalization** — xarray → numpy; single-column `treated_units` `y` squeezed to 1D (replaces per-class `.isel` / `.data`)
- **`build_coords()`** — shared PyMC coord dict; sklearn ignores it
- **Nine experiments updated**: DiD, RD, Panel, Staggered DiD, ITS, PiecewiseITS, PrePostNEGD, RK, SyntheticControl
- **RD** — main `score`/`predict` through adapter (`pred_discon` still on `self.model`; follow-up)
- **Unchanged**: IV, IPW, SDiD (custom `fit` signatures)

## Why #961 had to land first

Without `_model_backend`, collapsing branches would just relocate `isinstance` checks. #961 made the adapter the single dispatch point; this PR pushes **all fit-path backend conventions into the adapter** so experiment classes stay focused on causal logic.

## Test plan

- [x] `test_model_adapter_normalization.py` — 2D↔1D y equivalence, xarray inputs, `build_coords`
- [x] `make test-patch-cov` (1118 passed, 100% patch coverage on changed lines)
- [x] `prek` on changed files