### PR TITLE
Rename internal plot_xY to plot_posterior_over_x

### DIFF
--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -40,7 +40,7 @@ def _apply_legend_kwargs(legend: Any, kwargs: dict[str, Any]) -> None:
     """Mutate an existing Legend in place without recreating it.
 
     This preserves custom handles (e.g. ``(Line2D, PolyCollection)`` tuples
-    built by :func:`~causalpy.plot_utils.plot_xY`) that would be lost if the
+    built by :func:`~causalpy.plot_utils.plot_posterior_over_x`) that would be lost if the
     legend were rebuilt with ``ax.legend()``.
 
     Supported keys: ``loc``, ``bbox_to_anchor``, ``bbox_transform`` (only
@@ -331,7 +331,7 @@ class BaseExperiment(ABC):
             Keyword arguments to adjust legend placement and styling. The
             existing legend is modified **in place** so that custom
             handles (e.g. ``(Line2D, PolyCollection)`` tuples built by
-            :func:`~causalpy.plot_utils.plot_xY`) are preserved.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`) are preserved.
             Supported keys: ``loc``, ``bbox_to_anchor``, ``fontsize``,
             ``frameon``, ``title``. ``bbox_transform`` is accepted
             alongside ``bbox_to_anchor``.
@@ -339,16 +339,16 @@ class BaseExperiment(ABC):
             Subclass-specific drawing parameters forwarded verbatim to
             ``_bayesian_plot`` / ``_ols_plot``. May include ``kind``,
             ``ci_kind``, ``ci_prob``, and ``num_samples`` for
-            :func:`~causalpy.plot_utils.plot_xY`.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`.
 
         Notes
         -----
-        **Legend handling and ``plot_xY`` return types:** :func:`~causalpy.plot_utils.plot_xY`
+        **Legend handling and ``plot_posterior_over_x`` return types:** :func:`~causalpy.plot_utils.plot_posterior_over_x`
         returns ``(Line2D, PolyCollection)`` for ``kind="ribbon"`` but
         ``(list[Line2D], None)`` for ``kind="histogram"`` or ``"spaghetti"``.
         Subclass ``_bayesian_plot`` / ``_ols_plot`` implementations that assemble
         matplotlib legends from those return values should only pack
-        ``(line, patch)`` tuples when calling ``plot_xY`` with ``kind="ribbon"``
+        ``(line, patch)`` tuples when calling ``plot_posterior_over_x`` with ``kind="ribbon"``
         (the default). Many current experiment plots always use the ribbon
         default and never forward ``kind``; if a subclass forwards non-ribbon
         kinds, it must build legend handles accordingly. The base class applies
@@ -375,7 +375,7 @@ class BaseExperiment(ABC):
 
         # Apply legend customization if requested.  We mutate the existing
         # Legend object in place so that custom handles — especially the
-        # (Line2D, PolyCollection) tuples built by plot_xY — are preserved
+        # (Line2D, PolyCollection) tuples built by plot_posterior_over_x — are preserved
         # exactly as the subclass created them.
         if legend_kwargs is not None:
             # Normalise ax to a flat list so we can iterate uniformly.

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -40,8 +40,9 @@ def _apply_legend_kwargs(legend: Any, kwargs: dict[str, Any]) -> None:
     """Mutate an existing Legend in place without recreating it.
 
     This preserves custom handles (e.g. ``(Line2D, PolyCollection)`` tuples
-    built by :func:`~causalpy.plot_utils.plot_posterior_over_x`) that would be lost if the
-    legend were rebuilt with ``ax.legend()``.
+    built by :func:`~causalpy.plot_utils.plot_posterior_over_x` with
+    ``kind="ribbon"``) that would be lost if the legend were rebuilt with
+    ``ax.legend()``.
 
     Supported keys: ``loc``, ``bbox_to_anchor``, ``bbox_transform`` (only
     with ``bbox_to_anchor``), ``fontsize``, ``frameon``, ``title``.
