### PR TITLE
Fix DiD interaction-term matching

### DIFF
--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -215,10 +215,7 @@ class DifferenceInDifferences(BaseExperiment):
         # INTERVENTION: set the interaction term between the group and the
         # post_treatment variable to zero. This is the counterfactual.
         for i, label in enumerate(self.labels):
-            if (
-                self.post_treatment_variable_name in label
-                and self.group_variable_name in label
-            ):
+            if self._is_treatment_interaction(label):
                 new_x.iloc[:, i] = 0
         self.y_pred_counterfactual = self._model_backend.predict(np.asarray(new_x))
 
@@ -228,30 +225,17 @@ class DifferenceInDifferences(BaseExperiment):
             # This is the coefficient on the interaction term
             coeff_names = self.model.idata.posterior.coords["coeffs"].data
             for i, label in enumerate(coeff_names):
-                if (
-                    self.post_treatment_variable_name in label
-                    and self.group_variable_name in label
-                ):
+                if self._is_treatment_interaction(label):
                     self.causal_impact = self.model.idata.posterior["beta"].isel(
                         {"coeffs": i}
                     )
         elif self._model_backend.is_ols:
-            # This is the coefficient on the interaction term. Match by checking
-            # both variable names independently (as the Bayesian branch above
-            # does), rather than a single concatenated substring, since patsy
-            # may name the interaction term with either variable first (e.g.
-            # "post_treatment[T.True]:group" if the formula writes
-            # "post_treatment*group" instead of "group*post_treatment").
+            # This is the coefficient on the interaction term
             coef_map = dict(
                 zip(self.labels, self._model_backend.coefficients(), strict=False)
             )
             matched_key = next(
-                (
-                    k
-                    for k in coef_map
-                    if self.post_treatment_variable_name in k
-                    and self.group_variable_name in k
-                ),
+                (key for key in coef_map if self._is_treatment_interaction(key)),
                 None,
             )
             att = coef_map.get(matched_key) if matched_key is not None else None
@@ -329,8 +313,7 @@ class DifferenceInDifferences(BaseExperiment):
         # term, or an interaction between unrelated variables, would pass
         # validation and only fail later when `causal_impact` is accessed.
         if len(interaction_terms) == 0 or not (
-            self.group_variable_name in interaction_terms[0]
-            and self.post_treatment_variable_name in interaction_terms[0]
+            self._is_treatment_interaction(interaction_terms[0])
         ):
             raise FormulaException(
                 "Formula must contain exactly one interaction term between the "
@@ -339,6 +322,20 @@ class DifferenceInDifferences(BaseExperiment):
                 f"(e.g. '{self.group_variable_name}*{self.post_treatment_variable_name}'). "
                 "This interaction term identifies the difference-in-differences causal effect."
             )
+
+    def _is_treatment_interaction(self, term: str) -> bool:
+        """Whether a term is exactly the group/post-treatment interaction."""
+        factors = {
+            factor.split("[", maxsplit=1)[0]
+            for factor in term.replace("*", ":").split(":")
+        }
+        return len(factors) == 2 and all(
+            any(factor in {name, f"C({name})"} for factor in factors)
+            for name in (
+                self.group_variable_name,
+                self.post_treatment_variable_name,
+            )
+        )
 
     def summary(self, round_to: int | None = 2) -> None:
         """Print summary of main results and model coefficients.

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -203,6 +203,80 @@ def test_did_validation_interaction_term_order_independent():
     assert result.causal_impact is not None
 
 
+def test_did_validation_rejects_substring_only_interaction(did_data):
+    """Variable-name substrings must not count as the required interaction."""
+    df = did_data.rename(columns={"group": "g", "post_treatment": "post"}).copy()
+    df["group"] = df["g"]
+    df["post_treatment"] = df["post"]
+
+    with pytest.raises(FormulaException):
+        cp.DifferenceInDifferences(
+            df,
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="g",
+            post_treatment_variable_name="post",
+            model=LinearRegression(),
+        )
+
+
+def test_did_exact_interaction_matching_preserves_categorical_wrapper(did_data):
+    """Exact matching still accepts patsy's categorical wrapper."""
+    df = did_data.rename(columns={"group": "g", "post_treatment": "post"}).copy()
+
+    result = cp.DifferenceInDifferences(
+        df,
+        formula="y ~ 1 + C(g)*post",
+        time_variable_name="t",
+        group_variable_name="g",
+        post_treatment_variable_name="post",
+        model=LinearRegression(),
+    )
+
+    assert result.causal_impact is not None
+
+
+def test_did_ols_matches_only_exact_interaction(did_data):
+    """OLS lookup and counterfactual construction use the exact interaction."""
+    df = did_data.rename(columns={"group": "g", "post_treatment": "post"}).copy()
+    df["g_post"] = np.arange(len(df))
+    df["y"] = (
+        1 + 2 * df["g"] + 3 * df["post"] + 4 * df["g"] * df["post"] + 5 * df["g_post"]
+    )
+
+    result = cp.DifferenceInDifferences(
+        df,
+        formula="y ~ 1 + post*g + g_post",
+        time_variable_name="t",
+        group_variable_name="g",
+        post_treatment_variable_name="post",
+        model=LinearRegression(),
+    )
+
+    assert result.causal_impact == pytest.approx(4)
+    expected_counterfactual = (
+        1 + 2 + 3 + 5 * result.x_pred_counterfactual["g_post"].to_numpy()
+    )
+    np.testing.assert_allclose(result.y_pred_counterfactual, expected_counterfactual)
+
+
+def test_did_bayesian_matches_only_exact_interaction(mock_pymc_sample, did_data):
+    """Bayesian lookup must not confuse a similarly named main effect."""
+    df = did_data.rename(columns={"group": "g", "post_treatment": "post"}).copy()
+    df["g_post"] = np.arange(len(df))
+
+    result = cp.DifferenceInDifferences(
+        df,
+        formula="y ~ 1 + post*g + g_post",
+        time_variable_name="t",
+        group_variable_name="g",
+        post_treatment_variable_name="post",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    assert result.causal_impact.coords["coeffs"].item() == "post[T.True]:g"
+
+
 def test_did_validation_post_treatment_data():
     """Test that we get a DataException if do not include post_treatment in the data"""
     df = pd.DataFrame(


### PR DESCRIPTION
## Summary
- match DiD interaction factors exactly instead of using variable-name substrings
- use the same order-independent matcher for formula validation, counterfactual construction, and PyMC/sklearn coefficient lookup
- preserve Patsy categorical labels while avoiding similarly named main effects

Closes #995

## Test plan
- [x] `python -m pytest causalpy/tests/test_input_validation.py -k did --no-cov -q`
- [x] DiD sklearn and PyMC integration tests
- [x] `make test-patch-cov` (1153 passed, 5 skipped; 100% diff coverage)
- [x] `prek run --all-files`

Made with [Cursor](https://cursor.com)