### PR TITLE
Classify panel fixed effects with Patsy metadata

### DIFF
--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 """Panel Regression with Fixed Effects."""
 
+import re
 from typing import Any, Literal
 
 import arviz as az
@@ -20,7 +21,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.gridspec import GridSpec
-from patsy import dmatrices
+from patsy import ModelDesc, dmatrices
 from scipy import stats
 from sklearn.base import RegressorMixin
 
@@ -236,25 +237,43 @@ class PanelRegression(BaseExperiment):
                 "fe_method must be 'dummies' (unpooled fixed effects) or 'demeaned'"
             )
 
-        # Check if formula includes C(unit_var) or C(time_var) when using demeaned method
-        if (
-            self.fe_method == "demeaned"
-            and f"C({self.unit_fe_variable})" in self.formula
-        ):
-            raise ValueError(
-                f"When using fe_method='demeaned', do not include C({self.unit_fe_variable}) "
-                "in the formula. The demeaned transformation handles unit fixed effects automatically."
-            )
+        if self.fe_method == "demeaned":
+            rhs_terms = ModelDesc.from_formula(self.formula).rhs_termlist
+            for variable, effect_type in (
+                (self.unit_fe_variable, "unit"),
+                (self.time_fe_variable, "time"),
+            ):
+                if variable and any(
+                    self._is_fe_factor(factor.name(), variable)
+                    for term in rhs_terms
+                    for factor in term.factors
+                ):
+                    raise ValueError(
+                        f"When using fe_method='demeaned', do not include C({variable}) "
+                        f"in the formula. The demeaned transformation handles {effect_type} "
+                        "fixed effects automatically."
+                    )
 
-        if (
-            self.fe_method == "demeaned"
-            and self.time_fe_variable
-            and f"C({self.time_fe_variable})" in self.formula
-        ):
-            raise ValueError(
-                f"When using fe_method='demeaned', do not include C({self.time_fe_variable}) "
-                "in the formula. The demeaned transformation handles time fixed effects automatically."
+    @staticmethod
+    def _is_fe_factor(factor_name: str, variable: str) -> bool:
+        """Whether a Patsy factor categorically encodes the given variable."""
+        return (
+            re.match(
+                rf"^C\(\s*{re.escape(variable)}\s*(?:,|\))",
+                factor_name,
             )
+            is not None
+        )
+
+    def _get_fe_labels(self, variable: str) -> list[str]:
+        """Return labels belonging to the variable's plain fixed-effect term."""
+        labels: list[str] = []
+        for term in self._x_design_info.terms:
+            if len(term.factors) == 1 and self._is_fe_factor(
+                term.factors[0].name(), variable
+            ):
+                labels.extend(self.labels[self._x_design_info.term_slices[term]])
+        return labels
 
     def _build_design_matrices(self) -> None:
         """Build design matrices from formula and data using patsy.
@@ -376,17 +395,10 @@ class PanelRegression(BaseExperiment):
         """
         coeff_labels = self.labels.copy()
         if self.fe_method == "dummies":
-            coeff_labels = [
-                c
-                for c in coeff_labels
-                if not c.startswith(f"C({self.unit_fe_variable})")
-            ]
+            fe_labels = set(self._get_fe_labels(self.unit_fe_variable))
             if self.time_fe_variable:
-                coeff_labels = [
-                    c
-                    for c in coeff_labels
-                    if not c.startswith(f"C({self.time_fe_variable})")
-                ]
+                fe_labels.update(self._get_fe_labels(self.time_fe_variable))
+            coeff_labels = [label for label in coeff_labels if label not in fe_labels]
         return coeff_labels
 
     def summary(self, round_to: int | None = None) -> None:
@@ -742,9 +754,7 @@ class PanelRegression(BaseExperiment):
             )
 
         # Extract unit fixed effects from coefficients
