### PR TITLE
Add pymc_forecast model-provider adapter for InterruptedTimeSeries

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,6 +1,6 @@
 # ARCHITECTURE
 
-CausalPy implements 10+ quasi-experimental causal inference methods over two statistical backends (PyMC and scikit-learn). This document orients agents and contributors to where things live, how the pieces compose, and the non-obvious conventions.
+CausalPy implements 10+ quasi-experimental causal inference methods over two core statistical backends (PyMC and scikit-learn), plus an optional third backend (`pymc-forecast`, currently `InterruptedTimeSeries` only). This document orients agents and contributors to where things live, how the pieces compose, and the non-obvious conventions.
 
 ## Module Map
 
@@ -10,6 +10,7 @@ CausalPy implements 10+ quasi-experimental causal inference methods over two sta
 | `causalpy/experiments/` | One experiment class per file; `base.py` holds `BaseExperiment` |
 | `causalpy/pymc_models.py` | All `PyMCModel` subclasses (Bayesian backend) |
 | `causalpy/skl_models.py` | `ScikitLearnAdaptor` mixin, `create_causalpy_compatible_class()` |
+| `causalpy/pymc_forecast_models.py` | `PyMCForecastModel` wrapper (optional `pymc-forecast` backend) |
 | `causalpy/reporting.py` | `EffectSummary`, statistics and prose for both backends |
 | `causalpy/pipeline.py` | `Pipeline`, `PipelineContext`, `PipelineResult`, `Step` protocol |
 | `causalpy/steps/` | `EstimateEffect`, `SensitivityAnalysis`, `GenerateReport` |
@@ -21,9 +22,9 @@ CausalPy implements 10+ quasi-experimental causal inference methods over two sta
 | `docs/source/notebooks/` | How-to notebooks (`{method}_{backend}.ipynb`) |
 | `docs/source/knowledgebase/` | Educational content (glossary, reporting explainers) |
 
-## Two-Backend Model
+## Backend Model
 
-Backend dispatch is centralized in `causalpy/experiments/model_adapter.py`. `BaseExperiment.__init__` calls `make_model_adapter()`, which handles sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class()`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols` validation. Each experiment stores `self._model_backend` (private) and keeps `self.model` as the public handle.
+Backend dispatch is centralized in `causalpy/experiments/model_adapter.py`. `BaseExperiment.__init__` calls `make_model_adapter()`, which handles sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class()`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols`/`supports_pymc_forecast` validation. Each experiment stores `self._model_backend` (private) and keeps `self.model` as the public handle.
 
 Standard regression experiments call `self._model_backend.fit(X, y, coords=build_coords(...))` unconditionally. `build_coords()` assembles the PyMC `coeffs` / `obs_ind` / `treated_units` dict; sklearn backends ignore `coords`. `SklearnModelAdapter` normalizes inputs before delegating to sklearn: xarray `DataArray` values become numpy arrays, and a single-column `treated_units` outcome is squeezed to 1D so call sites do not need per-experiment `.isel(treated_units=0)` branches.
 
@@ -40,6 +41,8 @@ self._model_backend.fit(
 Experiments with non-standard fit signatures bypass this path and call `self.model.fit(...)` directly with custom arguments: `InstrumentalVariable` (two-stage IV), `InversePropensityWeighting` (propensity `fit(X, t, coords)`), and `SyntheticDifferenceInDifferences` (dict-shaped weight-fitter inputs). Those models are not forced through `build_coords` or sklearn y-normalization.
 
 `PyMCModel` extends `pymc.Model` with a sklearn-like `fit` / `predict` / `score` / `calculate_impact` interface. `ScikitLearnAdaptor` is a mixin patched onto any `RegressorMixin` via `create_causalpy_compatible_class()` during adapter construction. Every experiment declares `supports_ols` and `supports_bayes`; validation runs in `make_model_adapter()`. When `model=None`, `_default_model_class` is instantiated (always Bayesian; `PanelRegression` requires an explicit model).
+
+The optional third backend, `PyMCForecastModel` (`causalpy/pymc_forecast_models.py`), wraps a `pymc_forecast` forecasting model behind the same protocol and is wired through `PyMCForecastAdapter`. It reports as Bayesian (`is_bayesian` is true for both `"pymc"` and `"pymc-forecast"` adapter kinds), so experiments and checks that branch on Bayesian-vs-OLS treat it like a PyMC backend. Experiments opt in via `supports_pymc_forecast` (currently `InterruptedTimeSeries` only); the dependency ships as the `causalpy[forecast]` extra, pinned to one upstream minor while `pymc-forecast` is 0.x.
 
 ## Experiment Lifecycle
 
@@ -88,7 +91,7 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 
 Copy the closest existing experiment or model and follow the `BaseExperiment` contract:
 
-- Declare `supports_ols` / `supports_bayes`; implement `_bayesian_plot()` / `_ols_plot()` only for supported backends
+- Declare `supports_ols` / `supports_bayes` (and `supports_pymc_forecast` to opt into the optional pymc-forecast backend); implement `_bayesian_plot()` / `_ols_plot()` only for supported backends
 - `algorithm()` with the fit/predict/impact flow; `effect_summary()` via helpers in `causalpy.reporting`
 - Public `plot(*, ...)` with a kwarg-only signature that delegates to `_render_plot()` — bare `*args` / `**kwargs` are forbidden on the public surface (enforced by `causalpy/tests/test_public_plot_signatures.py`). For experiments without a unified plot view (e.g. `InversePropensityWeighting`, `InstrumentalVariable`), declare an explicit `plot()` stub that raises `NotImplementedError`. For `hdi_prob` defaults, use ``Defaults to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).`` in the docstring.
 - Raise `FormulaException`, `DataException`, or `BadIndexException` from `causalpy.custom_exceptions` for formula, data, and index errors

--- a/causalpy/__init__.py
+++ b/causalpy/__init__.py
@@ -14,6 +14,7 @@
 """CausalPy: causal inference for quasi-experiments in Python."""
 
 import causalpy.checks as checks  # noqa: E402
+import causalpy.pymc_forecast_models as pymc_forecast_models
 import causalpy.pymc_models as pymc_models
 import causalpy.skl_models as skl_models
 import causalpy.variable_selection_priors as variable_selection_priors
