### PR TITLE
Document and test the outcome-scale prediction contract

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -81,7 +81,7 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 | **Formulas** | Patsy `dmatrices()` for design matrices; `build_design_matrices()` for counterfactual prediction. Bare datetime predictors are encoded as continuous elapsed days from the fitted origin; use `C(date)` for date fixed effects. `PiecewiseITS` uses `step()`/`ramp()` stateful transforms. |
 | **obs_ind** | All experiments set `data.index.name = "obs_ind"`. Canonical xarray/PyMC dimension name. |
 | **treated_units always 2D** | Even single-unit experiments use `treated_units=["unit_0"]`. Never pass 1D y to PyMC. |
-| **Impact uses mu, not y_hat** | `calculate_impact()` subtracts posterior `mu` (expected value), not `y_hat` (with observation noise). |
+| **Impact uses mu, not y_hat** | `calculate_impact()` subtracts posterior `mu` (conditional expected outcome in observed units), not `y_hat` (with observation noise). For GLMs, `mu` must be inverse-linked before impact; see `docs/source/knowledgebase/prediction-contract.md`. |
 | **Intercept handling** | Patsy includes intercept by default. sklearn models must use `fit_intercept=False`. |
 | **Eager fitting** | MCMC runs during `__init__`. No lazy `.fit()` on the experiment. |
 | **HDI_PROB** | Project default is 0.94 (ArviZ default), not 0.95. |