@@ -331,7 +332,8 @@ class BaseExperiment(ABC):
             Keyword arguments to adjust legend placement and styling. The
             existing legend is modified **in place** so that custom
             handles (e.g. ``(Line2D, PolyCollection)`` tuples built by
-            :func:`~causalpy.plot_utils.plot_posterior_over_x`) are preserved.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x` with
+            ``kind="ribbon"``) are preserved.
             Supported keys: ``loc``, ``bbox_to_anchor``, ``fontsize``,
             ``frameon``, ``title``. ``bbox_transform`` is accepted
             alongside ``bbox_to_anchor``.
@@ -375,7 +377,8 @@ class BaseExperiment(ABC):
 
         # Apply legend customization if requested.  We mutate the existing
         # Legend object in place so that custom handles — especially the
-        # (Line2D, PolyCollection) tuples built by plot_posterior_over_x — are preserved
+        # (Line2D, PolyCollection) tuples built by plot_posterior_over_x with
+        # kind="ribbon" — are preserved
         # exactly as the subclass created them.
         if legend_kwargs is not None:
             # Normalise ax to a flat list so we can iterate uniformly.

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -359,8 +359,9 @@ class DifferenceInDifferences(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -31,7 +31,7 @@ from causalpy.custom_exceptions import (
     FormulaException,
 )
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (
     EffectSummary,
@@ -358,7 +358,7 @@ class DifferenceInDifferences(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -435,7 +435,7 @@ class DifferenceInDifferences(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``None``
             (use matplotlib's default).
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -510,7 +510,7 @@ class DifferenceInDifferences(BaseExperiment):
 
         # Plot model fit to control group
         time_points = self.x_pred_control[self.time_variable_name].values
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             time_points,
             self.y_pred_control["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
@@ -523,7 +523,7 @@ class DifferenceInDifferences(BaseExperiment):
 
         # Plot model fit to treatment group
         time_points = self.x_pred_control[self.time_variable_name].values
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             time_points,
             self.y_pred_treatment["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,
@@ -562,7 +562,7 @@ class DifferenceInDifferences(BaseExperiment):
                 pc.set_edgecolor("None")
                 pc.set_alpha(0.5)
         else:
-            h_line, h_patch = plot_xY(
+            h_line, h_patch = plot_posterior_over_x(
                 time_points,
                 self.y_pred_counterfactual.posterior_predictive.mu.isel(
                     treated_units=0

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -620,8 +620,9 @@ class InterruptedTimeSeries(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.
@@ -680,12 +681,13 @@ class InterruptedTimeSeries(BaseExperiment):
     ) -> Any:
         """Overlay a median dot + HDI errorbar for a single post-period datum.
 
-        ``plot_posterior_over_x`` (and the ``arviz.plot_hdi`` it wraps) renders a degenerate
-        zero-area polygon when the post-period contains a single observation,
-        so neither the median line nor the HDI ribbon is visible. Drawing an
-        explicit point and errorbar makes both the central tendency and the
-        uncertainty plain to read in that edge case. Returns the matplotlib
-        ``ErrorbarContainer`` so callers can use it as a legend handle.
+        When ``plot_posterior_over_x`` is called with ``kind="ribbon"`` and
+        HDI intervals, ``arviz.plot_hdi`` renders a degenerate zero-area polygon
+        when the post-period contains a single observation, so neither the median
+        line nor the HDI ribbon is visible. Drawing an explicit point and errorbar
+        makes both the central tendency and the uncertainty plain to read in that
+        edge case. Returns the matplotlib ``ErrorbarContainer`` so callers can use
+        it as a legend handle.
         """
         Y_plot = Y.isel(treated_units=0) if "treated_units" in Y.dims else Y
         median = float(np.asarray(Y_plot.median(("chain", "draw")).values).item())

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -29,9 +29,9 @@ from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
-    _PlotXYStyle,
+    _PosteriorPlotStyle,
     get_hdi_to_df,
-    plot_xY,
+    plot_posterior_over_x,
 )
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -619,7 +619,7 @@ class InterruptedTimeSeries(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -680,7 +680,7 @@ class InterruptedTimeSeries(BaseExperiment):
     ) -> Any:
         """Overlay a median dot + HDI errorbar for a single post-period datum.
 
-        ``plot_xY`` (and the ``arviz.plot_hdi`` it wraps) renders a degenerate
+        ``plot_posterior_over_x`` (and the ``arviz.plot_hdi`` it wraps) renders a degenerate
         zero-area polygon when the post-period contains a single observation,
         so neither the median line nor the HDI ribbon is visible. Drawing an
         explicit point and errorbar makes both the central tendency and the
@@ -732,7 +732,7 @@ class InterruptedTimeSeries(BaseExperiment):
         """
         counterfactual_label = "Counterfactual"
         single_post_obs = len(self.datapost) <= 1
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -746,7 +746,7 @@ class InterruptedTimeSeries(BaseExperiment):
         pre_mu_plot = (
             pre_mu.isel(treated_units=0) if "treated_units" in pre_mu.dims else pre_mu
         )
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapre.index,
             pre_mu_plot,
             ax=ax[0],
@@ -772,7 +772,7 @@ class InterruptedTimeSeries(BaseExperiment):
             if "treated_units" in post_mu.dims
             else post_mu
         )
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapost.index,
             post_mu_plot,
             ax=ax[0],
@@ -780,7 +780,7 @@ class InterruptedTimeSeries(BaseExperiment):
             plot_hdi_kwargs={"color": "C1"},
         )
         if single_post_obs:
-            # plot_xY's HDI ribbon collapses to a zero-area polygon for a
+            # plot_posterior_over_x's HDI ribbon collapses to a zero-area polygon for a
             # single post-period datum; overlay an explicit median + HDI
             # errorbar so the counterfactual is still visible. Use the
             # errorbar artist itself as the legend handle so the legend
@@ -846,7 +846,7 @@ class InterruptedTimeSeries(BaseExperiment):
             and "treated_units" in self.pre_impact.dims
             else self.pre_impact
         )
-        plot_xY(
+        plot_posterior_over_x(
             self.datapre.index,
             pre_impact_plot,
             ax=ax[1],
@@ -859,7 +859,7 @@ class InterruptedTimeSeries(BaseExperiment):
             and "treated_units" in self.post_impact.dims
             else self.post_impact
         )
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             post_impact_plot,
             ax=ax[1],
@@ -898,7 +898,7 @@ class InterruptedTimeSeries(BaseExperiment):
             and "treated_units" in self.post_impact_cumulative.dims
             else self.post_impact_cumulative
         )
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             post_cum_plot,
             ax=ax[2],

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -452,8 +452,9 @@ class PiecewiseITS(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -28,7 +28,7 @@ from sklearn.base import RegressorMixin
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
@@ -451,7 +451,7 @@ class PiecewiseITS(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -532,7 +532,7 @@ class PiecewiseITS(BaseExperiment):
         ax : list[plt.Axes]
             List of axes objects.
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -555,7 +555,7 @@ class PiecewiseITS(BaseExperiment):
         y_pred_mu = self.y_pred["posterior_predictive"]["mu"]
         if "treated_units" in y_pred_mu.dims:
             y_pred_mu = y_pred_mu.isel(treated_units=0)
-        h_line_fit, h_patch_fit = plot_xY(
+        h_line_fit, h_patch_fit = plot_posterior_over_x(
             time_values,
             y_pred_mu,
             ax=ax[0],
@@ -567,7 +567,7 @@ class PiecewiseITS(BaseExperiment):
         y_cf_mu = self.y_counterfactual["posterior_predictive"]["mu"]
         if "treated_units" in y_cf_mu.dims:
             y_cf_mu = y_cf_mu.isel(treated_units=0)
-        h_line_cf, h_patch_cf = plot_xY(
+        h_line_cf, h_patch_cf = plot_posterior_over_x(
             time_values,
             y_cf_mu,
             ax=ax[0],
@@ -595,7 +595,7 @@ class PiecewiseITS(BaseExperiment):
         labels_legend = ["Observations", "Fitted", "Counterfactual"]
 
         # MIDDLE PLOT: Causal Effect
-        plot_xY(
+        plot_posterior_over_x(
             time_values,
             self.effect,
             ax=ax[1],
@@ -612,7 +612,7 @@ class PiecewiseITS(BaseExperiment):
         ax[1].set(title="Causal Effect", ylabel="Effect")
 
         # BOTTOM PLOT: Cumulative Effect
-        plot_xY(
+        plot_posterior_over_x(
             time_values,
             self.cumulative_effect,
             ax=ax[2],

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -269,8 +269,9 @@ class PrePostNEGD(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -29,7 +29,7 @@ from causalpy.custom_exceptions import (
     DataException,
 )
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
 from causalpy.utils import _is_variable_dummy_coded, round_num
@@ -268,7 +268,7 @@ class PrePostNEGD(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -343,7 +343,7 @@ class PrePostNEGD(BaseExperiment):
         figsize : tuple of (float, float), optional
             Width and height of the figure in inches. Defaults to ``(7, 9)``.
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -366,7 +366,7 @@ class PrePostNEGD(BaseExperiment):
         ax[0].set(xlabel="Pretest", ylabel="Posttest")
 
         # plot posterior predictive of untreated
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.pred_xi,
             self.pred_untreated["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax[0],
@@ -378,7 +378,7 @@ class PrePostNEGD(BaseExperiment):
         labels = ["Control group"]
 
         # plot posterior predictive of treated
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.pred_xi,
             self.pred_treated["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax[0],

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -326,8 +326,9 @@ class RegressionDiscontinuity(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -28,7 +28,7 @@ from causalpy.custom_exceptions import (
     FormulaException,
 )
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rd
 from causalpy.utils import (
@@ -325,7 +325,7 @@ class RegressionDiscontinuity(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -401,7 +401,7 @@ class RegressionDiscontinuity(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``None``
             (use matplotlib's default).
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -430,7 +430,7 @@ class RegressionDiscontinuity(BaseExperiment):
         )
 
         # Plot model fit to data
-        plot_xY(
+        plot_posterior_over_x(
             self.x_pred[self.running_variable_name],
             self.pred["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -277,8 +277,9 @@ class RegressionKink(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -24,7 +24,7 @@ import seaborn as sns
 from patsy import build_design_matrices, dmatrices
 import xarray as xr
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rkink
@@ -276,7 +276,7 @@ class RegressionKink(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -352,7 +352,7 @@ class RegressionKink(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``None``
             (use matplotlib's default).
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -369,7 +369,7 @@ class RegressionKink(BaseExperiment):
         )
 
         # Plot model fit to data
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.x_pred[self.running_variable_name],
             self.pred["posterior_predictive"].mu.isel(treated_units=0),
             ax=ax,

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -440,8 +440,9 @@ class SyntheticControl(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -28,9 +28,9 @@ from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
-    _PlotXYStyle,
+    _PosteriorPlotStyle,
     get_hdi_to_df,
-    plot_xY,
+    plot_posterior_over_x,
 )
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
@@ -439,7 +439,7 @@ class SyntheticControl(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -529,7 +529,7 @@ class SyntheticControl(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``(7, 8)``.
         """
         counterfactual_label = "Counterfactual"
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -557,7 +557,7 @@ class SyntheticControl(BaseExperiment):
             treated_units=treated_unit
         )
 
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapre.index,
             pre_pred,
             ax=ax[0],
@@ -578,7 +578,7 @@ class SyntheticControl(BaseExperiment):
         labels.append("Observations")
 
         # post intervention period
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapost.index,
             post_pred,
             ax=ax[0],
@@ -608,14 +608,14 @@ class SyntheticControl(BaseExperiment):
         ax[0].set(title=f"{self._get_score_title(treated_unit, round_to)}")
 
         # MIDDLE PLOT -----------------------------------------------
-        plot_xY(
+        plot_posterior_over_x(
             self.datapre.index,
             self.pre_impact.sel(treated_units=treated_unit),
             ax=ax[1],
             **style,
             plot_hdi_kwargs={"color": "C0"},
         )
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             self.post_impact.sel(treated_units=treated_unit),
             ax=ax[1],
@@ -634,7 +634,7 @@ class SyntheticControl(BaseExperiment):
 
         # BOTTOM PLOT -----------------------------------------------
         ax[2].set(title="Cumulative Causal Impact")
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             self.post_impact_cumulative.sel(treated_units=treated_unit),
             ax=ax[2],

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -622,8 +622,9 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
-            For ``"spaghetti"`` and ``"histogram"``, the legend shows
-            individual sample lines rather than a shaded band.
+            For ``"spaghetti"``, legends use draw lines rather than a shaded
+            band. For ``"histogram"``, uncertainty is shown as a 2D density
+            heatmap with a mean line overlay (no ribbon patch for legends).
         ci_kind : {"hdi", "eti"}, optional
             Credible interval type when ``kind="ribbon"``. Defaults to
             ``"hdi"``.

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -28,7 +28,7 @@ from sklearn.base import RegressorMixin
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
-from causalpy.plot_utils import _PlotXYStyle, plot_xY
+from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import PyMCModel, SyntheticDifferenceInDifferencesWeightFitter
 from causalpy.reporting import EffectSummary
 
@@ -621,7 +621,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
-            :func:`~causalpy.plot_utils.plot_xY`. Defaults to ``"ribbon"``.
+            :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
             For ``"spaghetti"`` and ``"histogram"``, the legend shows
             individual sample lines rather than a shaded band.
         ci_kind : {"hdi", "eti"}, optional
@@ -708,7 +708,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         ax : list of matplotlib.axes.Axes
             The three axes (counterfactual, impact, cumulative impact).
         """
-        style: _PlotXYStyle = {
+        style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
@@ -727,7 +727,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         )
 
         # Pre-intervention synthetic control fit
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapre.index,
             pre_pred,
             ax=ax[0],
@@ -748,7 +748,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         labels.append("Observations")
 
         # Post-intervention counterfactual
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             self.datapost.index,
             post_pred,
             ax=ax[0],
@@ -781,14 +781,14 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         ax[0].set(title=f"SDiD: ATT = {round(tau_mean, r_to)}")
 
         # ---- MIDDLE PLOT: Impact ----
-        plot_xY(
+        plot_posterior_over_x(
             self.datapre.index,
             self.pre_impact.sel(treated_units=treated_unit),
             ax=ax[1],
             **style,
             plot_hdi_kwargs={"color": "C0"},
         )
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             self.post_impact.sel(treated_units=treated_unit),
             ax=ax[1],
@@ -809,7 +809,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
         # ---- BOTTOM PLOT: Cumulative impact ----
         ax[2].set(title="Cumulative Causal Impact")
-        plot_xY(
+        plot_posterior_over_x(
             self.datapost.index,
             self.post_impact_cumulative.sel(treated_units=treated_unit),
             ax=ax[2],

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -31,8 +31,8 @@ from pandas.api.extensions import ExtensionArray
 from causalpy.constants import HDI_PROB
 
 
-class _PlotXYStyle(TypedDict):
-    """Typed kwargs bundle forwarded from ``_bayesian_plot`` to every ``plot_xY`` call."""
+class _PosteriorPlotStyle(TypedDict):
+    """Typed kwargs bundle forwarded from ``_bayesian_plot`` to every ``plot_posterior_over_x`` call."""
 
     ci_prob: float
     kind: Literal["ribbon", "histogram", "spaghetti"]
@@ -40,7 +40,7 @@ class _PlotXYStyle(TypedDict):
     num_samples: int
 
 
-def plot_xY(
+def plot_posterior_over_x(
     x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
     Y: xr.DataArray,
     ax: plt.Axes,
@@ -93,9 +93,9 @@ def plot_xY(
           sample/mean lines and no single band patch.
 
         Experiment :meth:`~causalpy.experiments.base.BaseExperiment.plot` code
-        that builds legends from ``plot_xY`` return values should only assume
+        that builds legends from ``plot_posterior_over_x`` return values should only assume
         the ribbon shape when it passes ``kind="ribbon"`` (the default) through
-        to :func:`plot_xY`.
+        to :func:`plot_posterior_over_x`.
     """
     # Handle backward compatibility: hdi_prob was in original API
     if hdi_prob is not None:
@@ -264,7 +264,7 @@ def _plot_histogram(
     time_dims = [d for d in Y.dims if d not in ("chain", "draw")]
     if len(time_dims) != 1:
         msg = (
-            "plot_xY histogram expects Y with exactly one non-chain/draw dimension; "
+            "plot_posterior_over_x histogram expects Y with exactly one non-chain/draw dimension; "
             f"got {time_dims!r}"
         )
         raise ValueError(msg)

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -53,22 +53,28 @@ def plot_posterior_over_x(
     # Backward compatibility: hdi_prob was in original API
     hdi_prob: float | None = None,
 ) -> tuple[Line2D | list[Line2D], PolyCollection | None]:
-    """Plot posterior intervals or samples.
+    """Plot a posterior :class:`xarray.DataArray` along an x-axis.
+
+    Dispatches on ``kind`` to render ribbon (mean + interval band), spaghetti
+    (posterior draw lines), or histogram (2D density heatmap) visualizations.
 
     Parameters
     ----------
     x : pd.DatetimeIndex, np.ndarray, pd.Index, pd.Series, or ExtensionArray
-        Pandas datetime index or numpy array of x-axis values.
+        Values for the x-axis (e.g. time, a running variable, or a prediction
+        grid). Need not be temporal.
     Y : xr.DataArray
-        Xarray data array of y-axis data.
+        Posterior samples with ``chain`` and ``draw`` dimensions and one
+        dimension aligned with ``x``.
     ax : plt.Axes
         Matplotlib axes object.
     plot_hdi_kwargs : dict, optional
         Keyword arguments for line, band, heatmap, or sample styling (passed through
         to matplotlib / ArviZ helpers depending on ``kind`` and ``ci_kind``).
     ci_prob : float, optional
-        The size of the credible interval. Defaults to
-        :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+        Credible interval width when ``kind="ribbon"``. Defaults to
+        :data:`~causalpy.constants.HDI_PROB` (currently 0.94). Ignored for
+        other kinds.
     label : str, optional
         The plot label.
     kind : {"ribbon", "histogram", "spaghetti"}, optional
@@ -253,8 +259,8 @@ def _plot_histogram(
 ) -> tuple[list[Line2D], None]:
     """Plot histogram visualization of the posterior as a 2D heatmap.
 
-    Columns are time points (x), rows are y-value bins; cell values are
-    per-time histogram counts, column-normalized for display. The posterior
+    Columns are positions along ``x``; rows are y-value bins. Cell values are
+    per-column histogram counts, column-normalized for display. The posterior
     mean line is overlaid on top.
     """
     if plot_hdi_kwargs is None:

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -19,7 +19,7 @@ values actually change the rendered credible-interval bands.
 These tests guard against the regression described in GitHub issue
 `pymc-labs/CausalPy#890`_, where ``result.plot(hdi_prob=...)`` was silently
 swallowed by ``**kwargs`` rather than reaching the underlying