-        unit_fe_names = [
-            c for c in self.labels if c.startswith(f"C({self.unit_fe_variable})")
-        ]
+        unit_fe_names = self._get_fe_labels(self.unit_fe_variable)
 
         if not unit_fe_names:
             raise ValueError("No unit fixed effects found in model coefficients")

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -244,9 +244,9 @@ class PanelRegression(BaseExperiment):
                 (self.time_fe_variable, "time"),
             ):
                 if variable and any(
-                    self._is_fe_factor(factor.name(), variable)
+                    len(term.factors) == 1
+                    and self._is_fe_factor(term.factors[0].name(), variable)
                     for term in rhs_terms
-                    for factor in term.factors
                 ):
                     raise ValueError(
                         f"When using fe_method='demeaned', do not include C({variable}) "

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -267,6 +267,69 @@ def test_panel_regression_validation_errors(small_panel_data):
         )
 
 
+@pytest.mark.parametrize(
+    ("formula", "variable"),
+    [
+        ("y ~ C( unit ) + treatment + x1", "unit"),
+        ("y ~ C(unit, Treatment) + treatment + x1", "unit"),
+        ("y ~ C( time ) + treatment + x1", "time"),
+        ("y ~ C(time, Sum) + treatment + x1", "time"),
+    ],
+)
+def test_demeaned_rejects_patsy_fe_variants(small_panel_data, formula, variable):
+    """Whitespace and coding options must not bypass the demeaned FE guard."""
+    with pytest.raises(ValueError, match=rf"do not include C\({variable}\)"):
+        cp.PanelRegression(
+            data=small_panel_data,
+            formula=formula,
+            unit_fe_variable="unit",
+            time_fe_variable="time",
+            fe_method="demeaned",
+            model=LinearRegression(),
+        )
+
+
+def test_dummy_fe_labels_follow_patsy_term_metadata(small_panel_data):
+    """FE labels with whitespace or coding options are hidden and plottable."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C( unit ) + C(time, Sum) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=LinearRegression(),
+    )
+
+    fe_labels = set(result._get_fe_labels("unit"))
+    fe_labels.update(result._get_fe_labels("time"))
+    assert fe_labels
+    assert fe_labels.isdisjoint(result._get_non_fe_labels())
+
+    fig, _ = result.plot_unit_effects()
+    plt.close(fig)
+
+
+def test_interaction_labels_are_not_plain_fixed_effects(small_panel_data, capsys):
+    """Unit interactions remain visible and are excluded from FE plots."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit) + C(unit):treatment + x1",
+        unit_fe_variable="unit",
+        fe_method="dummies",
+        model=LinearRegression(),
+    )
+
+    unit_fe_labels = set(result._get_fe_labels("unit"))
+    interaction_labels = {label for label in result.labels if ":" in label}
+    assert interaction_labels
+    assert unit_fe_labels.isdisjoint(interaction_labels)
+    assert interaction_labels.issubset(result._get_non_fe_labels())
+
+    result.summary()
+    summary = capsys.readouterr().out
+    assert all(label in summary for label in interaction_labels)
+
+
 @pytest.mark.integration
 def test_panel_regression_plot_coefficients(mock_pymc_sample, small_panel_data):
     """Test plot_coefficients method."""

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -289,6 +289,19 @@ def test_demeaned_rejects_patsy_fe_variants(small_panel_data, formula, variable)
         )
 
 
+def test_demeaned_allows_unit_interaction_without_plain_fe(small_panel_data):
+    """A unit-specific slope is not a duplicate fixed-effect intercept."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit):treatment + x1",
+        unit_fe_variable="unit",
+        fe_method="demeaned",
+        model=LinearRegression(),
+    )
+
+    assert any("C(unit)" in label and ":treatment" in label for label in result.labels)
+
+
 def test_dummy_fe_labels_follow_patsy_term_metadata(small_panel_data):
     """FE labels with whitespace or coding options are hidden and plottable."""
     result = cp.PanelRegression(


### PR DESCRIPTION
## Summary
- detect unit and time fixed-effect factors semantically for demeaned-formula validation, including whitespace and contrast options
- derive plain FE coefficient labels from Patsy's term slices instead of reconstructed label prefixes
- keep substantive FE interaction coefficients visible in summaries, out of unit-effect plots, and valid as interaction-only terms under demeaning

## Test plan
- [x] `python -m pytest causalpy/tests/test_panel_regression.py --no-cov -q`
- [x] `prek run --all-files`
- [x] `make test-patch-cov` (1181 passed, 5 skipped; 100% diff coverage)

Closes #999