### PR TITLE
Treat datetime formula predictors as continuous

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -75,7 +75,7 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 
 | Topic | Detail |
 |-------|--------|
-| **Formulas** | Patsy `dmatrices()` for design matrices; `build_design_matrices()` for counterfactual prediction. `PiecewiseITS` uses `step()`/`ramp()` stateful transforms. |
+| **Formulas** | Patsy `dmatrices()` for design matrices; `build_design_matrices()` for counterfactual prediction. Bare datetime predictors are encoded as continuous elapsed days from the fitted origin; use `C(date)` for date fixed effects. `PiecewiseITS` uses `step()`/`ramp()` stateful transforms. |
 | **obs_ind** | All experiments set `data.index.name = "obs_ind"`. Canonical xarray/PyMC dimension name. |
 | **treated_units always 2D** | Even single-unit experiments use `treated_units=["unit_0"]`. Never pass 1D y to PyMC. |
 | **Impact uses mu, not y_hat** | `calculate_impact()` subtracts posterior `mu` (expected value), not `y_hat` (with observation noise). |

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -22,7 +22,7 @@ import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import ModelDesc, build_design_matrices, dmatrices
+from patsy import ModelDesc, build_design_matrices
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
@@ -31,6 +31,7 @@ from causalpy.custom_exceptions import (
     FormulaException,
 )
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (
@@ -128,7 +129,7 @@ class DifferenceInDifferences(BaseExperiment):
 
     def _build_design_matrices(self) -> None:
         """Build design matrices from formula and data using patsy."""
-        y, X = dmatrices(self.formula, self.data)
+        y, X = build_formula_matrices(self.formula, self.data)
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info
         self.labels = X.design_info.column_names

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -17,13 +17,14 @@ import warnings  # noqa: I001
 
 import numpy as np
 import pandas as pd
-from patsy import PatsyError, dmatrices
+from patsy import PatsyError
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 import arviz as az
 
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.pymc_models import InstrumentalVariableRegression
 from causalpy.utils import round_num
 
@@ -153,8 +154,10 @@ class InstrumentalVariable(BaseExperiment):
     def _build_design_matrices(self) -> None:
         """Build design matrices for outcome and instrument formulas."""
         try:
-            y, X = dmatrices(self.formula, self.data)
-            t, Z = dmatrices(self.instruments_formula, self.instruments_data)
+            y, X = build_formula_matrices(self.formula, self.data)
+            t, Z = build_formula_matrices(
+                self.instruments_formula, self.instruments_data
+            )
         except PatsyError as err:
             raise DataException(f"Unable to evaluate IV formula: {err}") from err
 
@@ -248,7 +251,7 @@ class InstrumentalVariable(BaseExperiment):
         if self.instrument_variable_name in self.data.columns:
             second_stage_data = self.data.copy(deep=True)
             second_stage_data[self.instrument_variable_name] = fitted_Z_values
-            _, X2 = dmatrices(self.formula, second_stage_data)
+            _, X2 = build_formula_matrices(self.formula, second_stage_data)
             X2 = np.asarray(X2)
         else:
             X2 = self.X.copy()

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -21,13 +21,14 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import build_design_matrices, dmatrices
+from patsy import build_design_matrices
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     get_hdi_to_df,
@@ -165,7 +166,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
     def _build_design_matrices(self) -> None:
         """Build design matrices for pre and post intervention periods using patsy."""
-        y, X = dmatrices(self.formula, self.datapre)
+        y, X = build_formula_matrices(self.formula, self.datapre)
         self.outcome_variable_name = y.design_info.column_names[0]
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -21,10 +21,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.lines import Line2D
-from patsy import PatsyError, dmatrices
+from patsy import PatsyError
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 from causalpy.custom_exceptions import DataException
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.pymc_models import PropensityScore
 from causalpy.reporting import EffectSummary
 
@@ -105,7 +106,7 @@ class InversePropensityWeighting(BaseExperiment):
         for use with doubly-robust outcome modelling.
         """
         try:
-            t, X = dmatrices(self.formula, self.data)
+            t, X = build_formula_matrices(self.formula, self.data)
         except PatsyError as err:
             raise DataException(
                 f"Unable to evaluate propensity formula: {err}"

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -21,13 +21,14 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from matplotlib.gridspec import GridSpec
-from patsy import ModelDesc, dmatrices
+from patsy import ModelDesc
 from scipy import stats
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import round_num
@@ -292,7 +293,7 @@ class PanelRegression(BaseExperiment):
                 # (single-pass is exact only for balanced; see docstring Notes).
                 data = self._demean_transform(data, self.time_fe_variable)
 
-        y, X = dmatrices(self.formula, data)
+        y, X = build_formula_matrices(self.formula, data)
         self.outcome_variable_name = y.design_info.column_names[0]
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -23,12 +23,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import ModelDesc, dmatrices
+from patsy import ModelDesc
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -92,6 +93,9 @@ class PiecewiseITS(BaseExperiment):
     The `step` and `ramp` transforms are patsy stateful transforms that handle
     both numeric and datetime time columns. For datetime, thresholds can be
     specified as strings (e.g., '2020-06-01') or pd.Timestamp objects.
+
+    Bare datetime predictors are represented as continuous elapsed days. Use
+    ``C(date)`` when date fixed effects are intended instead.
 
     References
     ----------
@@ -174,8 +178,8 @@ class PiecewiseITS(BaseExperiment):
             self._step_ramp_terms, self.time_col
         )
 
-        # Parse formula with patsy (step and ramp are available in namespace)
-        y, X = dmatrices(formula, self.data)
+        # Parse formula with datetime-aware Patsy handling.
+        y, X = build_formula_matrices(formula, self.data)
         self.outcome_variable_name = y.design_info.column_names[0]
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -22,13 +22,14 @@ import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import build_design_matrices, dmatrices
+from patsy import build_design_matrices
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
 )
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
@@ -119,7 +120,7 @@ class PrePostNEGD(BaseExperiment):
 
     def _build_design_matrices(self) -> None:
         """Build design matrices from formula and data using patsy."""
-        y, X = dmatrices(self.formula, self.data)
+        y, X = build_formula_matrices(self.formula, self.data)
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info
         self.labels = X.design_info.column_names

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -21,8 +21,10 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
-from patsy import ModelDesc, build_design_matrices, dmatrices
+from patsy import ModelDesc, build_design_matrices
 from sklearn.base import RegressorMixin
+
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
     DataException,
@@ -155,7 +157,7 @@ class RegressionDiscontinuity(BaseExperiment):
                 msg = f"Only {len(self.fit_data)} datapoints in the dataset."
             warnings.warn(msg, UserWarning, stacklevel=2)
 
-        y, X = dmatrices(self.formula, self.fit_data)
+        y, X = build_formula_matrices(self.formula, self.fit_data)
 
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -22,8 +22,9 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from patsy import ModelDesc, build_design_matrices, dmatrices
+from patsy import ModelDesc, build_design_matrices
 import xarray as xr
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 
@@ -106,9 +107,9 @@ class RegressionKink(BaseExperiment):
                     UserWarning,
                     stacklevel=2,
                 )
-            y, X = dmatrices(self.formula, filtered_data)
+            y, X = build_formula_matrices(self.formula, filtered_data)
         else:
-            y, X = dmatrices(self.formula, self.data)
+            y, X = build_formula_matrices(self.formula, self.data)
 
         self._y_design_info = y.design_info
         self._x_design_info = X.design_info

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -25,12 +25,13 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import PatsyError, dmatrices
+from patsy import PatsyError
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.experiments.model_adapter import build_coords
+from causalpy.formula_utils import build_formula_matrices
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 
@@ -419,7 +420,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         """Build design matrices using patsy."""
         # Build design matrix for the full data
         try:
-            y, X = dmatrices(self.formula, self.data)
+            y, X = build_formula_matrices(self.formula, self.data)
         except PatsyError as err:
             raise FormulaException(f"Unable to evaluate formula: {err}") from err
         self._y_design_info = y.design_info

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -1,0 +1,101 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Helpers for building Patsy design matrices from CausalPy formulas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pandas as pd
+from patsy import EvalEnvironment, EvalFactor, ModelDesc, Term, dmatrices
+
+from causalpy.transforms import elapsed, ramp, step
+
+
+def _datetime_columns(data: pd.DataFrame) -> set[str]:
+    """Return datetime column names that can appear as bare Patsy factors."""
+    return {
+        column
+        for column in data.columns
+        if isinstance(column, str)
+        and pd.api.types.is_datetime64_any_dtype(data[column])
+    }
+
+
+def _rewrite_datetime_terms(
+    terms: list[Term], datetime_columns: set[str]
+) -> list[Term]:
+    """Replace bare datetime factors with the stateful elapsed-time transform."""
+    return [
+        Term(
+            [
+                EvalFactor(f"elapsed({factor.code})")
+                if factor.code in datetime_columns
+                else factor
+                for factor in term.factors
+            ]
+        )
+        for term in terms
+    ]
+
+
+def datetime_continuous_formula(formula: str, data: pd.DataFrame) -> ModelDesc:
+    """Make bare datetime predictors continuous while preserving explicit transforms.
+
+    Bare datetime factors such as ``date`` become ``elapsed(date)``. Expressions
+    such as ``C(date)``, ``step(date, ...)``, and ``ramp(date, ...)`` are preserved
+    exactly, so users retain Patsy's explicit categorical syntax and CausalPy's
+    existing datetime intervention transforms.
+
+    Parameters
+    ----------
+    formula : str
+        Patsy formula to rewrite.
+    data : pd.DataFrame
+        Data used to identify datetime columns.
+    """
+    model_desc = ModelDesc.from_formula(formula)
+    return ModelDesc(
+        model_desc.lhs_termlist,
+        _rewrite_datetime_terms(model_desc.rhs_termlist, _datetime_columns(data)),
+    )
+
+
+def build_formula_matrices(
+    formula: str, data: pd.DataFrame, **kwargs: Any
+) -> tuple[Any, Any]:
+    """Build Patsy matrices with bare datetime predictors encoded as elapsed days.
+
+    The stateful ``elapsed`` transform stores its origin in Patsy's ``design_info``.
+    Calls to :func:`patsy.build_design_matrices` therefore use the same fitted origin
+    for new rows.
+
+    Parameters
+    ----------
+    formula : str
+        Patsy formula to evaluate.
+    data : pd.DataFrame
+        Data used to build the design matrices.
+    **kwargs : Any
+        Keyword arguments forwarded to :func:`patsy.dmatrices`.
+    """
+    eval_env = EvalEnvironment.capture(1).with_outer_namespace(
+        {"elapsed": elapsed, "ramp": ramp, "step": step}
+    )
+    return dmatrices(
+        datetime_continuous_formula(formula, data),
+        data,
+        eval_env=eval_env,
+        **kwargs,
+    )

--- a/causalpy/tests/test_formula_datetime_encoding.py
+++ b/causalpy/tests/test_formula_datetime_encoding.py
@@ -1,0 +1,134 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Regression tests for continuous datetime predictors in Patsy formulas."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from patsy import build_design_matrices
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.formula_utils import build_formula_matrices
+from causalpy.transforms import ElapsedDaysTransform
+
+
+def test_bare_datetime_predictor_is_continuous():
+    dates = pd.date_range("2020-01-01", periods=4, freq="MS")
+    data = pd.DataFrame({"date": dates, "y": np.arange(4, dtype=float)})
+
+    _, X = build_formula_matrices("y ~ 1 + date", data)
+
+    assert X.design_info.column_names == ["Intercept", "elapsed(date)"]
+    np.testing.assert_allclose(
+        np.asarray(X)[:, 1],
+        (dates - dates.min()).days,
+    )
+
+
+def test_elapsed_days_transform_tracks_origin_across_chunks():
+    transform = ElapsedDaysTransform()
+    later_dates = pd.date_range("2020-01-05", periods=2, freq="D")
+    earlier_dates = pd.date_range("2020-01-01", periods=2, freq="D")
+
+    transform.memorize_chunk(later_dates)
+    transform.memorize_chunk(earlier_dates)
+    transform.memorize_finish()
+
+    assert transform._origin == pd.Timestamp("2020-01-01")
+    np.testing.assert_array_equal(transform.transform(later_dates), [4.0, 5.0])
+
+
+def test_elapsed_days_transform_requires_fitted_origin():
+    with pytest.raises(RuntimeError, match="origin"):
+        ElapsedDaysTransform().transform(pd.date_range("2020-01-01", periods=1))
+
+
+def test_datetime_predictor_uses_fitted_origin_out_of_sample():
+    dates = pd.date_range("2020-01-01", periods=8, freq="MS")
+    data = pd.DataFrame({"date": dates, "y": np.arange(8, dtype=float)})
+
+    y_pre, X_pre = build_formula_matrices("y ~ 1 + date", data.iloc[:4])
+    _, X_post = build_design_matrices(
+        [y_pre.design_info, X_pre.design_info], data.iloc[4:]
+    )
+
+    assert X_post.design_info.column_names == X_pre.design_info.column_names
+    np.testing.assert_allclose(
+        np.asarray(X_post)[:, 1],
+        (dates[4:] - dates[0]).days,
+    )
+
+
+def test_C_datetime_predictor_remains_categorical():
+    dates = pd.date_range("2020-01-01", periods=4, freq="MS")
+    data = pd.DataFrame({"date": dates, "y": np.arange(4, dtype=float)})
+
+    _, X = build_formula_matrices("y ~ 1 + C(date)", data)
+
+    assert X.shape == (4, 4)
+    assert all("C(date)" in label for label in X.design_info.column_names[1:])
+
+
+def test_datetime_predictor_in_interaction_is_continuous():
+    dates = pd.date_range("2020-01-01", periods=4, freq="MS")
+    data = pd.DataFrame(
+        {"date": dates, "group": [0, 1, 0, 1], "y": np.arange(4, dtype=float)}
+    )
+
+    _, X = build_formula_matrices("y ~ 1 + date:group", data)
+
+    assert X.design_info.column_names == ["Intercept", "elapsed(date):group"]
+
+
+def test_interrupted_time_series_predicts_with_bare_datetime_predictor():
+    dates = pd.date_range("2020-01-01", periods=24, freq="MS")
+    data = pd.DataFrame(
+        {"date": dates, "y": 10 + 0.5 * np.arange(len(dates), dtype=float)}
+    ).set_index("date", drop=False)
+
+    result = cp.InterruptedTimeSeries(
+        data,
+        treatment_time=pd.Timestamp("2021-07-01"),
+        formula="y ~ 1 + date",
+        model=LinearRegression(),
+    )
+
+    assert result.labels == ["Intercept", "elapsed(date)"]
+    assert result.pre_design["X"].shape[1] == result.post_design["X"].shape[1] == 2
+    assert len(result.post_pred) == len(result.datapost)
+
+
+def test_piecewise_its_uses_single_datetime_baseline_column():
+    dates = pd.date_range("2020-01-01", periods=100, freq="D")
+    t = np.arange(len(dates))
+    data = pd.DataFrame(
+        {
+            "date": dates,
+            "y": 10 + 0.1 * t + 5 * (t >= 50) + 0.2 * np.maximum(0, t - 50),
+        }
+    )
+
+    result = cp.PiecewiseITS(
+        data,
+        formula="y ~ 1 + date + step(date, '2020-02-20') + ramp(date, '2020-02-20')",
+        model=LinearRegression(),
+    )
+
+    assert result.labels == [
+        "Intercept",
+        "elapsed(date)",
+        "step(date, '2020-02-20')",
+        "ramp(date, '2020-02-20')",
+    ]

--- a/causalpy/transforms.py
+++ b/causalpy/transforms.py
@@ -16,6 +16,8 @@ Patsy stateful transforms for Piecewise Interrupted Time Series analysis.
 
 This module provides `step` and `ramp` transforms for use in patsy formulas,
 enabling flexible specification of level and slope changes at intervention points.
+It also provides the internal `elapsed` transform used to represent bare datetime
+predictors as continuous elapsed days; use ``C(date)`` for categorical date effects.
 
 Examples
 --------
@@ -282,8 +284,57 @@ class RampTransform:
             return pd.Timestamp(threshold)  # type: ignore[arg-type, return-value]
 
 
+class ElapsedDaysTransform:
+    """Stateful transform that represents datetimes as days since the fitted origin."""
+
+    def __init__(self) -> None:
+        self._origin: pd.Timestamp | None = None
+
+    def memorize_chunk(self, x: Any) -> None:
+        """Store the earliest datetime encountered during Patsy's fitting pass.
+
+        Parameters
+        ----------
+        x : array-like
+            Datetime values from a Patsy fitting chunk.
+        """
+        x_dt = pd.to_datetime(x)
+        x_min = pd.Timestamp(x_dt.min())
+        if self._origin is None:
+            self._origin = x_min
+        else:
+            self._origin = min(self._origin, x_min)
+
+    def memorize_finish(self) -> None:
+        """Called after all chunks processed."""
+        pass
+
+    def transform(self, x: Any) -> np.ndarray:
+        """Return elapsed days from the fitted origin.
+
+        Parameters
+        ----------
+        x : array-like
+            Datetime values to encode.
+        """
+        if self._origin is None:
+            raise RuntimeError("elapsed() was used before its origin was initialized.")
+        x_dt = pd.to_datetime(x)
+        if isinstance(x_dt, pd.DatetimeIndex):
+            return np.asarray((x_dt - self._origin).total_seconds() / (24 * 3600))
+        return np.asarray((x_dt - self._origin).dt.total_seconds() / (24 * 3600))
+
+
 # Create callable stateful transforms for use in formulas
 step = patsy.stateful_transform(StepTransform)  # type: ignore[attr-defined]
 ramp = patsy.stateful_transform(RampTransform)  # type: ignore[attr-defined]
+elapsed = patsy.stateful_transform(ElapsedDaysTransform)  # type: ignore[attr-defined]
 
-__all__ = ["step", "ramp", "StepTransform", "RampTransform"]
+__all__ = [
+    "step",
+    "ramp",
+    "elapsed",
+    "StepTransform",
+    "RampTransform",
+    "ElapsedDaysTransform",
+]


### PR DESCRIPTION
## Summary
- Encode bare datetime formula predictors as continuous elapsed days across Patsy-based experiments.
- Preserve `C(date)` for explicit categorical date effects and retain datetime-aware `step()` / `ramp()` behavior.
- Add regression coverage for datetime encoding and ITS post-treatment prediction.

Fixes #1002

## Testing
- `prek run --all-files`
- `make test-patch-cov`

Made with [Cursor](https://cursor.com)