-:func:`causalpy.plot_utils.plot_xY` (and equivalent) calls.
+:func:`causalpy.plot_utils.plot_posterior_over_x` (and equivalent) calls.
 
 ``hdi_prob`` was the original parameter name. It was renamed to ``ci_prob``
 when ETI support was added (since the parameter controls the *credible interval*
@@ -49,7 +49,7 @@ sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
 # Each entry maps a "spy target" (dotted import path of the callable used by
 # the experiment's plot path) to the kwarg name that ``hdi_prob`` flows into.
-# ``plot_xY`` targets use ``"ci_prob"`` (the canonical name); other callables
+# ``plot_posterior_over_x`` targets use ``"ci_prob"`` (the canonical name); other callables
 # such as ``az.plot_posterior`` and ``az.plot_forest`` use ``"hdi_prob"``.
 _SpyTarget = tuple[str, str]
 
@@ -329,26 +329,26 @@ def _check_default(
 
 
 _ITS_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.interrupted_time_series.plot_xY", "ci_prob"),
+    ("causalpy.experiments.interrupted_time_series.plot_posterior_over_x", "ci_prob"),
 ]
 _SC_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.synthetic_control.plot_xY", "ci_prob"),
+    ("causalpy.experiments.synthetic_control.plot_posterior_over_x", "ci_prob"),
 ]
 _DID_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.diff_in_diff.plot_xY", "ci_prob"),
