### PR TITLE
Draft: heatwaves and excess mortality (piecewise ITS, UK)

### DIFF
--- a/docs/source/notebooks/gallery.yaml
+++ b/docs/source/notebooks/gallery.yaml
@@ -68,6 +68,9 @@ groups:
             notebook: its_post_intervention_analysis
           - title: Excess deaths due to COVID-19
             notebook: its_covid
+          - title: "Temperature and mortality: a UK causal analysis (draft)"
+            notebook: its_temperature_mortality
+            thumbnail: false
           - title: Lift Testing with Interrupted Time Series
             notebook: its_lift_test
           - title: "Placebo-in-time and falsification: a UK CO₂ case study"

--- a/docs/source/notebooks/gallery.yaml
+++ b/docs/source/notebooks/gallery.yaml
@@ -68,7 +68,7 @@ groups:
             notebook: its_post_intervention_analysis
           - title: Excess deaths due to COVID-19
             notebook: its_covid
-          - title: "Temperature and mortality: a UK causal analysis (draft)"
+          - title: "Heatwaves and excess mortality: a piecewise ITS analysis (draft)"
             notebook: its_temperature_mortality
             thumbnail: false
           - title: Lift Testing with Interrupted Time Series

--- a/docs/source/notebooks/index.md
+++ b/docs/source/notebooks/index.md
@@ -178,7 +178,7 @@ A quasi-experimental design that uses time series methods to generate counterfac
 :link-type: doc
 :::
 
-:::{grid-item-card} Temperature and mortality: a UK causal analysis (draft)
+:::{grid-item-card} Heatwaves and excess mortality: a piecewise ITS analysis (draft)
 :class-card: sd-card-h-100
 :link: its_temperature_mortality
 :link-type: doc

--- a/docs/source/notebooks/index.md
+++ b/docs/source/notebooks/index.md
@@ -178,6 +178,12 @@ A quasi-experimental design that uses time series methods to generate counterfac
 :link-type: doc
 :::
 
+:::{grid-item-card} Temperature and mortality: a UK causal analysis (draft)
+:class-card: sd-card-h-100
+:link: its_temperature_mortality
+:link-type: doc
+:::
+
 :::{grid-item-card} Lift Testing with Interrupted Time Series
 :class-card: sd-card-h-100
 :img-top: ../_static/thumbnails/its_lift_test.png
@@ -443,6 +449,7 @@ its_skl.ipynb
 its_pymc.ipynb
 its_post_intervention_analysis.ipynb
 its_covid.ipynb
+its_temperature_mortality.ipynb
 its_lift_test.ipynb
 its_placebo_in_time_analysis.ipynb
 :::

--- a/docs/source/notebooks/its_temperature_mortality.ipynb
+++ b/docs/source/notebooks/its_temperature_mortality.ipynb
@@ -4,19 +4,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Temperature and mortality: a causal analysis (UK)\n",
+    "# Heatwaves and excess mortality: a piecewise ITS analysis (UK)\n",
     "\n",
     ":::{note}\n",
-    "**Draft scaffold.** This notebook is a work-in-progress placeholder to build out a causal analysis of the effect of temperature on mortality in the UK. See the \"Plan\" section below for the intended narrative, data sources, and methodology. Nothing here is final.\n",
+    "**Draft scaffold.** Work-in-progress placeholder. See the \"Plan\" section for the intended narrative, data, and method. Nothing here is final.\n",
     ":::\n",
     "\n",
     "## Motivation\n",
     "\n",
-    "The UK is unusually exposed to temperature-related mortality: a large, old housing stock with poor insulation, near-zero domestic air conditioning, and a population unaccustomed to extreme heat. Both cold winters and summer heatwaves push up deaths. This notebook builds a causal, time-series account of how temperature drives mortality, and tries to go beyond the naive \"hot day → more deaths\" story.\n",
+    "The UK is unusually exposed to heat-related mortality: an old, poorly-insulated housing stock, near-zero domestic air conditioning, and a population unaccustomed to extreme heat. Homes have thermal mass, so during a sustained hot spell the indoor environment keeps warming even after the outdoor peak, and deaths climb over the course of the episode rather than tracking a single hot day.\n",
     "\n",
