### PR TITLE
Use Patsy response vectors for transformed formula LHS

### DIFF
--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -17,7 +17,7 @@ import warnings  # noqa: I001
 
 import numpy as np
 import pandas as pd
-from patsy import dmatrices
+from patsy import PatsyError, dmatrices
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 import arviz as az
@@ -142,8 +142,8 @@ class InstrumentalVariable(BaseExperiment):
         self.vs_hyperparams = vs_hyperparams or {}
         self.binary_treatment = binary_treatment
         self.use_vs_prior_outcome = self.vs_hyperparams.get("outcome", False)
-        self.input_validation()
         self._build_design_matrices()
+        self.input_validation()
 
         # Store user-provided priors (will set defaults in algorithm() if None)
         self.priors = priors
@@ -152,14 +152,18 @@ class InstrumentalVariable(BaseExperiment):
 
     def _build_design_matrices(self) -> None:
         """Build design matrices for outcome and instrument formulas."""
-        y, X = dmatrices(self.formula, self.data)
+        try:
+            y, X = dmatrices(self.formula, self.data)
+            t, Z = dmatrices(self.instruments_formula, self.instruments_data)
+        except PatsyError as err:
+            raise DataException(f"Unable to evaluate IV formula: {err}") from err
+
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info
         self.labels = X.design_info.column_names
         self.y, self.X = np.asarray(y), np.asarray(X)
         self.outcome_variable_name = y.design_info.column_names[0]
 
-        t, Z = dmatrices(self.instruments_formula, self.instruments_data)
         self._t_design_info = t.design_info
         self._z_design_info = Z.design_info
         self.labels_instruments = Z.design_info.column_names
@@ -206,19 +210,25 @@ class InstrumentalVariable(BaseExperiment):
 
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness."""
-        treatment = self.instruments_formula.split("~")[0]
-        test = treatment.strip() in self.instruments_data.columns
-        test = test & (treatment.strip() in self.data.columns)
-        if not test:
+        if self.instrument_variable_name not in self._x_design_info.term_name_slices:
             raise DataException(
-                f"""
-                The treatment variable:
-                {treatment} must appear in the instrument_data to be used
-                as an outcome variable and in the data object to be used as a covariate.
-                """
+                f"Treatment term '{self.instrument_variable_name}' from the instrument "
+                "formula must also appear in the outcome formula."
             )
-        Z = self.data[treatment.strip()]
-        check_binary = len(np.unique(Z)) > 2
+
+        if self.instrument_variable_name not in self.data.columns:
+            treatment_factor = next(iter(self._t_design_info.terms[0].factors))
+            # ponytail: transformed-treatment interactions need factor-level design
+            # reconstruction; add it only when that use case is required.
+            if any(
+                treatment_factor in term.factors and len(term.factors) > 1
+                for term in self._x_design_info.terms
+            ):
+                raise DataException(
+                    "Interactions with a transformed IV treatment are not supported."
+                )
+
+        check_binary = len(np.unique(self.t)) > 2
         if check_binary:
             warnings.warn(
                 """Warning. The treatment variable is not Binary.
@@ -235,9 +245,17 @@ class InstrumentalVariable(BaseExperiment):
         """
         first_stage_reg = sk_lin_reg().fit(self.Z, self.t)
         fitted_Z_values = first_stage_reg.predict(self.Z)
-        X2 = self.data.copy(deep=True)
-        X2[self.instrument_variable_name] = fitted_Z_values
-        _, X2 = dmatrices(self.formula, X2)
+        if self.instrument_variable_name in self.data.columns:
+            second_stage_data = self.data.copy(deep=True)
+            second_stage_data[self.instrument_variable_name] = fitted_Z_values
+            _, X2 = dmatrices(self.formula, second_stage_data)
+            X2 = np.asarray(X2)
+        else:
+            X2 = self.X.copy()
+            treatment_slice = self._x_design_info.term_name_slices[
+                self.instrument_variable_name
+            ]
+            X2[:, treatment_slice] = fitted_Z_values
         second_stage_reg = sk_lin_reg().fit(X=X2, y=self.y)
         betas_first = list(first_stage_reg.coef_[0][1:])
         betas_first.insert(0, first_stage_reg.intercept_[0])

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -21,7 +21,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.lines import Line2D
-from patsy import dmatrices
+from patsy import PatsyError, dmatrices
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 from causalpy.custom_exceptions import DataException
@@ -92,8 +92,8 @@ class InversePropensityWeighting(BaseExperiment):
         self.formula = formula
         self.outcome_variable = outcome_variable
         self.weighting_scheme = weighting_scheme
-        self.input_validation()
         self._build_design_matrices()
+        self.input_validation()
         self.algorithm()
 
     def _build_design_matrices(self) -> None:
@@ -104,7 +104,12 @@ class InversePropensityWeighting(BaseExperiment):
         design matrix (``self.X_outcome``) that includes the treatment indicator,
         for use with doubly-robust outcome modelling.
         """