+    ("causalpy.experiments.diff_in_diff.plot_posterior_over_x", "ci_prob"),
 ]
 _RD_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.regression_discontinuity.plot_xY", "ci_prob"),
+    ("causalpy.experiments.regression_discontinuity.plot_posterior_over_x", "ci_prob"),
 ]
 _RKINK_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.regression_kink.plot_xY", "ci_prob"),
+    ("causalpy.experiments.regression_kink.plot_posterior_over_x", "ci_prob"),
 ]
 _PREPOST_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.prepostnegd.plot_xY", "ci_prob"),
+    ("causalpy.experiments.prepostnegd.plot_posterior_over_x", "ci_prob"),
     ("causalpy.experiments.prepostnegd.az.plot_posterior", "hdi_prob"),
 ]
 _PIECEWISE_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.piecewise_its.plot_xY", "ci_prob"),
+    ("causalpy.experiments.piecewise_its.plot_posterior_over_x", "ci_prob"),
 ]
 _PANEL_TARGETS: list[_SpyTarget] = [
     ("causalpy.experiments.panel_regression.az.plot_forest", "hdi_prob"),
@@ -358,20 +358,20 @@ _PANEL_TARGETS: list[_SpyTarget] = [
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_its_plot_threads_ci_prob(mock_pymc_sample, fitted_its, ci_prob):
-    """ITS ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """ITS ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_its, _ITS_TARGETS, ci_prob)
 
 
 @pytest.mark.integration
 def test_its_plot_default_ci_prob(mock_pymc_sample, fitted_its):
-    """ITS default ``plot()`` forwards ``HDI_PROB`` to every ``plot_xY`` call (as ``ci_prob``)."""
+    """ITS default ``plot()`` forwards ``HDI_PROB`` to every ``plot_posterior_over_x`` call (as ``ci_prob``)."""
     _check_default(fitted_its, _ITS_TARGETS)
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_sc_plot_threads_ci_prob(mock_pymc_sample, fitted_sc, ci_prob):
-    """Synthetic Control ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """Synthetic Control ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_sc, _SC_TARGETS, ci_prob)
 
 
@@ -384,7 +384,7 @@ def test_sc_plot_default_ci_prob(mock_pymc_sample, fitted_sc):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_did_plot_threads_ci_prob(mock_pymc_sample, fitted_did, ci_prob):
-    """DiD ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """DiD ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_did, _DID_TARGETS, ci_prob)
 
 
@@ -397,7 +397,7 @@ def test_did_plot_default_ci_prob(mock_pymc_sample, fitted_did):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_rd_plot_threads_ci_prob(mock_pymc_sample, fitted_rd, ci_prob):
-    """RD ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """RD ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_rd, _RD_TARGETS, ci_prob)
 
 
@@ -410,7 +410,7 @@ def test_rd_plot_default_ci_prob(mock_pymc_sample, fitted_rd):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_rkink_plot_threads_ci_prob(mock_pymc_sample, fitted_rkink, ci_prob):
-    """Regression Kink ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """Regression Kink ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_rkink, _RKINK_TARGETS, ci_prob)
 
 
@@ -423,7 +423,7 @@ def test_rkink_plot_default_ci_prob(mock_pymc_sample, fitted_rkink):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_prepost_plot_threads_ci_prob(mock_pymc_sample, fitted_prepost, ci_prob):
-    """PrePostNEGD ``plot(ci_prob=...)`` reaches ``plot_xY`` and ``az.plot_posterior``."""
+    """PrePostNEGD ``plot(ci_prob=...)`` reaches ``plot_posterior_over_x`` and ``az.plot_posterior``."""
     _check_threading(fitted_prepost, _PREPOST_TARGETS, ci_prob)
 
 