@@ -64,6 +65,7 @@ __all__ = [
     "PanelRegression",
     "plot_correlations",
     "PrePostNEGD",
+    "pymc_forecast_models",
     "pymc_models",
     "ramp",
     "RegressionDiscontinuity",

--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -29,8 +29,8 @@ Supports two fold-selection strategies:
   fraction, minimum gap between folds, and optional period exclusion.
 
 Supports experiments with a ``treatment_time`` parameter
-(InterruptedTimeSeries, SyntheticControl).  Requires a PyMC model
-for posterior extraction.
+(InterruptedTimeSeries, SyntheticControl).  Requires a Bayesian model
+backend (PyMC or pymc-forecast) for posterior extraction.
 """
 
 from __future__ import annotations
@@ -50,7 +50,6 @@ from causalpy.experiments.base import BaseExperiment
 from causalpy.experiments.interrupted_time_series import InterruptedTimeSeries
 from causalpy.experiments.synthetic_control import SyntheticControl
 from causalpy.pipeline import PipelineContext
-from causalpy.pymc_models import PyMCModel
 
 logger = logging.getLogger(__name__)
 
@@ -300,8 +299,8 @@ class PlaceboInTime:
         Raises
         ------
         TypeError
-            If the experiment lacks ``treatment_time`` or uses a non-PyMC
-            model.
+            If the experiment lacks ``treatment_time`` or uses a
+            non-Bayesian model backend.
         """
         if not hasattr(experiment, "treatment_time"):
             raise TypeError(
@@ -309,11 +308,17 @@ class PlaceboInTime:
                 f"attribute. PlaceboInTime requires experiments with an "
                 f"explicit treatment time."
             )
-        if not isinstance(experiment.model, PyMCModel):
+        # Validate against the backend capability, not a concrete model
+        # class: any Bayesian backend (PyMCModel or PyMCForecastModel)
+        # yields the draw-level post_impact this check consumes.
+        backend = getattr(experiment, "_model_backend", None)
+        if backend is None or not backend.is_bayesian:
             raise TypeError(
-                f"PlaceboInTime requires a PyMC model for posterior "
-                f"extraction, but got {type(experiment.model).__name__}. "
-                f"Use a PyMC model (e.g. cp.pymc_models.LinearRegression)."
+                f"PlaceboInTime requires a Bayesian model backend for "
+                f"posterior extraction, but got "
+                f"{type(experiment.model).__name__}. Use a PyMC model "
+                f"(e.g. cp.pymc_models.LinearRegression) or a pymc-forecast "
+                f"backend (cp.pymc_forecast_models.PyMCForecastModel)."
             )
 
     def _get_factory(self, context: PipelineContext | None) -> Any:

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -32,6 +32,7 @@ from sklearn.base import RegressorMixin
 
 from causalpy.experiments.model_adapter import ModelAdapter, make_model_adapter
 from causalpy.maketables_adapters import get_maketables_adapter
+from causalpy.pymc_forecast_models import PyMCForecastModel
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
 
@@ -100,11 +101,14 @@ class BaseExperiment(ABC):
 
     Subclasses should set ``_default_model_class`` to a PyMC model class
     (e.g. ``LinearRegression``) so that ``model=None`` instantiates a sensible
-    Bayesian default. To use an OLS/sklearn model, pass one explicitly.
+    Bayesian default. To use an OLS/sklearn model — or, for experiments that
+    declare ``supports_pymc_forecast``, a
+    :class:`~causalpy.pymc_forecast_models.PyMCForecastModel` — pass one
+    explicitly.
 
     Parameters
     ----------
-    model : PyMCModel, RegressorMixin, or None, default None
+    model : PyMCModel, RegressorMixin, PyMCForecastModel, or None, default None
         Model instance to use. If ``None`` and ``_default_model_class`` is set,
         an instance of that default class is constructed.
 
@@ -188,7 +192,9 @@ class BaseExperiment(ABC):
 
     _model_backend: ModelAdapter
 
-    def __init__(self, model: PyMCModel | RegressorMixin | None = None) -> None:
+    def __init__(
+        self, model: PyMCModel | RegressorMixin | PyMCForecastModel | None = None
+    ) -> None:
         adapter = make_model_adapter(
             model,
             default_model_class=self._default_model_class,

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -121,6 +121,7 @@ class BaseExperiment(ABC):
 
     supports_bayes: bool
     supports_ols: bool
+    supports_pymc_forecast: bool = False
 
     _default_model_class: type[PyMCModel] | None = None
 
@@ -193,6 +194,7 @@ class BaseExperiment(ABC):
             default_model_class=self._default_model_class,
             supports_bayes=self.supports_bayes,
             supports_ols=self.supports_ols,
+            supports_pymc_forecast=self.supports_pymc_forecast,
         )
         self._model_backend = adapter
         self.model = adapter.model

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -33,6 +33,7 @@ from causalpy.plot_utils import (
     get_hdi_to_df,
     plot_posterior_over_x,
 )
+from causalpy.pymc_forecast_models import PyMCForecastModel
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import _as_scalar, round_num
@@ -61,9 +62,13 @@ class InterruptedTimeSeries(BaseExperiment):
         post-intervention period (uses ``>=`` comparison).
     formula : str
         A statistical model formula using patsy syntax (e.g., "y ~ 1 + t + C(month)").
-    model : Union[PyMCModel, RegressorMixin], optional
+    model : Union[PyMCModel, RegressorMixin, PyMCForecastModel], optional
         A PyMC (Bayesian) or sklearn (OLS) model. If None, defaults to a PyMC
-        LinearRegression model.
+        LinearRegression model. Alternatively, a
+        :class:`~causalpy.pymc_forecast_models.PyMCForecastModel` wrapping a
+        ``pymc_forecast`` forecasting model can serve as the counterfactual
+        backend (requires the optional ``pymc-forecast`` dependency); see
+        :mod:`causalpy.pymc_forecast_models` for when to prefer it.
     treatment_end_time : Union[int, float, pd.Timestamp], optional
         The time when treatment ended, enabling three-period analysis. Must be
         greater than ``treatment_time`` and within the data range. If None (default),
@@ -132,6 +137,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
     supports_ols = True
     supports_bayes = True
+    supports_pymc_forecast = True
     _default_model_class = LinearRegression
     _deprecated_design_aliases = {
         "pre_X": ("pre_design", "X"),
@@ -145,7 +151,7 @@ class InterruptedTimeSeries(BaseExperiment):
         data: pd.DataFrame,
         treatment_time: int | float | pd.Timestamp,
         formula: str,
-        model: PyMCModel | RegressorMixin | None = None,
+        model: PyMCModel | RegressorMixin | PyMCForecastModel | None = None,
         treatment_end_time: int | float | pd.Timestamp | None = None,
         **kwargs: Any,
     ) -> None:

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -87,7 +87,7 @@ class ModelAdapter(ABC):
 
     @property
     @abstractmethod
-    def model(self) -> PyMCModel | RegressorMixin:
+    def model(self) -> PyMCModel | RegressorMixin | PyMCForecastModel:
         """The underlying model instance."""
 
     @property

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -25,10 +25,11 @@ import numpy as np
 import xarray as xr
 from sklearn.base import RegressorMixin, clone
 
+from causalpy.pymc_forecast_models import PyMCForecastModel
 from causalpy.pymc_models import PyMCModel
 from causalpy.skl_models import create_causalpy_compatible_class
 
-BackendKind = Literal["pymc", "sklearn"]
+BackendKind = Literal["pymc", "sklearn", "pymc-forecast"]
 
 
 def build_coords(
@@ -96,8 +97,8 @@ class ModelAdapter(ABC):
 
     @property
     def is_bayesian(self) -> bool:
-        """Whether the backend is Bayesian (PyMC)."""
-        return self.kind == "pymc"
+        """Whether the backend is Bayesian (PyMC or pymc-forecast)."""
+        return self.kind in ("pymc", "pymc-forecast")
 
     @property
     def is_ols(self) -> bool:
@@ -385,6 +386,118 @@ class SklearnModelAdapter(ModelAdapter):
         self._model.print_coefficients(labels, round_to)
 
 
+class PyMCForecastAdapter(ModelAdapter):
+    """Adapter for :class:`~causalpy.pymc_forecast_models.PyMCForecastModel`
+    backends.
+
+    The wrapped model already speaks CausalPy's Bayesian conventions
+    (``mu``/``y_hat`` posterior-predictive output on ``obs_ind`` /
+    ``treated_units`` coords), so this adapter is pure delegation.
+
+    Parameters
+    ----------
+    model : PyMCForecastModel
+        Wrapped ``pymc_forecast`` backend model.
+    """
+
+    def __init__(self, model: PyMCForecastModel) -> None:
+        self._model = model
+
+    @property
+    def model(self) -> PyMCForecastModel:
+        """The underlying pymc-forecast wrapper."""
+        return self._model
+
+    @property
+    def kind(self) -> BackendKind:
+        """Backend identifier."""
+        return "pymc-forecast"
+
+    @property
+    def idata(self) -> az.InferenceData:
+        """Return the model's InferenceData (posterior draws)."""
+        if self._model.idata is None:
+            raise RuntimeError("Model has not been fit yet.")
+        return self._model.idata
+
+    def fit(
+        self,
+        X: Any,
+        y: Any,
+        *,
+        coords: dict[str, Any] | None = None,
+    ) -> az.InferenceData:
+        """Fit the forecasting model on the pre-period.
+
+        Parameters
+        ----------
+        X : xarray.DataArray
+            Design matrix with dims ``["obs_ind", "coeffs"]``.
+        y : xarray.DataArray
+            Outcome with dims ``["obs_ind", "treated_units"]``.
+        coords : dict, optional
+            Coordinate metadata; ignored (real coordinates are read from
+            ``X`` and ``y``).
+        """
+        return self._model.fit(X=X, y=y, coords=coords)
+
+    def predict(
+        self,
+        X: Any,
+        *,
+        out_of_sample: bool = False,
+        **kwargs: Any,
+    ) -> Any:
+        """Predict in-sample or forecast the counterfactual.
+
+        Parameters
+        ----------
+        X : xarray.DataArray
+            Design matrix for which to generate predictions.
+        out_of_sample : bool, default False
+            ``True`` draws the post-period counterfactual via the model's
+            forecasting path.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.predict(X=X, out_of_sample=out_of_sample, **kwargs)
+
+    def score(self, X: Any, y: Any, **kwargs: Any) -> Any:
+        """Score in-sample predictions with the Bayesian :math:`R^2`.
+
+        Parameters
+        ----------
+        X : xarray.DataArray
+            Design matrix.
+        y : xarray.DataArray
+            Observed outcomes.
+        **kwargs
+            Additional keyword arguments forwarded to the underlying model.
+        """
+        return self._model.score(X=X, y=y, **kwargs)
+
+    def coefficients(self) -> np.ndarray:
+        """Forecasting models have no design-matrix coefficients."""
+        raise NotImplementedError(
+            "pymc-forecast models do not expose design-matrix coefficients; "
+            "inspect the fitted posterior via `.idata` instead."
+        )
+
+    def print_coefficients(
+        self, labels: list[str], round_to: int | None = None
+    ) -> None:
+        """Print posterior summaries of the model's scalar parameters.
+
+        Parameters
+        ----------
+        labels : list of str
+            Design-matrix labels; ignored by forecasting models.
+        round_to : int, optional
+            Number of significant figures to round to.
+        """
+        self._model.print_coefficients(labels, round_to)
+
+
 def _prepare_sklearn_model(model: RegressorMixin) -> RegressorMixin:
     """Clone, augment, and validate a sklearn estimator for CausalPy."""
     try:
@@ -407,17 +520,18 @@ def _prepare_sklearn_model(model: RegressorMixin) -> RegressorMixin:
 
 
 def make_model_adapter(
-    model: PyMCModel | RegressorMixin | None,
+    model: PyMCModel | RegressorMixin | PyMCForecastModel | None,
     *,
     default_model_class: type[PyMCModel] | None,
     supports_bayes: bool,
     supports_ols: bool,
+    supports_pymc_forecast: bool = False,
 ) -> ModelAdapter:
     """Resolve, validate, and wrap a model in a backend adapter.
 
     Parameters
     ----------
-    model : PyMCModel, RegressorMixin, or None
+    model : PyMCModel, RegressorMixin, PyMCForecastModel, or None
         User-supplied model instance, or ``None`` to use the default.
     default_model_class : type[PyMCModel] or None
         PyMC model class used when ``model`` is ``None``.
@@ -425,6 +539,8 @@ def make_model_adapter(
         Whether the experiment supports Bayesian backends.
     supports_ols : bool
         Whether the experiment supports OLS/sklearn backends.
+    supports_pymc_forecast : bool, default False
+        Whether the experiment supports pymc-forecast backends.
 
     Returns
     -------
@@ -449,5 +565,10 @@ def make_model_adapter(
         if not supports_ols:
             raise ValueError("OLS models not supported.")
         return SklearnModelAdapter(model)
+
+    if isinstance(model, PyMCForecastModel):
+        if not supports_pymc_forecast:
+            raise ValueError("pymc-forecast models not supported.")
+        return PyMCForecastAdapter(model)
 
     raise ValueError("Unsupported model type")

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -437,7 +437,7 @@ class PanelRegression(BaseExperiment):
             # For OLS models the base print_coefficients uses positional zip
             # which would pair filtered labels with the wrong coefficient
             # values.  We do our own index-based lookup instead.
-            coefs = self.model.get_coeffs()
+            coefs = self.model.get_coeffs()  # type: ignore[union-attr]
             max_label_length = max(len(name) for name in coeff_labels)
             rd = round_to if round_to is not None else 2
             print("Model coefficients:")
@@ -614,7 +614,7 @@ class PanelRegression(BaseExperiment):
             # OLS: point estimates
             fig, ax = plt.subplots(figsize=(10, max(4, len(coeff_names) * 0.5)))
             coef_indices = [self.labels.index(c) for c in coeff_names]
-            coefs = self.model.get_coeffs()[coef_indices]
+            coefs = self.model.get_coeffs()[coef_indices]  # type: ignore[union-attr]
             y_pos = np.arange(len(coeff_names))
             ax.barh(y_pos, coefs)
             ax.set_yticks(y_pos)
@@ -784,7 +784,7 @@ class PanelRegression(BaseExperiment):
         else:
             # OLS: get point estimates
             unit_fe_indices = [self.labels.index(name) for name in unit_fe_names]
-            coefs = self.model.get_coeffs()
+            coefs = self.model.get_coeffs()  # type: ignore[union-attr]
             fe_values = [coefs[idx] for idx in unit_fe_indices]
 
             ax.hist(

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -42,12 +42,15 @@ causalpy[forecast]``).
 
 Notes
 -----
-Causal impact is computed from the noise-free latent predictor (upstream
-``mu`` / ``mu_future``), exactly like the native ``PyMCModel`` backends:
-parameter and latent uncertainty, excluding observation-level noise. The
-draw-level posterior predictive of the observed variable is reported
-separately as ``y_hat``. One posterior subsample is drawn at fit time and
-shared by every predictive call, so draw *i* of the pre-period fit and draw
+Causal impact is computed from upstream ``mu`` / ``mu_future``, which CausalPy
+interprets as the conditional expected outcome in observed outcome units:
+parameter and latent uncertainty, excluding observation-level noise. Models
+using a link function must therefore apply the inverse link before passing the
+latent to ``pymc_forecast.predict``. Passing a link-scale linear predictor
+would make CausalPy subtract quantities in incompatible units and is not
+supported. The draw-level posterior predictive of the observed variable is
+reported separately as ``y_hat``. One posterior subsample is drawn at fit time
+and shared by every predictive call, so draw *i* of the pre-period fit and draw
 *i* of the counterfactual come from the same parameter draw (upstream
 ``posterior=`` passthrough).
 

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -42,11 +42,16 @@ causalpy[forecast]``).
 
 Notes
 -----
-``pymc_forecast`` exposes draw-level posterior-predictive samples of the
-observed variable rather than a separate noise-free expectation, so this
-backend reports the posterior predictive as both ``mu`` and ``y_hat``. Causal
-impact therefore includes observation-level noise, unlike native
-``PyMCModel`` backends where impact is computed from the noise-free ``mu``.
+Causal impact is computed from the noise-free latent predictor (upstream
+``mu`` / ``mu_future``), exactly like the native ``PyMCModel`` backends:
+parameter and latent uncertainty, excluding observation-level noise. The
+draw-level posterior predictive of the observed variable is reported
+separately as ``y_hat``. One posterior subsample is drawn at fit time and
+shared by every predictive call, so draw *i* of the pre-period fit and draw
+*i* of the counterfactual come from the same parameter draw (upstream
+``posterior=`` passthrough). The one exception is ``StatespaceForecaster``
+models, whose upstream outputs carry no separate noise-free latent — there
+``mu`` falls back to the posterior predictive.
 """
 
 from __future__ import annotations
@@ -73,7 +78,7 @@ def _import_pymc_forecast():
         raise ImportError(
             "PyMCForecastModel requires the optional dependency 'pymc-forecast'. "
             "Install it with `pip install causalpy[forecast]` or "
-            "`pip install pymc-forecast>=0.1.0`."
+            "`pip install pymc-forecast>=0.2`."
         ) from err
     return pymc_forecast
 
@@ -90,18 +95,25 @@ class PyMCForecastModel:
         ethos.
     forecaster : type, optional
         The ``pymc_forecast`` forecaster class used to fit the model. Defaults
-        to :class:`pymc_forecast.HMCForecaster` (NUTS), matching CausalPy's
-        native PyMC backends. Pass :class:`pymc_forecast.Forecaster` (ADVI) or
+        to :class:`pymc_forecast.HMCForecaster` (NUTS) — or
+        :class:`pymc_forecast.StatespaceForecaster` when ``model_fn`` is a
+        :class:`pymc_forecast.StatespaceModel` — matching CausalPy's native
+        PyMC backends. Pass :class:`pymc_forecast.Forecaster` (ADVI) or
         :class:`pymc_forecast.PathfinderForecaster` for faster approximate
         inference — but check convergence before trusting the counterfactual.
     forecaster_kwargs : dict, optional
         Extra keyword arguments for the forecaster constructor (e.g.
-        ``{"draws": 500}`` for MCMC or ``{"num_steps": 20_000}`` for ADVI).
+        ``{"draws": 500}`` for MCMC, ``{"num_steps": 20_000}`` for ADVI, or
+        ``{"progressbar": True}`` — accepted uniformly by every forecaster).
+        The forecaster is constructed immediately (unfitted), so invalid
+        options fail at construction rather than at experiment time.
     num_samples : int, default 500
-        Number of posterior(-predictive) draws for in-sample prediction and
-        forecasting.
+        Number of posterior draws, drawn once at fit time and shared by every
+        predictive call so that in-sample prediction and counterfactual are
+        conditioned on the same parameter draws.
     random_seed : int, optional
-        Seed passed to fitting and every predictive call.
+        Seed passed to fitting, the posterior subsample, and every predictive
+        call.
 
     Examples
     --------
@@ -140,14 +152,25 @@ class PyMCForecastModel:
     ) -> None:
         self._pf = _import_pymc_forecast()
         self.model_fn = model_fn
-        self.forecaster_cls = (
-            forecaster if forecaster is not None else self._pf.HMCForecaster
-        )
+        if forecaster is None:
+            forecaster = (
+                self._pf.StatespaceForecaster
+                if isinstance(model_fn, self._pf.StatespaceModel)
+                else self._pf.HMCForecaster
+            )
+        self.forecaster_cls = forecaster
         self.forecaster_kwargs = dict(forecaster_kwargs or {})
         self.num_samples = num_samples
         self.random_seed = random_seed
-        self.forecaster: Any = None
+        # deferred-fit construction (pymc-forecast >= 0.2): hold a real
+        # configured forecaster, not a (class, kwargs) recipe
+        self.forecaster: Any = self.forecaster_cls(
+            self.model_fn,
+            random_seed=self.random_seed,
+            **self.forecaster_kwargs,
+        )
         self.idata: az.InferenceData | None = None
+        self._posterior: xr.Dataset | None = None
         self._treated_units: list[str] = ["unit_0"]
         self._has_covariates = False
 
@@ -181,17 +204,14 @@ class PyMCForecastModel:
         data = y.isel(treated_units=0, drop=True).rename({"obs_ind": "time"})
         covariates = self._as_covariates(X)
         self._has_covariates = covariates is not None
-        self.forecaster = self.forecaster_cls(
-            self.model_fn,
-            data,
-            covariates,
-            random_seed=self.random_seed,
-            **self.forecaster_kwargs,
-        )
-        posterior = self.forecaster.draw_posterior(
+        self.forecaster.fit(data, covariates, random_seed=self.random_seed)
+        # one posterior subsample, shared by every predictive call: draw i of
+        # the pre-period fit and draw i of the counterfactual come from the
+        # same parameter draw
+        self._posterior = self.forecaster.draw_posterior(
             self.num_samples, random_seed=self.random_seed
         )
-        self.idata = az.InferenceData(posterior=posterior)
+        self.idata = az.InferenceData(posterior=self._posterior)
         return self.idata
 
     @staticmethod
@@ -231,49 +251,58 @@ class PyMCForecastModel:
         -------
         az.InferenceData
             With a ``posterior_predictive`` group holding draw-level ``mu``
-            and ``y_hat`` variables with dims
+            (the noise-free latent predictor) and ``y_hat`` (the posterior
+            predictive of the observed variable) with dims
             ``(chain, draw, obs_ind, treated_units)``.
         """
-        if self.forecaster is None:
+        if self._posterior is None:
             raise RuntimeError("Model has not been fit yet.")
         if out_of_sample:
             if self._has_covariates:
                 result = self.forecaster.forecast(
                     future_covariates=self._as_covariates(X),
-                    num_samples=self.num_samples,
+                    posterior=self._posterior,
                     random_seed=self.random_seed,
                 )
             else:
                 result = self.forecaster.forecast(
                     future_index=X.obs_ind.values,
-                    num_samples=self.num_samples,
+                    posterior=self._posterior,
                     random_seed=self.random_seed,
                 )
-            samples = self._pf.prediction_samples(result)[self._pf.FORECAST_VAR]
-            samples = samples.rename({self._pf.FUTURE_DIM: "obs_ind"})
+            samples = self._pf.prediction_samples(result)
+            y_hat = samples[self._pf.FORECAST_VAR]
+            mu = samples.get(self._pf.MU_FORECAST_VAR, y_hat)
+            time_dim = self._pf.FUTURE_DIM
         else:
             result = self.forecaster.predict_in_sample(
-                num_samples=self.num_samples, random_seed=self.random_seed
+                posterior=self._posterior, random_seed=self.random_seed
             )
-            samples = self._pf.prediction_samples(result)[self._pf.OBS_VAR]
-            samples = samples.rename({self._pf.TIME_DIM: "obs_ind"})
-        return self._to_inference_data(samples, X.obs_ind.values)
+            samples = self._pf.prediction_samples(result)
+            y_hat = samples[self._pf.OBS_VAR]
+            mu = samples.get(self._pf.MU_VAR, y_hat)
+            time_dim = self._pf.TIME_DIM
+        # mu is the noise-free latent (upstream mu/mu_future); statespace
+        # results carry no separate latent, so mu falls back to y_hat there
+        mu = mu.rename({time_dim: "obs_ind"})
+        y_hat = y_hat.rename({time_dim: "obs_ind"})
+        return self._to_inference_data(mu, y_hat, X.obs_ind.values)
 
     def _to_inference_data(
-        self, samples: xr.DataArray, obs_ind: np.ndarray
+        self, mu: xr.DataArray, y_hat: xr.DataArray, obs_ind: np.ndarray
     ) -> az.InferenceData:
         """Rename schema dims onto CausalPy coords and wrap as InferenceData."""
-        if "series" in samples.dims:
-            samples = samples.rename({"series": "treated_units"})
-        else:
-            samples = samples.expand_dims(treated_units=self._treated_units)
-        samples = samples.assign_coords(obs_ind=obs_ind).transpose(
-            "chain", "draw", "obs_ind", "treated_units"
-        )
-        # pymc_forecast exposes the draw-level posterior predictive of the
-        # observed variable; there is no separate noise-free expectation, so
-        # mu and y_hat are the same samples (see module docstring).
-        ds = xr.Dataset({"mu": samples, "y_hat": samples})
+
+        def normalize(samples: xr.DataArray) -> xr.DataArray:
+            if "series" in samples.dims:
+                samples = samples.rename({"series": "treated_units"})
+            else:
+                samples = samples.expand_dims(treated_units=self._treated_units)
+            return samples.assign_coords(obs_ind=obs_ind).transpose(
+                "chain", "draw", "obs_ind", "treated_units"
+            )
+
+        ds = xr.Dataset({"mu": normalize(mu), "y_hat": normalize(y_hat)})
         return az.InferenceData(posterior_predictive=ds)
 
     # -- scoring and impact ------------------------------------------------

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -86,7 +86,7 @@ def _import_pymc_forecast():
         raise ImportError(
             "PyMCForecastModel requires the optional dependency 'pymc-forecast'. "
             "Install it with `pip install causalpy[forecast]` or "
-            "`pip install pymc-forecast>=0.2`."
+            "`pip install 'pymc-forecast[extras]>=0.2'`."
         ) from err
     return pymc_forecast
 

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -49,9 +49,17 @@ draw-level posterior predictive of the observed variable is reported
 separately as ``y_hat``. One posterior subsample is drawn at fit time and
 shared by every predictive call, so draw *i* of the pre-period fit and draw
 *i* of the counterfactual come from the same parameter draw (upstream
-``posterior=`` passthrough). The one exception is ``StatespaceForecaster``
-models, whose upstream outputs carry no separate noise-free latent — there
-``mu`` falls back to the posterior predictive.
+``posterior=`` passthrough).
+
+``StatespaceForecaster`` models are rejected for now: their upstream outputs
+carry no separate noise-free latent, so the impact convention above cannot be
+honoured without silently substituting the noisy predictive. Tracked upstream
+as `pymc-forecast#50 <https://github.com/pymc-labs/pymc-forecast/issues/50>`_.
+
+Inference diagnostics: :attr:`PyMCForecastModel.idata` holds the thinned,
+draw-coherent posterior subsample used for prediction; the *full* fit result
+(e.g. the complete NUTS ``InferenceData`` with sample stats) is exposed as
+:attr:`PyMCForecastModel.fit_idata`.
 """
 
 from __future__ import annotations
@@ -95,12 +103,12 @@ class PyMCForecastModel:
         ethos.
     forecaster : type, optional
         The ``pymc_forecast`` forecaster class used to fit the model. Defaults
-        to :class:`pymc_forecast.HMCForecaster` (NUTS) — or
-        :class:`pymc_forecast.StatespaceForecaster` when ``model_fn`` is a
-        :class:`pymc_forecast.StatespaceModel` — matching CausalPy's native
-        PyMC backends. Pass :class:`pymc_forecast.Forecaster` (ADVI) or
+        to :class:`pymc_forecast.HMCForecaster` (NUTS), matching CausalPy's
+        native PyMC backends. Pass :class:`pymc_forecast.Forecaster` (ADVI) or
         :class:`pymc_forecast.PathfinderForecaster` for faster approximate
         inference — but check convergence before trusting the counterfactual.
+        :class:`pymc_forecast.StatespaceForecaster` is not supported yet (its
+        outputs carry no noise-free latent; see pymc-forecast#50).
     forecaster_kwargs : dict, optional
         Extra keyword arguments for the forecaster constructor (e.g.
         ``{"draws": 500}`` for MCMC, ``{"num_steps": 20_000}`` for ADVI, or
@@ -153,10 +161,21 @@ class PyMCForecastModel:
         self._pf = _import_pymc_forecast()
         self.model_fn = model_fn
         if forecaster is None:
-            forecaster = (
-                self._pf.StatespaceForecaster
-                if isinstance(model_fn, self._pf.StatespaceModel)
-                else self._pf.HMCForecaster
+            forecaster = self._pf.HMCForecaster
+        # Statespace outputs carry no noise-free latent (mu/mu_future), so
+        # CausalPy's impact convention cannot be honoured without silently
+        # substituting the noisy predictive. Reject until pymc-forecast#50
+        # ships the expected-observation outputs.
+        if isinstance(model_fn, self._pf.StatespaceModel) or (
+            isinstance(forecaster, type)
+            and issubclass(forecaster, self._pf.StatespaceForecaster)
+        ):
+            raise NotImplementedError(
+                "StatespaceModel / StatespaceForecaster backends are not "
+                "supported yet: their prediction outputs carry no noise-free "
+                "latent (mu), which CausalPy's causal-impact convention "
+                "requires. Tracked upstream as "
+                "https://github.com/pymc-labs/pymc-forecast/issues/50."
             )
         self.forecaster_cls = forecaster
         self.forecaster_kwargs = dict(forecaster_kwargs or {})
@@ -173,6 +192,52 @@ class PyMCForecastModel:
         self._posterior: xr.Dataset | None = None
         self._treated_units: list[str] = ["unit_0"]
         self._has_covariates = False
+
+    def _clone(self) -> PyMCForecastModel:
+        """Return a fresh, unfitted copy with the same configuration.
+
+        Used by CausalPy's sensitivity checks (e.g.
+        :class:`~causalpy.checks.PlaceboInTime`) via
+        :func:`~causalpy.checks.base.clone_model` to refit the same model
+        specification on placebo data.
+        """
+        return type(self)(
+            self.model_fn,
+            forecaster=self.forecaster_cls,
+            forecaster_kwargs=dict(self.forecaster_kwargs),
+            num_samples=self.num_samples,
+            random_seed=self.random_seed,
+        )
+
+    @property
+    def fit_idata(self) -> az.InferenceData:
+        """Full inference result of the underlying forecaster fit.
+
+        For the default NUTS backend this is the complete MCMC
+        ``InferenceData`` (posterior, sample stats, diagnostics) — as
+        distinct from :attr:`idata`, which holds the thinned posterior
+        subsample shared by every predictive call for draw coherence.
+
+        Raises
+        ------
+        RuntimeError
+            If the model has not been fit yet.
+        AttributeError
+            If the forecaster does not retain an ``InferenceData`` fit
+            result (e.g. variational fits, which expose ``.approx`` /
+            ``.losses`` on ``.forecaster`` instead).
+        """
+        if self.idata is None:
+            raise RuntimeError("Model has not been fit yet.")
+        fit_result = getattr(self.forecaster, "idata", None)
+        if fit_result is None:
+            raise AttributeError(
+                f"{type(self.forecaster).__name__} does not retain a full "
+                "InferenceData fit result; inspect the forecaster directly "
+                "via `.forecaster` (e.g. `.approx` / `.losses` for "
+                "variational fits)."
+            )
+        return fit_result
 
     # -- fitting -----------------------------------------------------------
 
@@ -272,7 +337,7 @@ class PyMCForecastModel:
                 )
             samples = self._pf.prediction_samples(result)
             y_hat = samples[self._pf.FORECAST_VAR]
-            mu = samples.get(self._pf.MU_FORECAST_VAR, y_hat)
+            mu = samples[self._pf.MU_FORECAST_VAR]
             time_dim = self._pf.FUTURE_DIM
         else:
             result = self.forecaster.predict_in_sample(
@@ -280,10 +345,8 @@ class PyMCForecastModel:
             )
             samples = self._pf.prediction_samples(result)
             y_hat = samples[self._pf.OBS_VAR]
-            mu = samples.get(self._pf.MU_VAR, y_hat)
+            mu = samples[self._pf.MU_VAR]
             time_dim = self._pf.TIME_DIM
-        # mu is the noise-free latent (upstream mu/mu_future); statespace
-        # results carry no separate latent, so mu falls back to y_hat there
         mu = mu.rename({time_dim: "obs_ind"})
         y_hat = y_hat.rename({time_dim: "obs_ind"})
         return self._to_inference_data(mu, y_hat, X.obs_ind.values)

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -1,0 +1,375 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Adapter that lets a ``pymc_forecast`` forecasting model act as a model
+provider behind CausalPy's experiment API.
+
+CausalPy keeps identification, counterfactual construction, and placebo
+methods; ``pymc_forecast`` provides the fitted forecasting model. The wrapper
+maps CausalPy's backend protocol onto the ``pymc_forecast`` drivers:
+
+- ``fit(X, y)`` constructs and fits the forecasting model on the pre-period.
+- ``predict(X)`` (in-sample) uses ``predict_in_sample()``.
+- ``predict(X, out_of_sample=True)`` draws the counterfactual with
+  ``forecast(future_covariates=...)`` when the design matrix has columns, or
+  ``forecast(future_index=...)`` for a covariate-free trend/seasonal model.
+- Draw-level samples are extracted with ``prediction_samples()`` and the
+  documented output schema dims are renamed onto CausalPy coords
+  (``time`` / ``time_future`` -> ``obs_ind``, ``series`` -> ``treated_units``).
+
+**When to reach for this backend vs the existing PyMCModel classes:** use
+:class:`PyMCForecastModel` when the counterfactual is best expressed as a
+proper forecasting model (local level / trend, stochastic seasonality, ARIMA-
+style dynamics) built with ``pymc_forecast`` primitives, and you want its
+priors, inference backends (ADVI / NUTS / Pathfinder), and forecasting
+machinery. Stick with the native :class:`~causalpy.pymc_models.PyMCModel`
+classes (e.g. ``LinearRegression``, ``BayesianBasisExpansionTimeSeries``) for
+plain regression-style counterfactuals or when you need model coefficients
+tied to the patsy design matrix.
+
+Requires the optional dependency ``pymc-forecast`` (``pip install
+causalpy[forecast]``).
+
+Notes
+-----
+``pymc_forecast`` exposes draw-level posterior-predictive samples of the
+observed variable rather than a separate noise-free expectation, so this
+backend reports the posterior predictive as both ``mu`` and ``y_hat``. Causal
+impact therefore includes observation-level noise, unlike native
+``PyMCModel`` backends where impact is computed from the noise-free ``mu``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import arviz as az
+import numpy as np
+import pandas as pd
+import xarray as xr
+from arviz import r2_score
+
+from causalpy.constants import HDI_PROB
+from causalpy.utils import round_num
+
+__all__ = ["PyMCForecastModel"]
+
+
+def _import_pymc_forecast():
+    """Import ``pymc_forecast`` lazily, failing with install instructions."""
+    try:
+        import pymc_forecast
+    except ImportError as err:  # pragma: no cover - exercised without extra
+        raise ImportError(
+            "PyMCForecastModel requires the optional dependency 'pymc-forecast'. "
+            "Install it with `pip install causalpy[forecast]` or "
+            "`pip install pymc-forecast>=0.1.0`."
+        ) from err
+    return pymc_forecast
+
+
+class PyMCForecastModel:
+    """Wrap a ``pymc_forecast`` model as a CausalPy time-series backend.
+
+    Parameters
+    ----------
+    model_fn : callable or pymc_forecast.ForecastingModel
+        The forecasting model body ``(Horizon, covariates) -> None`` or a
+        :class:`pymc_forecast.ForecastingModel` instance. Priors flow through
+        this object (pymc-extras ``Prior``), preserving the transparent-prior
+        ethos.
+    forecaster : type, optional
+        The ``pymc_forecast`` forecaster class used to fit the model. Defaults
+        to :class:`pymc_forecast.HMCForecaster` (NUTS), matching CausalPy's
+        native PyMC backends. Pass :class:`pymc_forecast.Forecaster` (ADVI) or
+        :class:`pymc_forecast.PathfinderForecaster` for faster approximate
+        inference — but check convergence before trusting the counterfactual.
+    forecaster_kwargs : dict, optional
+        Extra keyword arguments for the forecaster constructor (e.g.
+        ``{"draws": 500}`` for MCMC or ``{"num_steps": 20_000}`` for ADVI).
+    num_samples : int, default 500
+        Number of posterior(-predictive) draws for in-sample prediction and
+        forecasting.
+    random_seed : int, optional
+        Seed passed to fitting and every predictive call.
+
+    Examples
+    --------
+    >>> import causalpy as cp
+    >>> import pandas as pd
+    >>> import pymc as pm
+    >>> import pytensor.tensor as pt
+    >>> import pymc_forecast  # doctest: +SKIP
+    >>> def local_level(h, covariates):  # doctest: +SKIP
+    ...     drift = pymc_forecast.time_series(
+    ...         h, "drift", lambda name, dims: pm.Normal(name, 0, 0.1, dims=dims)
+    ...     )
+    ...     sigma = pm.HalfNormal("sigma", 1)
+    ...     pymc_forecast.predict(
+    ...         h,
+    ...         lambda name, mu, dims, observed: pm.Normal(
+    ...             name, mu, sigma, dims=dims, observed=observed
+    ...         ),
+    ...         pt.cumsum(drift),
+    ...     )
+    >>> result = cp.InterruptedTimeSeries(  # doctest: +SKIP
+    ...     df,
+    ...     treatment_time,
+    ...     formula="y ~ 0",
+    ...     model=cp.pymc_forecast_models.PyMCForecastModel(local_level),
+    ... )
+    """
+
+    def __init__(
+        self,
+        model_fn: Any,
+        forecaster: type | None = None,
+        forecaster_kwargs: dict[str, Any] | None = None,
+        num_samples: int = 500,
+        random_seed: int | None = None,
+    ) -> None:
+        self._pf = _import_pymc_forecast()
+        self.model_fn = model_fn
+        self.forecaster_cls = (
+            forecaster if forecaster is not None else self._pf.HMCForecaster
+        )
+        self.forecaster_kwargs = dict(forecaster_kwargs or {})
+        self.num_samples = num_samples
+        self.random_seed = random_seed
+        self.forecaster: Any = None
+        self.idata: az.InferenceData | None = None
+        self._treated_units: list[str] = ["unit_0"]
+        self._has_covariates = False
+
+    # -- fitting -----------------------------------------------------------
+
+    def fit(
+        self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
+    ) -> az.InferenceData:
+        """Construct and fit the forecasting model on the pre-period.
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Design matrix with dims ``["obs_ind", "coeffs"]`` whose
+            ``obs_ind`` coordinate carries the real (datetime or numeric)
+            index. Columns are passed to ``pymc_forecast`` as covariates; a
+            zero-column design (formula ``"y ~ 0"``) fits a covariate-free
+            model.
+        y : xr.DataArray
+            Outcome with dims ``["obs_ind", "treated_units"]``. Must contain
+            exactly one treated unit.
+        coords : dict, optional
+            Ignored; the real coordinates are read from ``X`` and ``y``.
+        """
+        if y.sizes["treated_units"] != 1:
+            raise ValueError(
+                "PyMCForecastModel supports a single treated unit, got "
+                f"{y.sizes['treated_units']}."
+            )
+        self._treated_units = [str(u) for u in y.treated_units.values]
+        data = y.isel(treated_units=0, drop=True).rename({"obs_ind": "time"})
+        covariates = self._as_covariates(X)
+        self._has_covariates = covariates is not None
+        self.forecaster = self.forecaster_cls(
+            self.model_fn,
+            data,
+            covariates,
+            random_seed=self.random_seed,
+            **self.forecaster_kwargs,
+        )
+        posterior = self.forecaster.draw_posterior(
+            self.num_samples, random_seed=self.random_seed
+        )
+        self.idata = az.InferenceData(posterior=posterior)
+        return self.idata
+
+    @staticmethod
+    def _as_covariates(X: xr.DataArray) -> xr.DataArray | None:
+        """Map a patsy design matrix onto ``pymc_forecast`` covariates."""
+        if X.sizes["coeffs"] == 0:
+            return None
+        return X.rename({"obs_ind": "time", "coeffs": "covariate"})
+
+    # -- prediction --------------------------------------------------------
+
+    def predict(
+        self,
+        X: xr.DataArray,
+        coords: dict[str, Any] | None = None,
+        out_of_sample: bool | None = False,
+        **kwargs: Any,
+    ) -> az.InferenceData:
+        """Predict in-sample (pre-period) or forecast the counterfactual.
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Design matrix with dims ``["obs_ind", "coeffs"]``. In-sample
+            prediction replays the training window (``X`` supplies only the
+            output coordinates); out-of-sample prediction conditions the
+            forecast on ``X``'s columns as future covariates (or, for a
+            covariate-free model, forecasts over ``X``'s ``obs_ind`` index).
+        coords : dict, optional
+            Not used, kept for API compatibility.
+        out_of_sample : bool, default False
+            ``True`` draws the post-period counterfactual ("as if untreated").
+        **kwargs
+            Reserved for forward-compatibility; not consumed.
+
+        Returns
+        -------
+        az.InferenceData
+            With a ``posterior_predictive`` group holding draw-level ``mu``
+            and ``y_hat`` variables with dims
+            ``(chain, draw, obs_ind, treated_units)``.
+        """
+        if self.forecaster is None:
+            raise RuntimeError("Model has not been fit yet.")
+        if out_of_sample:
+            if self._has_covariates:
+                result = self.forecaster.forecast(
+                    future_covariates=self._as_covariates(X),
+                    num_samples=self.num_samples,
+                    random_seed=self.random_seed,
+                )
+            else:
+                result = self.forecaster.forecast(
+                    future_index=X.obs_ind.values,
+                    num_samples=self.num_samples,
+                    random_seed=self.random_seed,
+                )
+            samples = self._pf.prediction_samples(result)[self._pf.FORECAST_VAR]
+            samples = samples.rename({self._pf.FUTURE_DIM: "obs_ind"})
+        else:
+            result = self.forecaster.predict_in_sample(
+                num_samples=self.num_samples, random_seed=self.random_seed
+            )
+            samples = self._pf.prediction_samples(result)[self._pf.OBS_VAR]
+            samples = samples.rename({self._pf.TIME_DIM: "obs_ind"})
+        return self._to_inference_data(samples, X.obs_ind.values)
+
+    def _to_inference_data(
+        self, samples: xr.DataArray, obs_ind: np.ndarray
+    ) -> az.InferenceData:
+        """Rename schema dims onto CausalPy coords and wrap as InferenceData."""
+        if "series" in samples.dims:
+            samples = samples.rename({"series": "treated_units"})
+        else:
+            samples = samples.expand_dims(treated_units=self._treated_units)
+        samples = samples.assign_coords(obs_ind=obs_ind).transpose(
+            "chain", "draw", "obs_ind", "treated_units"
+        )
+        # pymc_forecast exposes the draw-level posterior predictive of the
+        # observed variable; there is no separate noise-free expectation, so
+        # mu and y_hat are the same samples (see module docstring).
+        ds = xr.Dataset({"mu": samples, "y_hat": samples})
+        return az.InferenceData(posterior_predictive=ds)
+
+    # -- scoring and impact ------------------------------------------------
+
+    def score(
+        self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
+    ) -> pd.Series:
+        """Bayesian :math:`R^2` of the in-sample posterior predictive vs ``y``.
+
+        Matches the ``PyMCModel.score`` output shape: one ``unit_{i}_r2`` /
+        ``unit_{i}_r2_std`` pair per treated unit.
+
+        Parameters
+        ----------
+        X : xr.DataArray
+            Design matrix with dims ``["obs_ind", "coeffs"]``.
+        y : xr.DataArray
+            Observed outcomes with dims ``["obs_ind", "treated_units"]``.
+        coords : dict, optional
+            Not used, kept for API compatibility.
+        """
+        pred = self.predict(X)
+        mu = az.extract(pred, group="posterior_predictive", var_names="mu")
+        scores = {}
+        for i, unit in enumerate(mu.coords["treated_units"].values):
+            unit_mu = mu.sel(treated_units=unit).transpose("sample", "obs_ind")
+            unit_y = y.sel(treated_units=unit).data
+            unit_score = r2_score(unit_y, unit_mu.data)
+            scores[f"unit_{i}_r2"] = unit_score["r2"]
+            scores[f"unit_{i}_r2_std"] = unit_score["r2_std"]
+        return pd.Series(scores)
+
+    def calculate_impact(
+        self, y_true: xr.DataArray, y_pred: az.InferenceData
+    ) -> xr.DataArray:
+        """Causal impact as observed minus counterfactual, at the draw level.
+
+        Parameters
+        ----------
+        y_true : xr.DataArray
+            Observed outcomes with dims ``["obs_ind", "treated_units"]``.
+        y_pred : az.InferenceData
+            Counterfactual prediction from :meth:`predict`.
+        """
+        y_hat = y_pred["posterior_predictive"]["mu"]
+        y_hat = y_hat.assign_coords(obs_ind=y_true["obs_ind"])
+        impact = y_true - y_hat
+        return impact.transpose(..., "obs_ind")
+
+    def calculate_cumulative_impact(self, impact: xr.DataArray) -> xr.DataArray:
+        """Cumulative sum of pointwise causal impact along ``obs_ind``.
+
+        Parameters
+        ----------
+        impact : xr.DataArray
+            Pointwise causal impact, typically the output of
+            :meth:`calculate_impact`.
+        """
+        return impact.cumsum(dim="obs_ind")
+
+    def print_coefficients(
+        self, labels: list[str], round_to: int | None = None
+    ) -> None:
+        """Print posterior means and HDIs of the model's scalar parameters.
+
+        Forecasting-model parameters do not map onto the patsy design-matrix
+        ``labels``, so those are ignored; every scalar variable in the fitted
+        posterior is reported instead. Time-varying latents are skipped.
+
+        Parameters
+        ----------
+        labels : list of str
+            Design-matrix labels; ignored by forecasting models.
+        round_to : int, optional
+            Number of significant figures to round to. Defaults to None,
+            in which case 2 significant figures are used.
+        """
+        if self.idata is None:
+            raise RuntimeError("Model has not been fit yet.")
+        posterior = self.idata.posterior
+        scalar_vars = [
+            name
+            for name, da in posterior.data_vars.items()
+            if set(da.dims) == {"chain", "draw"}
+        ]
+        print("Model parameters:")
+        if not scalar_vars:
+            print("  (no scalar parameters in posterior)")
+            return
+        max_label_length = max(len(name) for name in scalar_vars)
+        for name in scalar_vars:
+            samples = posterior[name]
+            formatted_val = (
+                f"{round_num(samples.mean().data, round_to)}, "
+                f"{HDI_PROB * 100:.0f}% HDI "
+                f"[{round_num(samples.quantile((1 - HDI_PROB) / 2).data, round_to)}, "
+                f"{round_num(samples.quantile(1 - (1 - HDI_PROB) / 2).data, round_to)}]"
+            )
+            print(f"  {name: <{max_label_length}}  {formatted_val}")

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -362,3 +362,84 @@ def test_three_period_design(its_data):
     )
     summary = result.effect_summary(period="comparison")
     assert "persistence" in summary.text
+
+
+def test_statespace_models_rejected():
+    """Statespace backends lack a noise-free latent (pymc-forecast#50)."""
+    with pytest.raises(NotImplementedError, match="pymc-forecast/issues/50"):
+        PyMCForecastModel(linear_model, forecaster=pymc_forecast.StatespaceForecaster)
+
+
+def test_clone_returns_unfitted_copy_with_same_config():
+    """clone_model dispatches to _clone; the copy is unfitted but identically
+    configured, so sensitivity checks can refit the same model spec."""
+    from causalpy.checks.base import clone_model
+
+    model = make_forecast_model()
+    cloned = clone_model(model)
+    assert isinstance(cloned, PyMCForecastModel)
+    assert cloned is not model
+    assert cloned.model_fn is model.model_fn
+    assert cloned.forecaster_cls is model.forecaster_cls
+    assert cloned.forecaster_kwargs == model.forecaster_kwargs
+    assert cloned.forecaster is not model.forecaster
+    assert cloned.num_samples == model.num_samples
+    assert cloned.random_seed == model.random_seed
+    assert cloned.idata is None
+
+
+@pytest.mark.integration
+def test_fit_idata_exposes_full_fit_result(forecast_result):
+    """fit_idata is the full NUTS result; idata the thinned draw-coherent
+    posterior used for prediction."""
+    model = forecast_result.model
+    full = model.fit_idata
+    assert hasattr(full, "sample_stats")
+    assert full.posterior.sizes["draw"] == sample_kwargs["draws"]
+    thinned = forecast_result.idata
+    assert thinned.posterior.sizes["chain"] == 1
+    assert thinned.posterior.sizes["draw"] == model.num_samples
+
+    with pytest.raises(RuntimeError, match="has not been fit"):
+        _ = make_forecast_model().fit_idata
+
+
+@pytest.mark.integration
+class TestPlaceboInTime:
+    """PlaceboInTime accepts the forecast backend and refits it via _clone."""
+
+    def test_validate_accepts_forecast_backend(self, forecast_result):
+        cp.checks.PlaceboInTime(n_folds=2).validate(forecast_result)
+
+    def test_placebo_run_clones_and_refits(self, its_data, forecast_result):
+        from causalpy.checks.base import clone_model
+
+        df, _ = its_data
+        base_model = forecast_result.model
+
+        def factory(data, treatment_time):
+            return cp.InterruptedTimeSeries(
+                data,
+                treatment_time,
+                formula="y ~ 1 + t",
+                model=clone_model(base_model),
+            )
+
+        check = cp.checks.PlaceboInTime(
+            n_folds=2,
+            experiment_factory=factory,
+            sample_kwargs={
+                "draws": 100,
+                "tune": 100,
+                "chains": 2,
+                "progressbar": False,
+            },
+            random_seed=42,
+        )
+        result = check.run(forecast_result)
+        assert len(result.metadata["fold_results"]) == 2
+        for fold in result.metadata["fold_results"]:
+            fold_model = fold.experiment.model
+            assert isinstance(fold_model, PyMCForecastModel)
+            assert fold_model is not base_model
+            assert fold_model.idata is not None

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -181,6 +181,48 @@ class TestRoundTripAgainstPyMCBackend:
         assert forecast_result._model_backend.kind == "pymc-forecast"
         assert forecast_result.idata.posterior is not None
 
+    def test_mu_is_noise_free(self, forecast_result):
+        """mu carries the upstream noise-free latent (mu/mu_future), so it is
+        strictly narrower than the posterior predictive y_hat."""
+        for pred in (forecast_result.pre_pred, forecast_result.post_pred):
+            pp = pred["posterior_predictive"]
+            mu_spread = float(pp["mu"].std(("chain", "draw")).mean())
+            y_hat_spread = float(pp["y_hat"].std(("chain", "draw")).mean())
+            assert mu_spread < y_hat_spread
+        # impact is computed from mu, i.e. excludes observation noise
+        impact_spread = float(forecast_result.post_impact.std(("chain", "draw")).mean())
+        post_pp = forecast_result.post_pred["posterior_predictive"]
+        assert impact_spread == pytest.approx(
+            float(post_pp["mu"].std(("chain", "draw")).mean()), rel=1e-6
+        )
+
+    def test_predictions_are_draw_coherent(self, forecast_result):
+        """One posterior is drawn at fit time and shared by every predictive
+        call: mu is a deterministic function of the shared draws, so repeated
+        calls reproduce it exactly, and pre/post mu come from the same draws
+        (checked through the linear model: mu = X @ beta draw-for-draw)."""
+        model = forecast_result.model
+        posterior = forecast_result.idata.posterior
+        for X, pred, out_of_sample in (
+            (forecast_result.pre_design["X"], forecast_result.pre_pred, False),
+            (forecast_result.post_design["X"], forecast_result.post_pred, True),
+        ):
+            mu = pred["posterior_predictive"]["mu"]
+            expected = xr.dot(
+                posterior["beta"],
+                X.rename({"coeffs": "covariate"}),
+                dim="covariate",
+            )
+            np.testing.assert_allclose(
+                mu.isel(treated_units=0).transpose("chain", "draw", "obs_ind").values,
+                expected.transpose("chain", "draw", "obs_ind").values,
+                rtol=1e-5,
+            )
+            again = model.predict(X, out_of_sample=out_of_sample)
+            np.testing.assert_allclose(
+                mu.values, again["posterior_predictive"]["mu"].values, rtol=1e-6
+            )
+
 
 @pytest.mark.integration
 def test_covariate_free_future_index_path(its_data):

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -34,9 +34,12 @@ from causalpy.pymc_forecast_models import PyMCForecastModel
 
 pymc_forecast = pytest.importorskip("pymc_forecast")
 
+# The y ~ 1 + t design leaves intercept and slope strongly correlated
+# (unscaled t), so give NUTS a real warmup budget: tune=200 produced a
+# badly adapted mass matrix and a biased posterior on CI's platform.
 sample_kwargs = {
-    "draws": 200,
-    "tune": 200,
+    "draws": 500,
+    "tune": 1000,
     "chains": 2,
 }
 

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -34,6 +34,26 @@ from causalpy.pymc_forecast_models import PyMCForecastModel
 
 pymc_forecast = pytest.importorskip("pymc_forecast")
 
+
+@pytest.fixture(scope="module", autouse=True)
+def real_pymc_sampling():
+    """Undo the session-scoped ``mock_pymc_sample`` patch for this module.
+
+    The conftest registers PyMC's ``mock_sample`` (prior sampling instead of
+    MCMC) session-wide, so once any earlier test module requests it,
+    ``pm.sample`` stays mocked for the rest of the run. The round-trip tests
+    here assert effect recovery against ground truth, which is meaningless
+    under prior sampling — restore the real sampler for this module only.
+    """
+    import pymc as pm
+    import pymc.sampling.mcmc
+
+    patched = pm.sample
+    pm.sample = pymc.sampling.mcmc.sample
+    yield
+    pm.sample = patched
+
+
 # The y ~ 1 + t design leaves intercept and slope strongly correlated
 # (unscaled t), so give NUTS a real warmup budget: tune=200 produced a
 # badly adapted mass matrix and a biased posterior on CI's platform.

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -1,0 +1,299 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the pymc-forecast model-provider adapter behind
+InterruptedTimeSeries (issue #1013)."""
+
+import matplotlib
+
+matplotlib.use("Agg")
+
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+import xarray as xr
+
+import causalpy as cp
+from causalpy.experiments.model_adapter import (
+    PyMCForecastAdapter,
+    make_model_adapter,
+)
+from causalpy.pymc_forecast_models import PyMCForecastModel
+
+pymc_forecast = pytest.importorskip("pymc_forecast")
+
+sample_kwargs = {
+    "draws": 200,
+    "tune": 200,
+    "chains": 2,
+}
+
+TRUE_EFFECT = 2.0
+
+
+def linear_model(h, covariates):
+    """Static regression on the patsy design matrix (intercept + trend)."""
+    beta = pm.Normal("beta", 0.0, 2.0, dims="covariate")
+    sigma = pm.HalfNormal("sigma", 1.0)
+    mu = pt.dot(covariates.values, beta)
+    pymc_forecast.predict(
+        h,
+        lambda name, m, dims, observed: pm.Normal(
+            name, m, sigma, dims=dims, observed=observed
+        ),
+        mu,
+    )
+
+
+class LocalLevel(pymc_forecast.ForecastingModel):  # type: ignore[name-defined]
+    """Covariate-free local-level (random-walk drift) model."""
+
+    def model(self, h, covariates):
+        drift = self.time_series(
+            "drift", lambda name, dims: pm.Normal(name, 0.0, 0.1, dims=dims)
+        )
+        sigma = pm.HalfNormal("sigma", 1.0)
+        self.predict(
+            lambda name, m, dims, observed: pm.Normal(
+                name, m, sigma, dims=dims, observed=observed
+            ),
+            pt.cumsum(drift),
+        )
+
+
+@pytest.fixture(scope="module")
+def its_data():
+    """Linear trend with a known level shift after treatment."""
+    rng = np.random.default_rng(42)
+    dates = pd.date_range("2020-01-01", periods=100, freq="D")
+    t = np.arange(100)
+    y = 2.0 + 0.05 * t + rng.normal(0, 0.3, 100)
+    y[70:] += TRUE_EFFECT
+    df = pd.DataFrame({"y": y, "t": t.astype(float)}, index=dates)
+    return df, dates[70]
+
+
+def make_forecast_model():
+    return PyMCForecastModel(
+        linear_model,
+        forecaster_kwargs=dict(sample_kwargs),
+        num_samples=200,
+        random_seed=42,
+    )
+
+
+@pytest.fixture(scope="module")
+def forecast_result(its_data):
+    df, treatment_time = its_data
+    return cp.InterruptedTimeSeries(
+        df,
+        treatment_time,
+        formula="y ~ 1 + t",
+        model=make_forecast_model(),
+    )
+
+
+@pytest.fixture(scope="module")
+def pymc_result(its_data):
+    df, treatment_time = its_data
+    return cp.InterruptedTimeSeries(
+        df,
+        treatment_time,
+        formula="y ~ 1 + t",
+        model=cp.pymc_models.LinearRegression(
+            sample_kwargs={**sample_kwargs, "progressbar": False, "random_seed": 42}
+        ),
+    )
+
+
+@pytest.mark.integration
+class TestRoundTripAgainstPyMCBackend:
+    """Fit pre / forecast post-as-untreated / calculate_impact on draw-level
+    samples, checked against the existing native PyMC path."""
+
+    def test_output_contract_matches_pymc_backend(self, forecast_result, pymc_result):
+        """Draw-level posterior-predictive output mirrors the native backend."""
+        for result in (forecast_result, pymc_result):
+            mu = result.post_pred["posterior_predictive"]["mu"]
+            assert mu.dims == ("chain", "draw", "obs_ind", "treated_units")
+            assert list(mu.coords["treated_units"].values) == ["unit_0"]
+            pd.testing.assert_index_equal(
+                pd.Index(mu.coords["obs_ind"].values),
+                result.datapost.index,
+                check_names=False,
+            )
+
+    def test_impact_recovers_true_effect(self, forecast_result, pymc_result):
+        """Both backends recover the simulated level shift at the draw level."""
+        for result in (forecast_result, pymc_result):
+            impact = result.post_impact
+            assert set(impact.dims) == {"chain", "draw", "obs_ind", "treated_units"}
+            assert impact.dims[-1] == "obs_ind"
+            mean_impact = float(
+                impact.mean(("chain", "draw")).isel(treated_units=0).mean()
+            )
+            assert mean_impact == pytest.approx(TRUE_EFFECT, abs=0.5)
+        forecast_mean = float(
+            forecast_result.post_impact.mean(("chain", "draw"))
+            .isel(treated_units=0)
+            .mean()
+        )
+        pymc_mean = float(
+            pymc_result.post_impact.mean(("chain", "draw")).isel(treated_units=0).mean()
+        )
+        assert forecast_mean == pytest.approx(pymc_mean, abs=0.5)
+
+    def test_cumulative_impact(self, forecast_result):
+        cum = forecast_result.post_impact_cumulative
+        assert "obs_ind" in cum.dims
+        last = float(cum.isel(obs_ind=-1).mean(("chain", "draw")).squeeze())
+        n_post = len(forecast_result.datapost)
+        assert last == pytest.approx(TRUE_EFFECT * n_post, rel=0.4)
+
+    def test_score_matches_pymc_shape(self, forecast_result, pymc_result):
+        assert list(forecast_result.score.index) == list(pymc_result.score.index)
+        assert forecast_result.score["unit_0_r2"] > 0.7
+
+    def test_plot_and_summaries_smoke(self, forecast_result, capsys):
+        fig, ax = forecast_result.plot(show=False)
+        assert len(ax) == 3
+        forecast_result.summary()
+        assert "Model parameters:" in capsys.readouterr().out
+        summary = forecast_result.effect_summary()
+        assert len(summary.text) > 0
+        plot_df = forecast_result.get_plot_data_bayesian()
+        assert {"prediction", "impact"}.issubset(plot_df.columns)
+
+    def test_experiment_reports_bayesian_backend(self, forecast_result):
+        assert forecast_result._model_backend.is_bayesian
+        assert forecast_result._model_backend.kind == "pymc-forecast"
+        assert forecast_result.idata.posterior is not None
+
+
+@pytest.mark.integration
+def test_covariate_free_future_index_path(its_data):
+    """A covariate-free model forecasts over the post-period index via
+    ``forecast(future_index=...)``."""
+    df, treatment_time = its_data
+    result = cp.InterruptedTimeSeries(
+        df,
+        treatment_time,
+        formula="y ~ 0",
+        model=PyMCForecastModel(
+            LocalLevel(),
+            forecaster_kwargs=dict(sample_kwargs),
+            num_samples=200,
+            random_seed=42,
+        ),
+    )
+    mu = result.post_pred["posterior_predictive"]["mu"]
+    assert mu.dims == ("chain", "draw", "obs_ind", "treated_units")
+    pd.testing.assert_index_equal(
+        pd.Index(mu.coords["obs_ind"].values),
+        result.datapost.index,
+        check_names=False,
+    )
+    # A local level frozen at treatment time underestimates the trend, but the
+    # level shift must dominate the impact estimate.
+    mean_impact = float(
+        result.post_impact.mean(("chain", "draw")).isel(treated_units=0).mean()
+    )
+    assert mean_impact > TRUE_EFFECT / 2
+
+
+def _design_arrays(n_units: int = 1):
+    obs_ind = pd.date_range("2020-01-01", periods=10, freq="D")
+    X = xr.DataArray(
+        np.random.default_rng(0).normal(size=(10, 1)),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": obs_ind, "coeffs": ["x"]},
+    )
+    y = xr.DataArray(
+        np.random.default_rng(1).normal(size=(10, n_units)),
+        dims=["obs_ind", "treated_units"],
+        coords={
+            "obs_ind": obs_ind,
+            "treated_units": [f"unit_{i}" for i in range(n_units)],
+        },
+    )
+    return X, y
+
+
+def test_multiple_treated_units_rejected():
+    X, y = _design_arrays(n_units=2)
+    with pytest.raises(ValueError, match="single treated unit"):
+        make_forecast_model().fit(X, y)
+
+
+def test_predict_before_fit_raises():
+    with pytest.raises(RuntimeError, match="has not been fit"):
+        make_forecast_model().predict(_design_arrays()[0])
+
+
+def test_adapter_resolution_and_gating():
+    """make_model_adapter wraps the model and experiments must opt in."""
+    model = make_forecast_model()
+    adapter = make_model_adapter(
+        model,
+        default_model_class=None,
+        supports_bayes=True,
+        supports_ols=True,
+        supports_pymc_forecast=True,
+    )
+    assert isinstance(adapter, PyMCForecastAdapter)
+    assert adapter.is_bayesian
+    assert not adapter.is_ols
+    assert adapter.model is model
+    with pytest.raises(ValueError, match="pymc-forecast models not supported"):
+        make_model_adapter(
+            model,
+            default_model_class=None,
+            supports_bayes=True,
+            supports_ols=True,
+            supports_pymc_forecast=False,
+        )
+
+
+def test_unfit_adapter_has_no_idata_or_coefficients():
+    adapter = make_model_adapter(
+        make_forecast_model(),
+        default_model_class=None,
+        supports_bayes=True,
+        supports_ols=True,
+        supports_pymc_forecast=True,
+    )
+    with pytest.raises(RuntimeError, match="has not been fit"):
+        _ = adapter.idata
+    with pytest.raises(NotImplementedError, match="design-matrix coefficients"):
+        adapter.coefficients()
+
+
+@pytest.mark.integration
+def test_three_period_design(its_data):
+    """treatment_end_time splitting works on the forecast backend's output."""
+    df, treatment_time = its_data
+    result = cp.InterruptedTimeSeries(
+        df,
+        treatment_time,
+        formula="y ~ 1 + t",
+        model=make_forecast_model(),
+        treatment_end_time=df.index[85],
+    )
+    assert result.intervention_pred.posterior_predictive["mu"].sizes["obs_ind"] == 15
+    assert (
+        result.post_intervention_pred.posterior_predictive["mu"].sizes["obs_ind"] == 15
+    )
+    summary = result.effect_summary(period="comparison")
+    assert "persistence" in summary.text

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -12,6 +12,7 @@
   data
   pymc_models
   skl_models
+  pymc_forecast_models
   experiments
   pipeline
   steps

--- a/environment.yml
+++ b/environment.yml
@@ -43,4 +43,4 @@ dependencies:
   - pip
   - pip:
       - marimo[mcp]
-      - pymc-forecast<0.3,>=0.2
+      - pymc-forecast[extras]<0.3,>=0.2

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,6 @@ dependencies:
   - prek
   - pymc-bart
   - pymc-extras>=0.3.0
-  - pymc-forecast<0.3,>=0.2
   - pymc<6,>=5.15.1
   - pytensor<3,>=2.38.1
   - pytest
@@ -44,3 +43,4 @@ dependencies:
   - pip
   - pip:
       - marimo[mcp]
+      - pymc-forecast<0.3,>=0.2

--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,7 @@ dependencies:
   - prek
   - pymc-bart
   - pymc-extras>=0.3.0
-  - pymc-forecast<0.2,>=0.1.0
+  - pymc-forecast<0.3,>=0.2
   - pymc<6,>=5.15.1
   - pytensor<3,>=2.38.1
   - pytest

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,7 @@ dependencies:
   - prek
   - pymc-bart
   - pymc-extras>=0.3.0
+  - pymc-forecast<0.2,>=0.1.0
   - pymc<6,>=5.15.1
   - pytensor<3,>=2.38.1
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,9 @@ dependencies = [
 [project.optional-dependencies]
 # pymc-forecast is young (0.x); pin the minor so API movement across 0.x
 # minors is opted into deliberately (see docs on the ITS forecast backend).
-forecast = ["pymc-forecast>=0.2,<0.3"]
+forecast = [
+    "pymc-forecast>=0.2,<0.3",
+]
 dev = [
     "prek",
     "twine",
@@ -105,10 +107,24 @@ docs = [
     "sphinxext-rediraffe",
 ]
 lint = ["prek", "ruff", "mypy"]
-test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill", "pymc-forecast>=0.2,<0.3"]
+test = [
+    "pytest",
+    "pytest-cov",
+    "diff-cover",
+    "codespell",
+    "nbformat",
+    "nbconvert",
+    "papermill",
+    "pymc-forecast>=0.2,<0.3",
+]
 
 [tool.pyproject2conda]
 channels = ["conda-forge"]
+
+# pymc-forecast is PyPI-only (not on conda-forge): route it to the pip
+# section of the generated environment.yml.
+[tool.pyproject2conda.dependencies]
+pymc-forecast = { pip = true }
 
 [project.urls]
 Homepage = "https://github.com/pymc-labs/CausalPy"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,8 +67,10 @@ dependencies = [
 [project.optional-dependencies]
 # pymc-forecast is young (0.x); pin the minor so API movement across 0.x
 # minors is opted into deliberately (see docs on the ITS forecast backend).
+# The [extras] marker pulls pymc-extras>=0.10, which upstream declares for
+# the Pathfinder integration the adapter advertises.
 forecast = [
-    "pymc-forecast>=0.2,<0.3",
+    "pymc-forecast[extras]>=0.2,<0.3",
 ]
 dev = [
     "prek",
@@ -115,7 +117,7 @@ test = [
     "nbformat",
     "nbconvert",
     "papermill",
-    "pymc-forecast>=0.2,<0.3",
+    "pymc-forecast[extras]>=0.2,<0.3",
 ]
 
 [tool.pyproject2conda]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
 [project.optional-dependencies]
 # pymc-forecast is young (0.x); pin the minor so API movement across 0.x
 # minors is opted into deliberately (see docs on the ITS forecast backend).
-forecast = ["pymc-forecast>=0.1.0,<0.2"]
+forecast = ["pymc-forecast>=0.2,<0.3"]
 dev = [
     "prek",
     "twine",
@@ -105,7 +105,7 @@ docs = [
     "sphinxext-rediraffe",
 ]
 lint = ["prek", "ruff", "mypy"]
-test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill", "pymc-forecast>=0.1.0,<0.2"]
+test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill", "pymc-forecast>=0.2,<0.3"]
 
 [tool.pyproject2conda]
 channels = ["conda-forge"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ dependencies = [
 #
 # Similar to `dependencies` above, these must be valid existing projects.
 [project.optional-dependencies]
+# pymc-forecast is young (0.x); pin the minor so API movement across 0.x
+# minors is opted into deliberately (see docs on the ITS forecast backend).
+forecast = ["pymc-forecast>=0.1.0,<0.2"]
 dev = [
     "prek",
     "twine",
@@ -102,7 +105,7 @@ docs = [
     "sphinxext-rediraffe",
 ]
 lint = ["prek", "ruff", "mypy"]
-test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill"]
+test = ["pytest", "pytest-cov", "diff-cover", "codespell", "nbformat", "nbconvert", "papermill", "pymc-forecast>=0.1.0,<0.2"]
 
 [tool.pyproject2conda]
 channels = ["conda-forge"]


### PR DESCRIPTION
Closes #1013.

Implements the ITS-only first pass: a thin adapter that lets a `pymc_forecast` forecasting model act as a **model provider** behind CausalPy's existing experiment API, in the same spirit as the sklearn wrapper. CausalPy keeps identification, counterfactual construction, and placebo methods; `pymc_forecast` provides the fitted forecasting model.

## What's in here

- **`causalpy/pymc_forecast_models.py`** — `PyMCForecastModel`, a thin wrapper (comparable in size to `skl_models.py`) around a `pymc_forecast` model function / `ForecastingModel` plus a forecaster class (NUTS `HMCForecaster` by default, matching CausalPy's native backends; ADVI/Pathfinder are explicit opt-ins). Maps the experiment protocol onto the upstream 0.1.0 API exactly as scoped in the issue:
  - `fit(X, y)` → construct + fit the forecaster on the pre-period; the patsy design matrix rides along as covariates (`obs_ind → time`, `coeffs → covariate`).
  - `predict(X)` (pre) → `predict_in_sample()`, `posterior_predictive` group.
  - `predict(X, out_of_sample=True)` (post, "as if untreated") → `forecast(future_covariates=post_X)` with exogenous regressors, or `forecast(future_index=post_index)` for a covariate-free trend model.
  - Draw-level samples come out of `prediction_samples(result)` and the documented schema dims are renamed onto CausalPy coords (`time_future → obs_ind`, `series → treated_units`).
  - Priors flow through the model object (pymc-extras `Prior`), keeping the transparent-prior ethos.
- **`PyMCForecastAdapter`** in `experiments/model_adapter.py`, gated by a new `supports_pymc_forecast` flag — enabled for `InterruptedTimeSeries` only (`SyntheticControl` is a tracked follow-up). No change to the public API/UX: users just pass `model=PyMCForecastModel(...)` to `cp.InterruptedTimeSeries`.
- **Optional extra, not a hard dep**: `pip install causalpy[forecast]` → `pymc-forecast>=0.1.0,<0.2` (minor pinned while upstream is 0.x; the output schema is the surface upstream contract-tests). Also added to the `test` extra so CI exercises the adapter; the test module `importorskip`s it.
- **Round-trip tests** (`test_pymc_forecast_adapter.py`, 12 tests): fit pre / forecast post-as-untreated / `calculate_impact` on draw-level samples, with the output contract and recovered effect checked against the existing PyMC `LinearRegression` path on the same synthetic data; plus the covariate-free `future_index` path, three-period designs, plot/`summary()`/`effect_summary()`/`get_plot_data_bayesian()` smoke, single-unit validation, and adapter resolution/gating.
- **Docs**: module docstring carries the "when to reach for this backend vs the existing `PyMCModel` classes" guidance (referenced from the ITS docstring), and the module is added to the API reference index.

## Out of scope (per the issue)

No outsourcing of placebo-in-time, power analysis, or power curves — the boundary stays at model-provider + forecasting metrics.

## Caveats

Coefficient printing reports posterior summaries of the model's scalar parameters instead of design-matrix coefficients.

~~`pymc_forecast` exposes the draw-level posterior predictive of the observed variable rather than a separate noise-free `mu` ...~~ **Resolved with pymc-forecast 0.2**: `mu` now carries the upstream noise-free latent predictor (`mu`/`mu_future`), so causal impact excludes observation noise exactly like the native backends, one posterior subsample is shared by the pre-period fit and the counterfactual (draw coherence via `posterior=`), and the forecaster uses the deferred-fit lifecycle. Pinned `pymc-forecast>=0.2,<0.3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