-    "The compelling, timely hook is the **July 2022 heatwave**, when the UK recorded 40°C for the first time and the ONS attributed thousands of excess deaths to the heat episodes that summer.\n",
+    "The timely hook is the **July 2022 heatwave**, when the UK passed 40°C for the first time on record and the ONS attributed hundreds of excess deaths to the heat episodes that summer.\n",
     "\n",
-    "This sits naturally alongside the existing [Excess deaths due to COVID-19](its_covid.ipynb) notebook, which already uses England & Wales deaths and temperature as a *control*. Here temperature is the treatment of interest rather than a nuisance variable."
+    "This is a natural companion to the existing [Excess deaths due to COVID-19](its_covid.ipynb) notebook: same interrupted-time-series machinery, but the interruption is a heatwave rather than a pandemic."
    ]
   },
   {
@@ -25,26 +25,32 @@
    "source": [
     "## Plan (to build out)\n",
     "\n",
-    "**Research question.** What is the causal effect of temperature on UK mortality, and how much of it is explained by *accumulated* thermal exposure rather than instantaneous temperature?\n",
+    "**Estimand.** Excess mortality during and after a heatwave, relative to the counterfactual mortality that the pre-heatwave trend and seasonal baseline imply. This is a clean quasi-experiment: the heatwave is an intervention at a **known date**, and next week's deaths do not cause this week's weather, so there is no reverse causation.\n",
     "\n",
-    "**Key idea to demonstrate.** It is not just today's temperature. Homes have thermal mass: during a sustained hot spell the indoor environment keeps warming even after the outdoor peak, so a *running/cumulative* temperature term (a distributed-lag or exponentially-weighted exposure) should predict deaths better than a single-day temperature. Adding **humidity** should sharpen this further, since humid heat impairs the body's ability to cool.\n",
+    "**Why piecewise ITS.** A heatwave is not an instantaneous shock. [Piecewise interrupted time series (segmented regression)](piecewise_its_pymc.ipynb) is built for exactly this: it estimates a **level change** (the acute jump in deaths as the heat hits) *and* a **slope change** (the build-up as homes heat up over successive days, then the compensating dip afterwards from short-term mortality displacement / \"harvesting\"). The level-plus-slope decomposition is how the \"houses warm up\" thesis shows up in the model, without needing a continuous dose-response curve.\n",
     "\n",
-    "**Methodology sketch.**\n",
-    "1. Establish an expected-mortality baseline (seasonal + trend), in the spirit of the COVID excess-deaths notebook.\n",
-    "2. Model deaths as a function of temperature with a **distributed lag / cumulative exposure** term (e.g. exponentially-weighted temperature, or explicit lags), so we can show the cumulative signal beats the contemporaneous one.\n",
-    "3. Add **humidity** and a temperature×humidity interaction.\n",
-    "4. Treat a specific episode (July 2022 heatwave) as an intervention and estimate excess deaths as a counterfactual, using CausalPy's ITS machinery.\n",
-    "5. Sensitivity / falsification: placebo-in-time checks (see the placebo notebook) to guard against spurious effects.\n",
+    "**Method sketch.**\n",
+    "1. Weekly expected-mortality baseline: cyclic seasonal term + slow long-term/ageing trend (population offset per age band), in the spirit of the COVID notebook.\n",
+    "2. Frame the major heatwaves (2018, 2019, 2022) as repeated known-date interruptions and fit a piecewise ITS with `causalpy`, reading off level and slope effects per episode.\n",
+    "3. Bring the engineered daily heat-load in as a predictor within the model: an exponentially-weighted (thermal-mass) temperature, consecutive-hot-day count, and an apparent-temperature/heat-index term that folds in humidity.\n",
+    "4. Quantify excess deaths per episode as the counterfactual gap, with posterior uncertainty.\n",
+    "5. Falsification: placebo-in-time interruptions on non-heatwave dates should show no effect.\n",
     "\n",
-    "**Data needed (TODO).**\n",
-    "- **Deaths.** Ideally *daily* or *weekly* UK deaths over many years. ONS publishes weekly death registrations for England & Wales going back years; daily is harder but exists for recent years. The packaged `\"covid\"` dataset is currently only *monthly* (E&W, 2006–), which is too coarse to see the cumulative-heat effect — we will need a finer series.\n",
-    "- **Temperature.** Met Office HadUK-Grid or the Central England Temperature (CET) daily record (long, freely available). Match spatial/temporal resolution to the deaths series.\n",
-    "- **Humidity.** Met Office observations or ERA5 reanalysis (relative humidity). Needs sourcing and licensing check before adding to `causalpy/data/`.\n",
+    "**Headline figure.** Observed weekly deaths, the counterfactual band, heatwave windows shaded, and the excess quantified per episode.\n",
     "\n",
-    "**Open questions.**\n",
-    "- Weekly vs daily resolution: weekly is easier to source and less noisy; daily is needed to resolve short heatwaves. Decide.\n",
-    "- Region: England & Wales (ONS coverage) vs UK-wide. Lack of AC argues UK, but data coverage may force E&W.\n",
-    "- How to encode \"house warms up\": exponentially-weighted moving average of temperature vs explicit multi-day lags vs a simple thermal-mass ODE. Pick and justify."
+    "**Scope note.** The graded, whole-year temperature–mortality dose-response (the V-shaped curve with cold and heat arms) is a different, non-quasi-experimental question. It is deliberately out of scope here; this notebook is about discrete heatwave episodes as interruptions, which is what CausalPy is for."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Data (sourced, to be assembled)\n",
+    "\n",
+    "- **Deaths (weekly, ONS).** `weekly-deaths-age-sex` via the ONS API: England & Wales, 5-year age bands to 100+, **occurrence** dates (avoids bank-holiday registration artifacts), 2010–present. Full history is split across editions (`2010-19`, `covid-19`, yearly), so it needs stitching into one series. Age-band population estimates provide the denominator/offset.\n",
+    "- **Weather (daily, Open-Meteo ERA5, CC-BY).** Mean/max/min 2 m temperature, relative humidity, dewpoint, population-weighted across a handful of English points, then engineered to weekly heat-load features. Confirmed to resolve the 19 Jul 2022 spike (~37.6°C at a central point).\n",
+    "\n",
+    "Both fetch cleanly; the packaged monthly `\"covid\"` dataset below is only a placeholder so this scaffold runs."
    ]
   },
   {
@@ -72,31 +78,15 @@
    "outputs": []
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Starting point: the packaged monthly data\n",
-    "\n",
-    "For now we load the existing `\"covid\"` dataset (monthly England & Wales deaths and mean temperature, 2006–) as a placeholder so the notebook runs. This is *too coarse* for the cumulative-heat story and will be replaced with a weekly/daily series (see the data TODO above)."
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "source": [
+    "# Placeholder: packaged monthly E&W deaths + temperature, so the scaffold runs.\n",
+    "# To be replaced with the weekly ONS occurrence series + engineered daily weather.\n",
     "df = cp.load_data(\"covid\")\n",
     "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
-    "df.head()"
-   ],
-   "outputs": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "source": [
-    "# Quick look: deaths and temperature move together seasonally (inverse in winter).\n",
+    "\n",
     "fig, ax = plt.subplots(2, 1, figsize=(10, 6), sharex=True)\n",
     "ax[0].plot(df[\"date\"], df[\"deaths\"])\n",
     "ax[0].set(ylabel=\"deaths / month\")\n",
@@ -111,11 +101,11 @@
    "source": [
     "## Next steps\n",
     "\n",
-    "- [ ] Source a weekly (ideally daily) UK/E&W deaths series and add temperature + humidity.\n",
-    "- [ ] Build the seasonal baseline and the cumulative/lagged temperature exposure term.\n",
-    "- [ ] Add humidity and the interaction.\n",
-    "- [ ] Frame the July 2022 heatwave as an intervention and estimate excess deaths with CausalPy ITS.\n",
-    "- [ ] Placebo-in-time falsification.\n",
+    "- [ ] Stitch the ONS weekly age-banded occurrence series (2010–present) and add age-band population offsets.\n",
+    "- [ ] Pull population-weighted daily English weather; engineer weekly heat-load (EWMA temp, consecutive hot days, heat index with humidity).\n",
+    "- [ ] Fit a piecewise ITS with heatwaves (2018/2019/2022) as known-date interruptions; read off level and slope effects.\n",
+    "- [ ] Quantify excess deaths per episode with uncertainty; build the headline figure.\n",
+    "- [ ] Placebo-in-time falsification on non-heatwave dates.\n",
     "- [ ] Register a thumbnail and finalise the gallery entry."
    ]
   }

--- a/docs/source/notebooks/its_temperature_mortality.ipynb
+++ b/docs/source/notebooks/its_temperature_mortality.ipynb
@@ -1,0 +1,135 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Temperature and mortality: a causal analysis (UK)\n",
+    "\n",
+    ":::{note}\n",
+    "**Draft scaffold.** This notebook is a work-in-progress placeholder to build out a causal analysis of the effect of temperature on mortality in the UK. See the \"Plan\" section below for the intended narrative, data sources, and methodology. Nothing here is final.\n",
+    ":::\n",
+    "\n",
+    "## Motivation\n",
+    "\n",
+    "The UK is unusually exposed to temperature-related mortality: a large, old housing stock with poor insulation, near-zero domestic air conditioning, and a population unaccustomed to extreme heat. Both cold winters and summer heatwaves push up deaths. This notebook builds a causal, time-series account of how temperature drives mortality, and tries to go beyond the naive \"hot day → more deaths\" story.\n",
+    "\n",
+    "The compelling, timely hook is the **July 2022 heatwave**, when the UK recorded 40°C for the first time and the ONS attributed thousands of excess deaths to the heat episodes that summer.\n",
+    "\n",
+    "This sits naturally alongside the existing [Excess deaths due to COVID-19](its_covid.ipynb) notebook, which already uses England & Wales deaths and temperature as a *control*. Here temperature is the treatment of interest rather than a nuisance variable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Plan (to build out)\n",
+    "\n",
+    "**Research question.** What is the causal effect of temperature on UK mortality, and how much of it is explained by *accumulated* thermal exposure rather than instantaneous temperature?\n",
+    "\n",
+    "**Key idea to demonstrate.** It is not just today's temperature. Homes have thermal mass: during a sustained hot spell the indoor environment keeps warming even after the outdoor peak, so a *running/cumulative* temperature term (a distributed-lag or exponentially-weighted exposure) should predict deaths better than a single-day temperature. Adding **humidity** should sharpen this further, since humid heat impairs the body's ability to cool.\n",
+    "\n",
+    "**Methodology sketch.**\n",
+    "1. Establish an expected-mortality baseline (seasonal + trend), in the spirit of the COVID excess-deaths notebook.\n",
+    "2. Model deaths as a function of temperature with a **distributed lag / cumulative exposure** term (e.g. exponentially-weighted temperature, or explicit lags), so we can show the cumulative signal beats the contemporaneous one.\n",
+    "3. Add **humidity** and a temperature×humidity interaction.\n",
+    "4. Treat a specific episode (July 2022 heatwave) as an intervention and estimate excess deaths as a counterfactual, using CausalPy's ITS machinery.\n",
+    "5. Sensitivity / falsification: placebo-in-time checks (see the placebo notebook) to guard against spurious effects.\n",
+    "\n",
+    "**Data needed (TODO).**\n",
+    "- **Deaths.** Ideally *daily* or *weekly* UK deaths over many years. ONS publishes weekly death registrations for England & Wales going back years; daily is harder but exists for recent years. The packaged `\"covid\"` dataset is currently only *monthly* (E&W, 2006–), which is too coarse to see the cumulative-heat effect — we will need a finer series.\n",
+    "- **Temperature.** Met Office HadUK-Grid or the Central England Temperature (CET) daily record (long, freely available). Match spatial/temporal resolution to the deaths series.\n",
+    "- **Humidity.** Met Office observations or ERA5 reanalysis (relative humidity). Needs sourcing and licensing check before adding to `causalpy/data/`.\n",
+    "\n",
+    "**Open questions.**\n",
+    "- Weekly vs daily resolution: weekly is easier to source and less noisy; daily is needed to resolve short heatwaves. Decide.\n",
+    "- Region: England & Wales (ONS coverage) vs UK-wide. Lack of AC argues UK, but data coverage may force E&W.\n",
+    "- How to encode \"house warms up\": exponentially-weighted moving average of temperature vs explicit multi-day lags vs a simple thermal-mass ODE. Pick and justify."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pandas as pd\n",
+    "\n",
+    "import causalpy as cp"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "%config InlineBackend.figure_format = 'retina'\n",
+    "seed = 42"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Starting point: the packaged monthly data\n",
+    "\n",
+    "For now we load the existing `\"covid\"` dataset (monthly England & Wales deaths and mean temperature, 2006–) as a placeholder so the notebook runs. This is *too coarse* for the cumulative-heat story and will be replaced with a weekly/daily series (see the data TODO above)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "df = cp.load_data(\"covid\")\n",
+    "df[\"date\"] = pd.to_datetime(df[\"date\"])\n",
+    "df.head()"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "source": [
+    "# Quick look: deaths and temperature move together seasonally (inverse in winter).\n",
+    "fig, ax = plt.subplots(2, 1, figsize=(10, 6), sharex=True)\n",
+    "ax[0].plot(df[\"date\"], df[\"deaths\"])\n",
+    "ax[0].set(ylabel=\"deaths / month\")\n",
+    "ax[1].plot(df[\"date\"], df[\"temp\"], color=\"C1\")\n",
+    "ax[1].set(ylabel=\"mean temp (°C)\", xlabel=\"date\");"
+   ],
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Next steps\n",
+    "\n",
+    "- [ ] Source a weekly (ideally daily) UK/E&W deaths series and add temperature + humidity.\n",
+    "- [ ] Build the seasonal baseline and the cumulative/lagged temperature exposure term.\n",
+    "- [ ] Add humidity and the interaction.\n",
+    "- [ ] Frame the July 2022 heatwave as an intervention and estimate excess deaths with CausalPy ITS.\n",
+    "- [ ] Placebo-in-time falsification.\n",
+    "- [ ] Register a thumbnail and finalise the gallery entry."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CausalPy",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
**Draft scaffold / build space** for a CausalPy example (and the basis for a LinkedIn post). Not ready for review.

### Framing (corrected)
Rather than treating continuous temperature as a graded treatment (which isn't a quasi-experiment), this frames **heatwaves as interruptions at known dates** and uses **piecewise interrupted time series (segmented regression)** to estimate excess mortality against the pre-heatwave counterfactual. Same machinery as the existing `its_covid` notebook; the interruption is a heatwave.

The "houses warm up" thesis is expressed as the **level change** (acute spike) plus **slope change** (build-up over successive days, then the harvesting dip) that piecewise ITS estimates directly, no dose-response curve required. Humidity and the cumulative heat-load enter as engineered predictors within the model.

Timely hook: the July 2022 40°C record. Multiple heatwaves (2018/2019/2022) as repeated interruptions give one clean, shareable figure: observed deaths, counterfactual band, shaded heatwave windows, excess quantified.

### Data (sourced)
- **Deaths:** ONS `weekly-deaths-age-sex`, England & Wales, 5-year age bands, occurrence dates (avoids registration artifacts), 2010–present, stitched across editions. Age-band populations as offset.
- **Weather:** Open-Meteo ERA5 (CC-BY), daily temp/humidity/dewpoint, population-weighted over English points, engineered to weekly heat-load features.

### Next steps
- [ ] Assemble the ONS weekly occurrence series + population offsets.
- [ ] Population-weighted daily weather → weekly heat-load features.
- [ ] Fit piecewise ITS with heatwave interruptions; report level/slope + excess deaths.
- [ ] Placebo-in-time falsification.
- [ ] Thumbnail + finalise gallery card.

### Registered in the How-To gallery
Card under Interrupted Time Series, `thumbnail: false` so it renders without an executed-plot thumbnail. Docs preview builds on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)