@@ -436,7 +436,7 @@ def test_prepost_plot_default_ci_prob(mock_pymc_sample, fitted_prepost):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_piecewise_plot_threads_ci_prob(mock_pymc_sample, fitted_piecewise, ci_prob):
-    """PiecewiseITS ``plot(ci_prob=...)`` reaches every ``plot_xY`` call."""
+    """PiecewiseITS ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
     _check_threading(fitted_piecewise, _PIECEWISE_TARGETS, ci_prob)
 
 
@@ -470,14 +470,19 @@ def test_panel_plot_default_ci_prob(mock_pymc_sample, fitted_panel):
 
 @pytest.mark.integration
 def test_deprecated_hdi_prob_still_wired(mock_pymc_sample, fitted_its):
-    """``plot(hdi_prob=...)`` still reaches ``plot_xY`` via the deprecated alias.
+    """``plot(hdi_prob=...)`` still reaches ``plot_posterior_over_x`` via the deprecated alias.
 
     Ensures that existing user code does not silently break after the rename
     to ``ci_prob``. The deprecated alias must emit a ``FutureWarning`` and
-    forward the value to ``plot_xY`` as ``ci_prob``.
+    forward the value to ``plot_posterior_over_x`` as ``ci_prob``.
     """
     stack, recorded = _record_hdi_prob_calls(
-        [("causalpy.experiments.interrupted_time_series.plot_xY", "ci_prob")]
+        [
+            (
+                "causalpy.experiments.interrupted_time_series.plot_posterior_over_x",
+                "ci_prob",
+            )
+        ]
     )
     import warnings
 