-        t, X = dmatrices(self.formula, self.data)
+        try:
+            t, X = dmatrices(self.formula, self.data)
+        except PatsyError as err:
+            raise DataException(
+                f"Unable to evaluate propensity formula: {err}"
+            ) from err
         self._t_design_info = t.design_info
         self._x_design_info = X.design_info
         self.labels = X.design_info.column_names
@@ -128,37 +133,25 @@ class InversePropensityWeighting(BaseExperiment):
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness.
 
-        Checks that both the treatment variable (left-hand side of the formula)
-        and the ``outcome_variable`` exist in ``self.data``, and that the
-        treatment variable has at most two unique values.  Note that a
-        constant (single-value) treatment passes this check without error
-        but may cause downstream estimators to fail or produce undefined
-        results.
+        Checks that the ``outcome_variable`` exists in ``self.data`` and that
+        the treatment values produced by the formula are binary. Note that a
+        constant (single-value) treatment passes this check without error but
+        may cause downstream estimators to fail or produce undefined results.
 
         Raises
         ------
         DataException
-            If the treatment or outcome variable is missing from the data,
-            or if the treatment variable has more than two unique values.
+            If the outcome variable is missing from the data or if the
+            formula produces treatment values other than zero and one.
         """
-        treatment = self.formula.split("~")[0]
-        test = treatment.strip() in self.data.columns
-        test = test & (self.outcome_variable in self.data.columns)
-        if not test:
+        if self.outcome_variable not in self.data.columns:
             raise DataException(
-                f"""
-                The treatment variable:
-                {treatment} must appear in the data to be used
-                as an outcome variable. And {self.outcome_variable}
-                must also be available in the data to be re-weighted
-                """
+                f"Outcome variable '{self.outcome_variable}' must be available "
+                "in the data to be re-weighted."
             )
-        T = self.data[treatment.strip()]
-        check_binary = len(np.unique(T)) > 2
-        if check_binary:
+        if not set(np.unique(self.t)).issubset({0, 1}):
             raise DataException(
-                """Warning. The treatment variable is not 0-1 Binary.
-                """
+                "The treatment values produced by the formula must be 0-1 binary."
             )
 
     def _prepare_ps(self, ps: np.ndarray, eps: float = 1e-6) -> np.ndarray:

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -1306,7 +1306,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         lower_pct = (1 - hdi_prob) / 2 * 100
         upper_pct = (1 + hdi_prob) / 2 * 100
         mu_draws = self.y_pred["posterior_predictive"].mu.isel(treated_units=0)
-        y_observed = np.asarray(self.data[self.outcome_variable_name].values)
+        y_observed = self._observed_outcome.to_numpy()
         tau_draws_all = y_observed - mu_draws.values
 
         att_gt_rows: list[dict[str, Any]] = []
@@ -1336,7 +1336,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             return pd.DataFrame()
 
         pretreatment_data["tau_hat"] = (
-            pretreatment_data[self.outcome_variable_name] - pretreatment_data["y_hat0"]
+            self._observed_outcome.loc[pretreatment_data.index].to_numpy()
+            - pretreatment_data["y_hat0"].to_numpy()
         )
         att_gt = (
             pretreatment_data.groupby(["G", self.time_variable_name])["tau_hat"]
@@ -1518,7 +1519,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         mu_draws = self.y_pred["posterior_predictive"].mu.isel(treated_units=0)
 
         # Get observed y for all observations
-        y_observed = np.asarray(self.data[self.outcome_variable_name].values)
+        y_observed = self._observed_outcome.to_numpy()
 
         # Compute tau draws for all observations
         tau_draws_all = y_observed - mu_draws.values

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -25,7 +25,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import dmatrices
+from patsy import PatsyError, dmatrices
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
@@ -246,13 +246,6 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 "Either provide treated_variable_name or treatment_time_variable_name."
             )
 
-        # Validate formula contains outcome variable
-        outcome_match = self.formula.split("~")[0].strip()
-        if outcome_match not in self.data.columns:
-            raise FormulaException(
-                f"Outcome variable '{outcome_match}' from formula not found in data"
-            )
-
         # Validate absorbing treatment (once treated, always treated)
         self._validate_absorbing_treatment()
 
@@ -425,7 +418,10 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
     def _build_design_matrices(self) -> None:
         """Build design matrices using patsy."""
         # Build design matrix for the full data
-        y, X = dmatrices(self.formula, self.data)
+        try:
+            y, X = dmatrices(self.formula, self.data)
+        except PatsyError as err:
+            raise FormulaException(f"Unable to evaluate formula: {err}") from err
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info
         self.labels = X.design_info.column_names
@@ -434,6 +430,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         # Store full design matrix
         self.X_full = np.asarray(X)
         self.y_full = np.asarray(y)
+        self._observed_outcome = pd.Series(self.y_full.ravel(), index=self.data.index)
 
         # Get untreated subset for training
         untreated_mask = np.asarray(self.data["_is_untreated"].values, dtype=bool)
@@ -491,7 +488,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         self.data["tau_hat"] = np.nan  # Initialize with NaN
         treated_mask = ~self.data["_is_untreated"]
         self.data.loc[treated_mask, "tau_hat"] = (
-            self.data.loc[treated_mask, self.outcome_variable_name]
+            self._observed_outcome.loc[treated_mask]
             - self.data.loc[treated_mask, "y_hat0"]
         )
 
@@ -556,7 +553,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         mu_draws = self.y_pred["posterior_predictive"].mu.isel(treated_units=0)
 
         # Get observed y for all observations
-        y_observed = np.asarray(self.data[self.outcome_variable_name].values)
+        y_observed = self._observed_outcome.to_numpy()
 
         # Compute tau draws for all observations
         # tau_draws has shape (chain, draw, obs_ind)
@@ -684,8 +681,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         if len(pretreatment_data) > 0:
             pretreatment_data = pretreatment_data.copy()
             pretreatment_data["tau_hat"] = (
-                pretreatment_data[self.outcome_variable_name]
-                - pretreatment_data["y_hat0"]
+                self._observed_outcome.loc[pretreatment_data.index].to_numpy()
+                - pretreatment_data["y_hat0"].to_numpy()
             )
 
         # Combine pre-treatment and post-treatment for event-time aggregation

--- a/causalpy/tests/test_instrumental_variable.py
+++ b/causalpy/tests/test_instrumental_variable.py
@@ -249,6 +249,47 @@ def test_iv_continuous_treatment_warning(iv_data, sample_kwargs):
         )
 
 
+def test_iv_accepts_transformed_treatment_lhs(mock_pymc_sample, sample_kwargs):
+    """The parsed first-stage treatment is used throughout IV fitting."""
+    Z = np.linspace(0.1, 1, 20)
+    X = np.exp(1 + 2 * Z)
+    y = 3 * np.log(X)
+    df = pd.DataFrame({"y": y, "X": X, "Z": Z})
+
+    with pytest.warns(UserWarning, match="treatment variable is not Binary"):
+        result = cp.InstrumentalVariable(
+            instruments_data=df[["X", "Z"]],
+            data=df[["y", "X"]],
+            instruments_formula="np.log(X) ~ 1 + Z",
+            formula="y ~ 1 + np.log(X)",
+            model=cp.pymc_models.InstrumentalVariableRegression(
+                sample_kwargs=sample_kwargs
+            ),
+        )
+
+    np.testing.assert_allclose(result.t.ravel(), np.log(X))
+    assert result.instrument_variable_name == "np.log(X)"
+    assert hasattr(result, "second_stage_reg")
+
+
+def test_iv_rejects_interaction_with_transformed_treatment(sample_kwargs):
+    """Unsupported transformed-treatment interactions fail before fitting."""
+    Z = np.linspace(0.1, 1, 20)
+    X = np.exp(1 + 2 * Z)
+    df = pd.DataFrame({"y": 3 * np.log(X), "X": X, "Z": Z})
+
+    with pytest.raises(DataException, match="Interactions with a transformed"):
+        cp.InstrumentalVariable(
+            instruments_data=df[["X", "Z"]],
+            data=df,
+            instruments_formula="np.log(X) ~ 1 + Z",
+            formula="y ~ 1 + np.log(X)*Z",
+            model=cp.pymc_models.InstrumentalVariableRegression(
+                sample_kwargs=sample_kwargs
+            ),
+        )
+
+
 # =============================================================================
 # Test Binary Treatment
 # =============================================================================

--- a/causalpy/tests/test_ipw_get_ate.py
+++ b/causalpy/tests/test_ipw_get_ate.py
@@ -23,6 +23,7 @@ import numpy as np
 import pytest
 
 import causalpy as cp
+from causalpy.custom_exceptions import DataException
 
 
 @pytest.fixture(scope="module")
@@ -54,6 +55,48 @@ def ipw_result(mock_pymc_sample):
 def propensity_scores(ipw_result):
     """Extract propensity scores from the first posterior sample."""
     return ipw_result.idata["posterior"]["p"].stack(z=("chain", "draw"))[:, 0].values
+
+
+def test_ipw_accepts_binary_transformed_treatment(mock_pymc_sample):
+    """IPW validates and fits the treatment vector produced by Patsy."""
+    df = cp.load_data("nhefs")
+    result = cp.InversePropensityWeighting(
+        df,
+        formula="I(1 - trt) ~ 1 + age + race",
+        outcome_variable="outcome",
+        weighting_scheme="robust",
+        model=cp.pymc_models.PropensityScore(
+            sample_kwargs={"tune": 5, "draws": 5, "chains": 1}
+        ),
+    )
+
+    np.testing.assert_array_equal(result.t.ravel(), 1 - df["trt"].to_numpy())
+
+
+def test_ipw_rejects_nonbinary_transformed_treatment():
+    """A transformed LHS must still satisfy the Bernoulli model's 0/1 contract."""
+    df = cp.load_data("nhefs")
+
+    with pytest.raises(DataException, match="0-1 binary"):
+        cp.InversePropensityWeighting(
+            df,
+            formula="center(trt) ~ 1 + age + race",
+            outcome_variable="outcome",
+            weighting_scheme="robust",
+        )
+
+
+def test_ipw_missing_treatment_expression_raises_data_exception():
+    """Missing formula inputs retain a CausalPy validation error."""
+    df = cp.load_data("nhefs")
+
+    with pytest.raises(DataException, match="Unable to evaluate propensity formula"):
+        cp.InversePropensityWeighting(
+            df,
+            formula="missing_treatment ~ 1 + age + race",
+            outcome_variable="outcome",
+            weighting_scheme="robust",
+        )
 
 
 class TestComputeAteRobust:

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -302,6 +302,29 @@ def test_staggered_did_accepts_transformed_outcome():
     )
     assert result.outcome_variable_name == "np.log(positive_y)"
     assert result.data_["tau_hat"].notna().any()
