### PR TITLE
Make OLS causal_impact lookup order-independent for the DiD interaction term

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 __pycache__
 _build
+.venv/
 .ipynb_checkpoints
 *_checkpoints
 *.DS_Store

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -236,16 +236,24 @@ class DifferenceInDifferences(BaseExperiment):
                         {"coeffs": i}
                     )
         elif self._model_backend.is_ols:
-            # This is the coefficient on the interaction term
-            # Store the coefficient into dictionary {intercept:value}
+            # This is the coefficient on the interaction term. Match by checking
+            # both variable names independently (as the Bayesian branch above
+            # does), rather than a single concatenated substring, since patsy
+            # may name the interaction term with either variable first (e.g.
+            # "post_treatment[T.True]:group" if the formula writes
+            # "post_treatment*group" instead of "group*post_treatment").
             coef_map = dict(
                 zip(self.labels, self._model_backend.coefficients(), strict=False)
             )
-            # Create and find the interaction term based on the values user provided
-            interaction_term = (
-                f"{self.group_variable_name}:{self.post_treatment_variable_name}"
+            matched_key = next(
+                (
+                    k
+                    for k in coef_map
+                    if self.post_treatment_variable_name in k
+                    and self.group_variable_name in k
+                ),
+                None,
             )
-            matched_key = next((k for k in coef_map if interaction_term in k), None)
             att = coef_map.get(matched_key) if matched_key is not None else None
             self.causal_impact = att
         else:

--- a/causalpy/tests/test_integration_skl_examples.py
+++ b/causalpy/tests/test_integration_skl_examples.py
@@ -52,6 +52,43 @@ def test_did(did_data):
 
 
 @pytest.mark.integration
+def test_did_causal_impact_order_independent_ols(did_data):
+    """
+    Regression test: causal_impact must not depend on which variable is
+    written first in the DiD interaction term.
+
+    Previously, DifferenceInDifferences.algorithm() looked up the OLS
+    interaction coefficient using a single concatenated substring
+    ("group:post_treatment"), which only matched patsy's column naming when
+    the formula wrote the group variable first. Writing the formula the
+    other way round (post_treatment*group) fit an identical model but
+    silently produced causal_impact=None instead of the real value.
+    """
+    data = did_data
+
+    result_group_first = cp.DifferenceInDifferences(
+        data.copy(),
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    result_post_first = cp.DifferenceInDifferences(
+        data.copy(),
+        formula="y ~ 1 + post_treatment*group",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    assert result_group_first.causal_impact is not None
+    assert result_post_first.causal_impact is not None
+    assert result_group_first.causal_impact == pytest.approx(
+        result_post_first.causal_impact
+    )
+
+
+@pytest.mark.integration
 def test_rd_drinking():
     """
     Test Regression Discontinuity scikit-learn experiment on drinking age data.


### PR DESCRIPTION
## Summary

`DifferenceInDifferences.algorithm()` looked up the OLS interaction coefficient by checking whether a single concatenated string (`"group:post_treatment"`) appeared in each coefficient label. `patsy` names the interaction column with whichever variable is written first in the formula, so writing `post_treatment*group` instead of `group*post_treatment` produced an identically-fitted model but a coefficient labeled `"post_treatment[T.True]:group"` — which the concatenated-string check silently failed to match, leaving `causal_impact` as `None` with no error or warning.

The Bayesian branch immediately above already matches by checking both variable names as independent substrings, which is order-independent. This PR makes the OLS branch do the same.

This is a follow-up to #993, which fixed a related but separate bug (missing validation when no interaction term exists at all). That PR is scoped to validation at construction time; this one fixes a silent incorrect result in the OLS causal-impact computation itself.

## Changes

- `causalpy/experiments/diff_in_diff.py`: OLS branch of `algorithm()` now matches the interaction coefficient by checking both the group and post-treatment variable names independently, instead of a single concatenated substring.
- `causalpy/tests/test_integration_skl_examples.py`: new regression test confirming `group*post_treatment` and `post_treatment*group` produce identical, non-`None` `causal_impact` values.

## Test plan

- [x] `make doctest` — 36 passed, 13 skipped
- [x] `make test-patch-cov` — full suite 1149 passed, 5 skipped (pre-existing/unrelated); patch coverage 100% on both changed files
- [x] `prek run` on changed files — all hooks pass (ruff, mypy, numpydoc-validation, etc.)
- [x] Manually verified: `post_treatment*group` (OLS) now returns the same `causal_impact` value as `group*post_treatment`, matching the Bayesian estimate for the same formula