--- a/causalpy/tests/test_plot_utils.py
+++ b/causalpy/tests/test_plot_utils.py
@@ -22,7 +22,7 @@ import pytest
 import xarray as xr
 from matplotlib.collections import PolyCollection
 
-from causalpy.plot_utils import get_hdi_to_df, plot_xY
+from causalpy.plot_utils import get_hdi_to_df, plot_posterior_over_x
 
 
 @pytest.mark.integration
@@ -101,7 +101,7 @@ def test_get_hdi_to_df_with_coordinate_dimensions():
 
 @pytest.fixture
 def synthetic_posterior_data():
-    """Create synthetic posterior data for testing plot_xY."""
+    """Create synthetic posterior data for testing plot_posterior_over_x."""
     np.random.seed(42)
     n_chains = 2
     n_draws = 100
@@ -182,12 +182,12 @@ def synthetic_posterior_data_numeric():
 
 
 @pytest.mark.integration
-def test_plot_xY_ribbon_hdi(synthetic_posterior_data):
+def test_plot_posterior_over_x_ribbon_hdi(synthetic_posterior_data):
     """Test ribbon plot with HDI (default behavior)."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
-    h_line, h_patch = plot_xY(
+    h_line, h_patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -212,12 +212,12 @@ def test_plot_xY_ribbon_hdi(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_ribbon_eti(synthetic_posterior_data):
+def test_plot_posterior_over_x_ribbon_eti(synthetic_posterior_data):
     """Test ribbon plot with ETI."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
