### PR TITLE
Reject unsorted or duplicate ITS time indexes before fitting

### DIFF
--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -54,7 +54,8 @@ class InterruptedTimeSeries(BaseExperiment):
     ----------
     data : pd.DataFrame
         A pandas dataframe with time series data. The index should be either
-        a DatetimeIndex or numeric (integer/float).
+        a DatetimeIndex or numeric (integer/float), with unique values in
+        monotonically increasing order.
     treatment_time : Union[int, float, pd.Timestamp]
         The time when treatment occurred, should be in reference to the data index.
         Must match the index type (DatetimeIndex requires pd.Timestamp).
@@ -252,6 +253,11 @@ class InterruptedTimeSeries(BaseExperiment):
         treatment_end_time : int, float, pd.Timestamp, or None, default None
             Optional end of the treatment period for three-period designs.
         """
+        if not data.index.is_unique or not data.index.is_monotonic_increasing:
+            raise BadIndexException(
+                "data.index must be unique and monotonically increasing. "
+                "Sort the data and remove duplicate index values before fitting."
+            )
         if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
             treatment_time, pd.Timestamp
         ):

--- a/causalpy/tests/test_three_period_its.py
+++ b/causalpy/tests/test_three_period_its.py
@@ -18,6 +18,8 @@ Tests the extension of InterruptedTimeSeries to support temporary interventions
 with pre-intervention, intervention, and post-intervention periods.
 """
 
+from unittest.mock import patch
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -577,6 +579,45 @@ def test_effect_summary_invalid_period_raises_error(datetime_data, mock_pymc_sam
 # ==============================================================================
 # 4.2.4 Validation
 # ==============================================================================
+
+
+@pytest.mark.parametrize(
+    ("index", "treatment_time"),
+    [
+        pytest.param(pd.Index([0, 2, 1, 3]), 2, id="unsorted-numeric"),
+        pytest.param(pd.Index([0, 1, 1, 2]), 1, id="duplicate-numeric"),
+        pytest.param(
+            pd.DatetimeIndex(["2024-01-01", "2024-01-03", "2024-01-02", "2024-01-04"]),
+            pd.Timestamp("2024-01-03"),
+            id="unsorted-datetime",
+        ),
+        pytest.param(
+            pd.DatetimeIndex(["2024-01-01", "2024-01-02", "2024-01-02", "2024-01-03"]),
+            pd.Timestamp("2024-01-02"),
+            id="duplicate-datetime",
+        ),
+    ],
+)
+def test_invalid_time_index_rejected_before_design_matrices(index, treatment_time):
+    """Unsorted and duplicate time indexes fail before matrix construction."""
+    data = pd.DataFrame(
+        {"y": np.arange(len(index)), "t": np.arange(len(index))}, index=index
+    )
+
+    with (
+        patch.object(
+            cp.InterruptedTimeSeries, "_build_design_matrices"
+        ) as build_design_matrices,
+        pytest.raises(BadIndexException, match="unique and monotonically increasing"),
+    ):
+        cp.InterruptedTimeSeries(
+            data,
+            treatment_time=treatment_time,
+            formula="y ~ 1 + t",
+            model=LinearRegression(fit_intercept=False),
+        )
+
+    build_design_matrices.assert_not_called()
 
 
 def test_treatment_end_time_less_than_treatment_time_raises_error(datetime_data):


### PR DESCRIPTION
## Summary

- Validate `InterruptedTimeSeries` input indexes are unique and monotonically increasing in `input_validation()` before design matrices are built.
- Raise `BadIndexException` with an actionable message when the contract is violated.
- Add four fast regression tests (unsorted/duplicate numeric and datetime indexes) that assert validation runs before `_build_design_matrices`.
- Document the ordering requirement in the public `data` parameter docstring.

Closes #1018.

## Test plan

- [x] `pytest causalpy/tests/test_three_period_its.py::test_invalid_time_index_rejected_before_design_matrices`
- [x] `prek run` on changed files


Made with [Cursor](https://cursor.com)