### PR TITLE
Parse PiecewiseITS transforms with Patsy metadata

### DIFF
--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -13,6 +13,7 @@
 #   limitations under the License.
 """Piecewise Interrupted Time Series Analysis (Segmented Regression)."""
 
+import ast
 import re
 import warnings
 from typing import Any, Literal
@@ -22,7 +23,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import dmatrices
+from patsy import ModelDesc, dmatrices
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
@@ -165,11 +166,9 @@ class PiecewiseITS(BaseExperiment):
         # Rename the index to "obs_ind" for consistency
         self.data.index.name = "obs_ind"
 
-        # Input validation
-        self._validate_inputs()
-
         # Parse and validate step/ramp terms before any downstream logic.
         self._step_ramp_terms = self._parse_step_ramp_terms()
+        self._validate_inputs()
         self.time_col = self._extract_time_column(self._step_ramp_terms)
         self.interruption_times = self._extract_and_canonicalize_interruption_times(
             self._step_ramp_terms, self.time_col
@@ -217,19 +216,42 @@ class PiecewiseITS(BaseExperiment):
     def _validate_inputs(self) -> None:
         """Validate input data and formula."""
         # Check formula contains at least one step() or ramp() term
-        if "step(" not in self.formula and "ramp(" not in self.formula:
+        if not self._step_ramp_terms:
             raise FormulaException(
                 "Formula must contain at least one step() or ramp() term. "
                 "Example: 'y ~ 1 + t + step(t, 50) + ramp(t, 50)'"
             )
 
+    @staticmethod
+    def _parse_step_ramp_factor(factor_name: str) -> list[dict[str, str]]:
+        """Extract bare ``step`` and ``ramp`` calls from one Patsy factor."""
+        expression = ast.parse(factor_name, mode="eval")
+        calls = []
+        for node in ast.walk(expression):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id in {"step", "ramp"}
+                and len(node.args) == 2
+                and isinstance(node.args[0], ast.Name)
+            ):
+                threshold = ast.get_source_segment(factor_name, node.args[1])
+                calls.append(
+                    {
+                        "transform": node.func.id,
+                        "variable": node.args[0].id,
+                        "raw_threshold": threshold or ast.unparse(node.args[1]),
+                    }
+                )
+        return calls
+
     def _parse_step_ramp_terms(self) -> list[dict[str, str]]:
         """Parse step/ramp terms into structured metadata."""
-        pattern = r"(step|ramp)\s*\(\s*(\w+)\s*,\s*([^)]+?)\s*\)"
-        matches = re.findall(pattern, self.formula)
         return [
-            {"transform": transform, "variable": variable, "raw_threshold": threshold}
-            for transform, variable, threshold in matches
+            call
+            for term in ModelDesc.from_formula(self.formula).rhs_termlist
+            for factor in term.factors
+            for call in self._parse_step_ramp_factor(factor.name())
         ]
 
     def _extract_time_column(self, terms: list[dict[str, str]]) -> str:
@@ -264,7 +286,13 @@ class PiecewiseITS(BaseExperiment):
 
         canonical_thresholds: list[int | float | pd.Timestamp] = []
         for term in terms:
-            raw_threshold = term["raw_threshold"].strip().strip("'\"")
+            raw_threshold = term["raw_threshold"].strip()
+            if (
+                len(raw_threshold) >= 2
+                and raw_threshold[0] in "'\""
+                and raw_threshold[-1] == raw_threshold[0]
+            ):
+                raw_threshold = raw_threshold[1:-1]
 
             if is_datetime:
                 try:
@@ -295,11 +323,13 @@ class PiecewiseITS(BaseExperiment):
 
     def _get_interruption_column_indices(self) -> list[int]:
         """Get indices of columns related to interruptions (step/ramp terms)."""
-        indices = []
-        for i, label in enumerate(self.labels):
-            # Patsy labels step/ramp terms like "step(t, 50)" or "ramp(t, 50)"
-            if "step(" in label or "ramp(" in label:
-                indices.append(i)
+        indices: list[int] = []
+        for term in self._x_design_info.terms:
+            if any(
+                self._parse_step_ramp_factor(factor.name()) for factor in term.factors
+            ):
+                term_slice = self._x_design_info.term_slices[term]
+                indices.extend(range(term_slice.start, term_slice.stop))
         return indices
 
     def _compute_counterfactual_and_effects(self) -> None:

--- a/causalpy/tests/test_piecewise_its.py
+++ b/causalpy/tests/test_piecewise_its.py
@@ -286,6 +286,43 @@ def test_piecewise_its_no_step_or_ramp():
         )
 
 
+def test_piecewise_its_parser_preserves_nested_threshold_expressions():
+    """Patsy's parsed factors preserve nested parentheses and commas."""
+    experiment = object.__new__(cp.PiecewiseITS)
+    experiment.formula = "y ~ step(t, int(50)) + ramp(t, foo(a, b))"
+
+    assert experiment._parse_step_ramp_terms() == [
+        {"transform": "step", "variable": "t", "raw_threshold": "int(50)"},
+        {"transform": "ramp", "variable": "t", "raw_threshold": "foo(a, b)"},
+    ]
+
+
+@pytest.mark.parametrize("factor", ["np.step(t, 50)", "mystep(t, 50)"])
+def test_piecewise_its_parser_requires_bare_transform_name(factor):
+    """Qualified or similarly named functions are not interruption transforms."""
+    assert cp.PiecewiseITS._parse_step_ramp_factor(factor) == []
+
+
+@pytest.mark.parametrize("raw_threshold", ["50'", "''50''"])
+def test_piecewise_its_threshold_unwraps_only_one_matched_quote_pair(raw_threshold):
+    """Stray or repeated quotes are not silently stripped into valid numbers."""
+    experiment = object.__new__(cp.PiecewiseITS)
+    experiment.data = pd.DataFrame({"t": np.arange(100)})
+    terms = [{"transform": "step", "variable": "t", "raw_threshold": raw_threshold}]
+
+    with pytest.raises(FormulaException, match="Invalid numeric threshold"):
+        experiment._extract_and_canonicalize_interruption_times(terms, "t")
+
+
+def test_piecewise_its_matched_quoted_threshold_still_parses():
+    """A single matched quote pair remains supported."""
+    experiment = object.__new__(cp.PiecewiseITS)
+    experiment.data = pd.DataFrame({"t": np.arange(100)})
+    terms = [{"transform": "step", "variable": "t", "raw_threshold": "'50'"}]
+
+    assert experiment._extract_and_canonicalize_interruption_times(terms, "t") == [50]
+
+
 def test_piecewise_its_missing_column():
     """Test that missing column in formula raises error."""
     from patsy import PatsyError


### PR DESCRIPTION
## Summary
- replace substring and regex parsing of `step()`/`ramp()` with Patsy factor metadata and Python AST calls
- preserve nested threshold expressions while excluding qualified or similarly named functions
- unwrap only one matched quote pair and identify counterfactual columns semantically

Closes #1000

## Test plan
- [x] `python -m pytest causalpy/tests/test_piecewise_its.py --no-cov -q`
- [x] `prek run --all-files`
- [x] `make test-patch-cov`


Made with [Cursor](https://cursor.com)