-    h_line, h_patch = plot_xY(
+    h_line, h_patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -242,12 +242,12 @@ def test_plot_xY_ribbon_eti(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram(synthetic_posterior_data):
+def test_plot_posterior_over_x_histogram(synthetic_posterior_data):
     """Test histogram visualization (2D heatmap)."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
-    handles, patch = plot_xY(
+    handles, patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -271,12 +271,12 @@ def test_plot_xY_histogram(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_numeric(synthetic_posterior_data_numeric):
+def test_plot_posterior_over_x_histogram_numeric(synthetic_posterior_data_numeric):
     """Test histogram visualization with numeric x values."""
     x, Y = synthetic_posterior_data_numeric
     fig, ax = plt.subplots()
 
-    handles, patch = plot_xY(
+    handles, patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -299,12 +299,12 @@ def test_plot_xY_histogram_numeric(synthetic_posterior_data_numeric):
 
 
 @pytest.mark.integration
-def test_plot_xY_spaghetti(synthetic_posterior_data):
+def test_plot_posterior_over_x_spaghetti(synthetic_posterior_data):
     """Test spaghetti plot visualization."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
-    handles, patch = plot_xY(
+    handles, patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -326,13 +326,13 @@ def test_plot_xY_spaghetti(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_default_behavior(synthetic_posterior_data):
+def test_plot_posterior_over_x_default_behavior(synthetic_posterior_data):
     """Test that default behavior matches original (ribbon with HDI)."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
     # Test with no parameters (should default to ribbon, hdi, 0.94)
-    h_line, h_patch = plot_xY(x, Y, ax=ax)
+    h_line, h_patch = plot_posterior_over_x(x, Y, ax=ax)
 
     # Check return types
     assert isinstance(h_line, plt.Line2D), "Should return Line2D for mean line"
@@ -342,13 +342,15 @@ def test_plot_xY_default_behavior(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_backward_compatibility_hdi_prob(synthetic_posterior_data):
+def test_plot_posterior_over_x_backward_compatibility_hdi_prob(
+    synthetic_posterior_data,
+):
     """Test backward compatibility with hdi_prob parameter."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
     # Test that hdi_prob still works (should override ci_prob)
-    h_line, h_patch = plot_xY(x, Y, ax=ax, hdi_prob=0.95)
+    h_line, h_patch = plot_posterior_over_x(x, Y, ax=ax, hdi_prob=0.95)
 
     # Check return types
     assert isinstance(h_line, plt.Line2D), "Should return Line2D for mean line"
@@ -358,14 +360,14 @@ def test_plot_xY_backward_compatibility_hdi_prob(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_different_ci_prob(synthetic_posterior_data):
+def test_plot_posterior_over_x_different_ci_prob(synthetic_posterior_data):
     """Test different ci_prob values."""
     x, Y = synthetic_posterior_data
 
     for ci_prob in [0.80, 0.89, 0.94, 0.95, 0.99]:
         fig, ax = plt.subplots()
 
-        h_line, h_patch = plot_xY(
+        h_line, h_patch = plot_posterior_over_x(
             x,
             Y,
             ax=ax,
@@ -386,26 +388,26 @@ def test_plot_xY_different_ci_prob(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_invalid_kind(synthetic_posterior_data):
+def test_plot_posterior_over_x_invalid_kind(synthetic_posterior_data):
     """Test that invalid kind parameter raises ValueError."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
     with pytest.raises(ValueError, match="Unknown kind"):
-        plot_xY(x, Y, ax=ax, kind="invalid_kind")
+        plot_posterior_over_x(x, Y, ax=ax, kind="invalid_kind")
 
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_spaghetti_num_samples(synthetic_posterior_data):
+def test_plot_posterior_over_x_spaghetti_num_samples(synthetic_posterior_data):
     """Test spaghetti plot with different num_samples values."""
     x, Y = synthetic_posterior_data
 
     for num_samples in [10, 50, 100]:
         fig, ax = plt.subplots()
 
-        handles, patch = plot_xY(
+        handles, patch = plot_posterior_over_x(
             x,
             Y,
             ax=ax,
@@ -429,12 +431,12 @@ def test_plot_xY_spaghetti_num_samples(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_custom_colormap(synthetic_posterior_data):
+def test_plot_posterior_over_x_histogram_custom_colormap(synthetic_posterior_data):
     """Test histogram with custom colormap."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
 
-    handles, patch = plot_xY(
+    handles, patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -450,7 +452,7 @@ def test_plot_xY_histogram_custom_colormap(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_requires_single_time_dim():
+def test_plot_posterior_over_x_histogram_requires_single_time_dim():
     """Histogram rejects Y with more than one non-chain/draw dimension."""
     rng = np.random.default_rng(0)
     Y = xr.DataArray(
@@ -465,22 +467,24 @@ def test_plot_xY_histogram_requires_single_time_dim():
     )
     fig, ax = plt.subplots()
     with pytest.raises(ValueError, match="exactly one non-chain/draw"):
-        plot_xY(np.arange(4), Y, ax=ax, kind="histogram")
+        plot_posterior_over_x(np.arange(4), Y, ax=ax, kind="histogram")
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_x_length_mismatch_raises(synthetic_posterior_data):
+def test_plot_posterior_over_x_histogram_x_length_mismatch_raises(
+    synthetic_posterior_data,
+):
     """Histogram rejects x length differing from the posterior time dimension."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
     with pytest.raises(ValueError, match="Length of x"):
-        plot_xY(x[:3], Y, ax=ax, kind="histogram")
+        plot_posterior_over_x(x[:3], Y, ax=ax, kind="histogram")
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_single_time_point():
+def test_plot_posterior_over_x_histogram_single_time_point():
     """Histogram with one time point exercises single-edge x bin construction."""
     rng = np.random.default_rng(2)
     x = pd.date_range("2020-01-01", periods=1, freq="D")
@@ -494,30 +498,32 @@ def test_plot_xY_histogram_single_time_point():
         },
     )
     fig, ax = plt.subplots()
-    handles, patch = plot_xY(x, Y, ax=ax, kind="histogram")
+    handles, patch = plot_posterior_over_x(x, Y, ax=ax, kind="histogram")
     assert isinstance(handles, list)
     assert patch is None
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_histogram_object_dtype_datetime_strings(synthetic_posterior_data):
+def test_plot_posterior_over_x_histogram_object_dtype_datetime_strings(
+    synthetic_posterior_data,
+):
     """Object-dtype x of ISO strings hits datetime parsing in _x_as_numeric_mesh."""
     x, Y = synthetic_posterior_data
     x_obj = np.array([str(t) for t in x], dtype=object)
     fig, ax = plt.subplots()
-    handles, patch = plot_xY(x_obj, Y, ax=ax, kind="histogram")
+    handles, patch = plot_posterior_over_x(x_obj, Y, ax=ax, kind="histogram")
     assert isinstance(handles, list)
     assert patch is None
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_ribbon_fill_kwargs_eti(synthetic_posterior_data):
+def test_plot_posterior_over_x_ribbon_fill_kwargs_eti(synthetic_posterior_data):
     """Ribbon ETI path uses fill_kwargs and default label when label is None."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
-    h_line, h_patch = plot_xY(
+    h_line, h_patch = plot_posterior_over_x(
         x,
         Y,
         ax=ax,
@@ -535,20 +541,24 @@ def test_plot_xY_ribbon_fill_kwargs_eti(synthetic_posterior_data):
 
 
 @pytest.mark.integration
-def test_plot_xY_warns_ci_kind_ignored_for_non_ribbon(synthetic_posterior_data):
+def test_plot_posterior_over_x_warns_ci_kind_ignored_for_non_ribbon(
+    synthetic_posterior_data,
+):
     """ci_kind is ignored for histogram/spaghetti; a UserWarning must be raised."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
     with pytest.warns(UserWarning, match="ci_kind.*ignored"):
-        plot_xY(x, Y, ax=ax, kind="histogram", ci_kind="eti")
+        plot_posterior_over_x(x, Y, ax=ax, kind="histogram", ci_kind="eti")
     plt.close(fig)
 
 
 @pytest.mark.integration
-def test_plot_xY_warns_num_samples_ignored_for_non_spaghetti(synthetic_posterior_data):
+def test_plot_posterior_over_x_warns_num_samples_ignored_for_non_spaghetti(
+    synthetic_posterior_data,
+):
     """num_samples is ignored for ribbon/histogram; a UserWarning must be raised."""
     x, Y = synthetic_posterior_data
     fig, ax = plt.subplots()
     with pytest.warns(UserWarning, match="num_samples.*ignored"):
-        plot_xY(x, Y, ax=ax, kind="ribbon", num_samples=100)
+        plot_posterior_over_x(x, Y, ax=ax, kind="ribbon", num_samples=100)
     plt.close(fig)

--- a/causalpy/tests/test_public_plot_signatures.py
+++ b/causalpy/tests/test_public_plot_signatures.py
@@ -125,7 +125,7 @@ def test_every_concrete_subclass_declares_plot() -> None:
     )
 
 
-_POSTERIOR_PLOT_XY_CLASSES = [
+_POSTERIOR_OVER_X_PLOT_CLASSES = [
     "InterruptedTimeSeries",
     "DifferenceInDifferences",
     "PrePostNEGD",
@@ -137,14 +137,14 @@ _POSTERIOR_PLOT_XY_CLASSES = [
 ]
 
 
-@pytest.mark.parametrize("class_name", _POSTERIOR_PLOT_XY_CLASSES)
+@pytest.mark.parametrize("class_name", _POSTERIOR_OVER_X_PLOT_CLASSES)
 def test_posterior_plot_exposes_viz_kind(class_name: str) -> None:
     cls = next(c for c in _OVERRIDING_SUBCLASSES if c.__name__ == class_name)
     plot_method = cls.__dict__["plot"]
     sig = inspect.signature(plot_method).parameters
     for param in ("kind", "ci_kind", "num_samples"):
         assert param in sig, (
-            f"{class_name}.plot() is missing '{param}'; all plot_xY-backed classes "
+            f"{class_name}.plot() is missing '{param}'; all posterior-over-x plot classes "
             "must expose kind, ci_kind, and num_samples."
         )
 


### PR DESCRIPTION
## Summary

- Renames the internal plotting helper `plot_xY` → `plot_posterior_over_x` and `_PlotXYStyle` → `_PosteriorPlotStyle`.
- Follows up on closed #983: after #680 the function dispatches ribbon, histogram, and spaghetti visualizations along an x-axis, so `plot_ribbon` was the wrong target; `plot_posterior_over_x` matches the actual contract.
- Pure rename — no behavior or public API changes (`plot_xY` was never exported from `causalpy`).

## Test plan

- [x] `grep -rn plot_xY causalpy` returns nothing
- [x] `prek run --all-files`
- [x] `pytest causalpy/tests/test_hdi_prob_wiring.py causalpy/tests/test_plot_utils.py causalpy/tests/test_public_plot_signatures.py`


Made with [Cursor](https://cursor.com)