+    assert not result._get_group_time_placebo_data().empty
+
+
+def test_staggered_did_bayesian_plot_data_accepts_transformed_outcome(
+    mock_pymc_sample,
+):
+    """Bayesian placebo and plotting paths use Patsy's observed response."""
+    df = generate_staggered_did_data(
+        n_units=10, n_time_periods=8, treatment_cohorts={4: 5}, seed=42
+    )
+    df["positive_y"] = np.exp(df["y"] / 10)
+
+    result = cp.StaggeredDifferenceInDifferences(
+        df,
+        formula="np.log(positive_y) ~ 1 + C(unit) + C(time)",
+        unit_variable_name="unit",
+        time_variable_name="time",
+        treated_variable_name="treated",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    assert not result._get_group_time_placebo_data().empty
+    assert not result.get_plot_data_bayesian(hdi_prob=0.8).empty
 
 
 # ==============================================================================

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -281,6 +281,29 @@ def test_staggered_did_formula_missing_outcome():
         )
 
 
+def test_staggered_did_accepts_transformed_outcome():
+    """Treatment effects use the outcome vector evaluated by Patsy."""
+    df = generate_staggered_did_data(
+        n_units=10, n_time_periods=8, treatment_cohorts={4: 5}, seed=42
+    )
+    df["positive_y"] = np.exp(df["y"] / 10)
+
+    result = cp.StaggeredDifferenceInDifferences(
+        df,
+        formula="np.log(positive_y) ~ 1 + C(unit) + C(time)",
+        unit_variable_name="unit",
+        time_variable_name="time",
+        treated_variable_name="treated",
+        model=LinearRegression(),
+    )
+
+    np.testing.assert_allclose(
+        result._observed_outcome.to_numpy(), np.log(df["positive_y"])
+    )
+    assert result.outcome_variable_name == "np.log(positive_y)"
+    assert result.data_["tau_hat"].notna().any()
+
+
 # ==============================================================================
 # Unit Tests - Core Functionality
 # ==============================================================================


### PR DESCRIPTION
## Summary
- evaluate IV and IPW treatment responses with Patsy before validating them, preserving clear CausalPy errors for invalid formulas
- use Patsy's transformed IV response in 2SLS and the transformed staggered-DiD outcome across ATT, placebo, and plotting paths
- keep IPW's Bernoulli treatment contract explicit: binary-preserving transforms are supported, while transforms such as `center(trt)` remain invalid

## Test plan
- [x] `python -m pytest causalpy/tests/test_instrumental_variable.py causalpy/tests/test_ipw_get_ate.py causalpy/tests/test_staggered_did.py --no-cov -q`
- [x] `prek run --all-files`
- [x] `make test-patch-cov` (1168 passed, 5 skipped; 100% diff coverage)

Closes #997