### PR TITLE
Validate exact treated predictors in RD and RK

### DIFF
--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -13,14 +13,15 @@
 #   limitations under the License.
 """Regression discontinuity design."""
 
-import warnings  # noqa: I001
+import re  # noqa: I001
+import warnings
 from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
-from patsy import build_design_matrices, dmatrices
+from patsy import ModelDesc, build_design_matrices, dmatrices
 from sklearn.base import RegressorMixin
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
@@ -235,9 +236,18 @@ class RegressionDiscontinuity(BaseExperiment):
 
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness."""
-        if "treated" not in self.formula:
+        if not any(
+            re.search(r"\btreated\b", factor.name())
+            for term in ModelDesc.from_formula(self.formula).rhs_termlist
+            for factor in term.factors
+        ):
             raise FormulaException(
-                "A predictor called `treated` should be in the formula"
+                "A predictor called `treated` should be in the formula RHS"
+            )
+
+        if "treated" not in self.data.columns:
+            raise DataException(
+                "A dummy-coded `treated` column should be present in the data"
             )
 
         if not _is_variable_dummy_coded(self.data["treated"]):

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -14,14 +14,15 @@
 
 """Regression kink design."""
 
-import warnings  # noqa: I001
+import re  # noqa: I001
+import warnings
 
 
 from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from patsy import build_design_matrices, dmatrices
+from patsy import ModelDesc, build_design_matrices, dmatrices
 import xarray as xr
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
@@ -161,9 +162,18 @@ class RegressionKink(BaseExperiment):
 
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness."""
-        if "treated" not in self.formula:
+        if not any(
+            re.search(r"\btreated\b", factor.name())
+            for term in ModelDesc.from_formula(self.formula).rhs_termlist
+            for factor in term.factors
+        ):
             raise FormulaException(
-                "A predictor called `treated` should be in the formula"
+                "A predictor called `treated` should be in the formula RHS"
+            )
+
+        if "treated" not in self.data.columns:
+            raise DataException(
+                "A dummy-coded `treated` column should be present in the data"
             )
 
         if not _is_variable_dummy_coded(self.data["treated"]):

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -558,6 +558,36 @@ def test_rd_validation_treated_is_dummy():
         )
 
 
+@pytest.mark.parametrize(
+    ("experiment", "threshold_argument"),
+    [
+        (cp.RegressionDiscontinuity, "treatment_threshold"),
+        (cp.RegressionKink, "kink_point"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("formula", "extra_columns", "exception"),
+    [
+        ("y ~ 1 + x + untreated", {"untreated": [0, 0, 1, 1]}, FormulaException),
+        ("treated ~ 1 + x", {"treated": [0, 0, 1, 1]}, FormulaException),
+        ("y ~ 1 + x + treated", {}, DataException),
+    ],
+)
+def test_rd_rk_validation_requires_treated_rhs_column(
+    experiment, threshold_argument, formula, extra_columns, exception
+):
+    """The exact treated column must exist and be referenced on the RHS."""
+    df = pd.DataFrame({"x": [0, 1, 2, 3], "y": [1, 1, 2, 2], **extra_columns})
+
+    with pytest.raises(exception):
+        experiment(
+            df,
+            formula=formula,
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+            **{threshold_argument: 0.5},
+        )
+
+
 def test_iv_treatment_var_is_present():
     """Test the treatment variable is present for Instrumental Variable experiment"""
     data = pd.DataFrame({"x": [1, 2, 3], "y": [2, 4, 5]})


### PR DESCRIPTION
## Summary
- parse Patsy's RHS factors instead of searching the full formula for the `treated` substring
- require the literal dummy-coded `treated` data column used by RD/RK prediction frames
- reject similarly named predictors, an outcome-only `treated`, and missing backing columns with clear CausalPy exceptions

## Test plan
- [x] RD/RK validation and integration tests
- [x] `prek run --all-files`
- [x] `make test-patch-cov` (1174 passed, 5 skipped; 100% diff coverage)

Closes #998

Made with [Cursor](https://cursor.com)