--- a/causalpy/tests/test_prediction_contract.py
+++ b/causalpy/tests/test_prediction_contract.py
@@ -1,0 +1,207 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Contract tests for outcome-scale ``mu`` semantics in causal impact."""
+
+from __future__ import annotations
+
+import numpy as np
+import pymc as pm
+import pytest
+import xarray as xr
+
+from causalpy.pymc_models import LinearRegression, PyMCModel
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def _single_unit_coords(n_obs: int, n_coeffs: int = 2) -> dict:
+    return {
+        "obs_ind": np.arange(n_obs),
+        "coeffs": [f"x{i}" for i in range(n_coeffs)],
+        "treated_units": ["unit_0"],
+    }
+
+
+def _design_matrix(n_obs: int, rng: np.random.Generator) -> xr.DataArray:
+    x = rng.normal(size=(n_obs, 2))
+    x[:, 0] = 1.0
+    return xr.DataArray(
+        x,
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": np.arange(n_obs), "coeffs": ["Intercept", "x1"]},
+    )
+
+
+class PoissonLogLinkModel(PyMCModel):
+    """Poisson regression with ``mu = exp(eta)`` on the count scale."""
+
+    def build_model(self, X, y, coords):
+        with self:
+            self.add_coords(coords)
+            X_ = pm.Data(name="X", value=X, dims=["obs_ind", "coeffs"])
+            y_ = pm.Data(name="y", value=y, dims=["obs_ind", "treated_units"])
+            beta = pm.Normal("beta", mu=0, sigma=1, dims=["treated_units", "coeffs"])
+            eta = pm.Deterministic(
+                "eta",
+                pm.math.dot(X_, beta.T),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu = pm.Deterministic(
+                "mu", pm.math.exp(eta), dims=["obs_ind", "treated_units"]
+            )
+            pm.Poisson("y_hat", mu=mu, observed=y_, dims=["obs_ind", "treated_units"])
+
+
+class BernoulliLogitModel(PyMCModel):
+    """Bernoulli regression with ``mu = sigmoid(eta)`` on the probability scale."""
+
+    def build_model(self, X, y, coords):
+        with self:
+            self.add_coords(coords)
+            X_ = pm.Data(name="X", value=X, dims=["obs_ind", "coeffs"])
+            y_ = pm.Data(name="y", value=y, dims=["obs_ind", "treated_units"])
+            beta = pm.Normal("beta", mu=0, sigma=1, dims=["treated_units", "coeffs"])
+            eta = pm.Deterministic(
+                "eta",
+                pm.math.dot(X_, beta.T),
+                dims=["obs_ind", "treated_units"],
+            )
+            mu = pm.Deterministic(
+                "mu",
+                pm.math.sigmoid(eta),
+                dims=["obs_ind", "treated_units"],
+            )
+            pm.Bernoulli("y_hat", p=mu, observed=y_, dims=["obs_ind", "treated_units"])
+
+
+def test_linear_regression_mu_matches_outcome_scale_impact(rng, mock_pymc_sample):
+    """Identity-link Gaussian ``mu`` yields outcome-scale impact draws."""
+    n_obs = 12
+    X = _design_matrix(n_obs, rng)
+    beta = np.array([[0.5, 1.2]])
+    y = xr.DataArray(
+        (X.data @ beta.T + rng.normal(scale=0.5, size=(n_obs, 1))).astype(float),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(n_obs), "treated_units": ["unit_0"]},
+    )
+    coords = _single_unit_coords(n_obs)
+
+    model = LinearRegression(sample_kwargs={**sample_kwargs, "random_seed": 42})
+    model.fit(X, y, coords)
+    pred = model.predict(X, coords)
+
+    impact = model.calculate_impact(y, pred)
+    mu = pred.posterior_predictive["mu"]
+    expected = (y - mu).transpose(..., "obs_ind")
+
+    xr.testing.assert_allclose(impact, expected)
+    assert impact.dims[-1] == "obs_ind"
+
+
+def test_poisson_log_link_mu_is_expected_count(rng, mock_pymc_sample):
+    """Compliant Poisson models expose ``exp(eta)`` as ``mu`` for count-scale impact."""
+    n_obs = 15
+    X = _design_matrix(n_obs, rng)
+    rate = np.exp(X.data @ np.array([[0.2, 0.4]]).T)
+    counts = rng.poisson(lam=np.clip(rate, 0.1, None)).astype(float)
+    y = xr.DataArray(
+        counts,
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(n_obs), "treated_units": ["unit_0"]},
+    )
+    coords = _single_unit_coords(n_obs)
+
+    model = PoissonLogLinkModel(sample_kwargs={**sample_kwargs, "random_seed": 7})
+    model.fit(X, y, coords)
+    pred = model.predict(X, coords)
+
+    mu = pred.posterior_predictive["mu"]
+    assert float(mu.min()) >= 0.0
+    impact = model.calculate_impact(y, pred)
+    assert impact.dims[-1] == "obs_ind"
+    # Impact mean should be on the count scale, not the log scale.
+    assert abs(float(impact.mean()) - float((y - mu).mean())) < 1e-6
+
+
+def test_bernoulli_logit_mu_is_probability(rng, mock_pymc_sample):
+    """Compliant Bernoulli models expose ``sigmoid(eta)`` as ``mu``."""
+    n_obs = 20
+    X = _design_matrix(n_obs, rng)
+    logits = X.data @ np.array([[-0.5, 1.0]]).T
+    probs = 1.0 / (1.0 + np.exp(-logits))
+    outcomes = rng.binomial(1, probs).astype(float)
+    y = xr.DataArray(
+        outcomes,
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(n_obs), "treated_units": ["unit_0"]},
+    )
+    coords = _single_unit_coords(n_obs)
+
+    model = BernoulliLogitModel(sample_kwargs={**sample_kwargs, "random_seed": 11})
+    model.fit(X, y, coords)
+    pred = model.predict(X, coords)
+
+    mu = pred.posterior_predictive["mu"]
+    assert float(mu.min()) >= 0.0
+    assert float(mu.max()) <= 1.0
+    impact = model.calculate_impact(y, pred)
+    xr.testing.assert_allclose(impact, (y - mu).transpose(..., "obs_ind"))
+
+
+def test_link_scale_mu_would_mix_units():
+    """Using link-scale ``eta`` as ``mu`` produces contrasts in the wrong units."""
+    n_obs = 3
+    counts = xr.DataArray(
+        np.array([8.0, 10.0, 12.0]),
+        dims=["obs_ind"],
+        coords={"obs_ind": np.arange(n_obs)},
+    )
+    eta = xr.DataArray(
+        np.log([8.0, 10.0, 12.0]),
+        dims=["obs_ind"],
+        coords={"obs_ind": np.arange(n_obs)},
+    )
+    mu = np.exp(eta)
+
+    wrong_impact = counts - eta
+    right_impact = counts - mu
+
+    assert not np.allclose(wrong_impact, right_impact)
+    # Link-scale subtraction is not centered near zero when counts match exp(eta).
+    assert abs(float(wrong_impact.mean())) > 1.0
+    assert abs(float(right_impact.mean())) < 1e-10
+
+
+def test_calculate_impact_uses_mu_not_y_hat(rng, mock_pymc_sample):
+    """Impact excludes observation noise by using ``mu`` rather than ``y_hat``."""
+    n_obs = 10
+    X = _design_matrix(n_obs, rng)
+    y = xr.DataArray(
+        (
+            X.data @ np.array([[0.0, 1.0]]).T + rng.normal(scale=1.0, size=(n_obs, 1))
+        ).astype(float),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": np.arange(n_obs), "treated_units": ["unit_0"]},
+    )
+    coords = _single_unit_coords(n_obs)
+
+    model = LinearRegression(sample_kwargs={**sample_kwargs, "random_seed": 3})
+    model.fit(X, y, coords)
+    pred = model.predict(X, coords)
+
+    impact_from_mu = model.calculate_impact(y, pred)
+    noise_inclusive = y - pred.posterior_predictive["y_hat"]
+
+    with pytest.raises(AssertionError):
+        xr.testing.assert_allclose(impact_from_mu, noise_inclusive)

--- a/docs/source/knowledgebase/estimands.md
+++ b/docs/source/knowledgebase/estimands.md
@@ -22,6 +22,8 @@ The **structure of available data** also constrains which empirical estimands ar
 
 The estimator is the machinery that transforms data into an estimate. Different estimators make different bias-variance trade-offs and have different data requirements. See {doc}`structural_causal_models` for a deeper treatment of structural versus reduced-form approaches.
 
+For Bayesian experiments, the default **response-scale** additive impact (`observed - counterfactual expectation`) is documented in {doc}`prediction-contract`. That contract distinguishes the linear predictor, the conditional expected outcome (`mu`), and posterior-predictive draws (`y_hat`). Risk ratios, odds ratios, and link-scale contrasts are separate estimands and are not the default reporting scale in CausalPy.
+
 :::{note}
 This is an iterative process: estimates inform new theoretical questions, refining our understanding over time.
 :::

--- a/docs/source/knowledgebase/index.md
+++ b/docs/source/knowledgebase/index.md
@@ -5,6 +5,7 @@
 
 glossary
 estimands
+prediction-contract
 reporting_statistics
 design_notation
 quasi_dags.ipynb

--- a/docs/source/knowledgebase/prediction-contract.md
+++ b/docs/source/knowledgebase/prediction-contract.md
@@ -1,0 +1,50 @@
+# Prediction contract for causal impact
+
+CausalPy calculates Bayesian causal impact as the difference between observed outcomes and a counterfactual **expected outcome** in observed outcome units. Experiments call :meth:`~causalpy.pymc_models.PyMCModel.calculate_impact`, which subtracts ``posterior_predictive["mu"]`` from the observed ``y``. That subtraction only has a causal interpretation when ``mu`` is the conditional expectation :math:`E[Y \mid \text{parameters}, \text{covariates}]` on the **response scale**, excluding observation-level noise.
+
+Gaussian models with an identity link make the linear predictor, conditional expectation, and outcome scale look interchangeable. For generalized linear models they are not. With a Poisson log link, the linear predictor :math:`\eta` is on the log-rate scale while counts live on the outcome scale; CausalPy needs :math:`\exp(\eta) = E[Y \mid \cdot]` in ``mu``, not :math:`\eta` itself. The same principle applies to Bernoulli/logit models, where ``mu`` must be a probability in :math:`(0, 1)`.
+
+## Three prediction quantities
+
+| Quantity | Typical name in CausalPy | Scale | Includes observation noise? | Used for impact? |
+|----------|-------------------------|-------|----------------------------|------------------|
+| Linear predictor / latent state | model-specific (e.g. ``eta``) | Link scale | No | No |
+| Conditional expected outcome | ``mu`` | Outcome / response scale | No | **Yes** |
+| Posterior predictive draw | ``y_hat`` | Outcome scale | Yes | No (by default) |
+
+**Impact** uses the middle row: draw-level contrasts ``y - mu`` are computed in outcome units, then summarized. **Plots and effect summaries** inherit this convention unless a method documents a different estimand (for example link-scale regression coefficients).
+
+Posterior transformations for nonlinear models must be applied **draw by draw** before contrasts or averages. In general, ``inverse_link(mean(eta))`` differs from ``mean(inverse_link(eta))``; g-computation averages unit-level potential outcomes on the response scale. See {doc}`estimands` for how this relates to empirical estimands. A worked tutorial notebook is tracked in `CausalPy#1017 <https://github.com/pymc-labs/CausalPy/issues/1017>`_.
+
+## Backend obligations
+
+Every Bayesian backend that participates in impact calculation must expose outcome-scale conditional expectations through ``mu`` in the object returned by ``predict()``:
+
+| Backend | ``mu`` semantics today | Notes |
+|---------|------------------------|-------|
+| Native :class:`~causalpy.pymc_models.PyMCModel` subclasses (e.g. ``LinearRegression``) | ``Deterministic`` named ``mu`` in the PyMC graph | Identity-link Gaussian models satisfy the contract by construction. Custom subclasses must inverse-link before naming the node ``mu``. See {doc}`custom_pymc_models`. |
+| :class:`~causalpy.pymc_models.StateSpaceTimeSeries` | ``mu`` aliases the smoothed expected observation | Gaussian observation model; ``mu`` and ``y_hat`` coincide up to naming. |
+| :class:`~causalpy.pymc_forecast_models.PyMCForecastModel` | Upstream ``mu`` / ``mu_future`` latent passed to ``pymc_forecast.predict()`` | CausalPy treats these as outcome-scale expectations. For linked GLMs, pass the inverse-linked expectation as the latent until upstream exposes a dedicated expected-observation output (`pymc-forecast#52 <https://github.com/pymc-labs/pymc-forecast/issues/52>`_). ``StatespaceForecaster`` is rejected because upstream does not yet expose a separate noise-free expectation (`pymc-forecast#50 <https://github.com/pymc-labs/pymc-forecast/issues/50>`_). |
+| scikit-learn adapters | Point predictions on the outcome scale | OLS backends return fitted values in ``y`` units; no separate ``mu`` draw dimension. |
+
+sklearn backends compute impact as ``y_true - y_pred`` with the same outcome-scale requirement.
+
+## Public name and compatibility
+
+The public posterior predictive name remains ``mu`` for backward compatibility. The contract is **semantic**, not lexical: ``mu`` must denote the conditional expected outcome in observed units. A future explicit name such as ``expected_outcome`` may be added in a minor release once all built-in backends are audited; until then, custom model authors should treat ``mu`` as that quantity.
+
+## Authoring checklist for custom PyMC models
+
+1. Compute the linear predictor or latent state on the link scale if needed, but do not expose it as ``mu`` unless the outcome scale is the identity link.
+2. Apply the inverse link draw by draw and register the result as a ``Deterministic`` named ``mu`` with dims ``["obs_ind", "treated_units"]``.
+3. Keep ``y_hat`` as the likelihood / posterior predictive of the observed variable (including sampling noise where applicable).
+4. Ensure ``predict()`` returns both ``mu`` and ``y_hat`` in ``posterior_predictive`` so :meth:`~causalpy.pymc_models.PyMCModel.calculate_impact` and :meth:`~causalpy.pymc_models.PyMCModel.score` behave consistently.
+
+Fast regression tests in ``causalpy/tests/test_prediction_contract.py`` encode this contract for identity-link Gaussian, Poisson log-link, and Bernoulli logit models.
+
+## Related issues
+
+- CausalPy #1016 (this documentation and contract tests)
+- CausalPy #1017 (g-computation tutorial notebook)
+- `pymc-forecast#52 <https://github.com/pymc-labs/pymc-forecast/issues/52>`_ — explicit expected-observation outputs
+- `pymc-forecast#50 <https://github.com/pymc-labs/pymc-forecast/issues/50>`_ — statespace expected observations


### PR DESCRIPTION
## Summary

- Add knowledgebase page `prediction-contract.md` defining linear predictor vs conditional expectation (`mu`) vs posterior predictive (`y_hat`).
- Document backend obligations for native PyMC models, state-space, sklearn, and `PyMCForecastModel`.
- Cross-link from `estimands.md` and expand the ARCHITECTURE impact convention.
- Add `test_prediction_contract.py` with fast Poisson log-link, Bernoulli logit, and Gaussian contract tests plus a link-scale violation example.

Phase 1 only: no API rename; statespace audit deferred.

Closes #1016 (Phase 1).

## Test plan

- [x] `pytest causalpy/tests/test_prediction_contract.py`
- [x] `prek run` on changed files
- [x] Full test suite passed locally


Made with [Cursor](https://cursor.com)