### PR TITLE
Require a valid group*post_treatment interaction term in DiD formulas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 _build
+.venv/
 .ipynb_checkpoints
 *_checkpoints
 *.DS_Store

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -280,8 +280,14 @@ class DifferenceInDifferences(BaseExperiment):
 
     def _validate_formula_interaction_terms(self) -> None:
         """
-        Validate that the formula contains at most one interaction term and no three-way or higher-order interactions.
-        Raises FormulaException if more than one interaction term is found or if any interaction term has more than 2 variables.
+        Validate that the formula contains exactly one interaction term, that it
+        is between the group and post-treatment variables, and that it is not a
+        three-way or higher-order interaction.
+
+        Raises FormulaException if no interaction term is found, if more than one
+        interaction term is found, if any interaction term has more than 2
+        variables, or if the single interaction term does not involve both the
+        group and post-treatment variables.
         """
         # Define interaction indicators
         INTERACTION_INDICATORS = ["*", ":"]
@@ -306,6 +312,24 @@ class DifferenceInDifferences(BaseExperiment):
             raise FormulaException(
                 f"Formula contains {len(interaction_terms)} interaction terms: {interaction_terms}. "
                 "Multiple interaction terms are not currently supported as they complicate interpretation of the causal effect."
+            )
+
+        # A DiD formula must contain exactly one interaction term, and it must be
+        # between the group and post-treatment variables: that term is what
+        # identifies the causal effect (see `algorithm`, which reads it back off
+        # the fitted model). Without this check a formula with no interaction
+        # term, or an interaction between unrelated variables, would pass
+        # validation and only fail later when `causal_impact` is accessed.
+        if len(interaction_terms) == 0 or not (
+            self.group_variable_name in interaction_terms[0]
+            and self.post_treatment_variable_name in interaction_terms[0]
+        ):
+            raise FormulaException(
+                "Formula must contain exactly one interaction term between the "
+                f"group variable '{self.group_variable_name}' and the "
+                f"post-treatment variable '{self.post_treatment_variable_name}' "
+                f"(e.g. '{self.group_variable_name}*{self.post_treatment_variable_name}'). "
+                "This interaction term identifies the difference-in-differences causal effect."
             )
 
     def summary(self, round_to: int | None = 2) -> None:

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -156,6 +156,52 @@ def test_did_validation_post_treatment_formula():
             model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
         )
 
+    # Test 11: No interaction term at all (should be invalid)
+    with pytest.raises(FormulaException):
+        _ = cp.DifferenceInDifferences(
+            df,
+            formula="y ~ 1 + group + post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    # Test 12: Interaction term between unrelated variables, not group/post_treatment
+    # (should be invalid)
+    with pytest.raises(FormulaException):
+        _ = cp.DifferenceInDifferences(
+            df,
+            formula="y ~ 1 + group + post_treatment + male*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+
+def test_did_validation_interaction_term_order_independent():
+    """Test that the group*post_treatment interaction term is accepted
+    regardless of which variable is written first in the formula."""
+    df = pd.DataFrame(
+        {
+            "group": [0, 0, 1, 1],
+            "t": [0, 1, 0, 1],
+            "unit": [0, 0, 1, 1],
+            "post_treatment": [0, 1, 0, 1],
+            "y": [1, 2, 3, 4],
+        }
+    )
+
+    # group*post_treatment and post_treatment*group are statistically identical;
+    # construction must succeed either way.
+    result = cp.DifferenceInDifferences(
+        df,
+        formula="y ~ 1 + post_treatment*group",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    assert result.causal_impact is not None
+
 
 def test_did_validation_post_treatment_data():
     """Test that we get a DataException if do not include post_treatment in the data"""


### PR DESCRIPTION
## Summary

`DifferenceInDifferences` previously accepted formulas with no interaction term at all, or with an interaction term between unrelated variables, and only failed later when `causal_impact` was accessed:

- Bayesian models: `AttributeError` (`causal_impact` was never assigned in that code path)
- OLS models: silently returned `causal_impact = None`, with no exception or warning

This PR adds validation in `_validate_formula_interaction_terms` requiring exactly one interaction term that involves both the group and post-treatment variables, raising a clear `FormulaException` at construction time instead.

## Changes

- `causalpy/experiments/diff_in_diff.py`: extend `_validate_formula_interaction_terms` to reject a missing interaction term, or one not between the group/post-treatment variables.
- `causalpy/tests/test_input_validation.py`: add regression tests for both new rejection cases, plus a test confirming a reversed-order interaction term (`post_treatment*group`) still constructs successfully (this fix is scoped to the missing-validation bug; a separate, order-sensitivity bug in the OLS causal_impact lookup is being addressed in a follow-up PR).

## Test plan

- [x] `make doctest` — 36 passed, 13 skipped
- [x] `make test-patch-cov` — full suite 1149 passed, 5 skipped (pre-existing/unrelated); patch coverage 100% on both changed files
- [x] `prek run` on changed files — all hooks pass (ruff, mypy, numpydoc-validation, etc.)
- [x] Manually verified: formula with no interaction term now raises `FormulaException` (previously constructed silently); formula with unrelated interaction term now raises; normal and reversed-order valid formulas still construct successfully