### PR TITLE
Add a g-computation tutorial for link-function outcome effects

### DIFF
--- a/docs/source/knowledgebase/prediction-contract.md
+++ b/docs/source/knowledgebase/prediction-contract.md
@@ -14,7 +14,7 @@ Gaussian models with an identity link make the linear predictor, conditional exp
 
 **Impact** uses the middle row: draw-level contrasts ``y - mu`` are computed in outcome units, then summarized. **Plots and effect summaries** inherit this convention unless a method documents a different estimand (for example link-scale regression coefficients).
 
-Posterior transformations for nonlinear models must be applied **draw by draw** before contrasts or averages. In general, ``inverse_link(mean(eta))`` differs from ``mean(inverse_link(eta))``; g-computation averages unit-level potential outcomes on the response scale. See {doc}`estimands` for how this relates to empirical estimands. A worked tutorial notebook is tracked in `CausalPy#1017 <https://github.com/pymc-labs/CausalPy/issues/1017>`_.
+Posterior transformations for nonlinear models must be applied **draw by draw** before contrasts or averages. In general, ``inverse_link(mean(eta))`` differs from ``mean(inverse_link(eta))``; g-computation averages unit-level potential outcomes on the response scale. See {doc}`estimands` for how this relates to empirical estimands and {doc}`../notebooks/g-computation-link-functions-pymc` for worked Poisson and logit examples.
 
 ## Backend obligations
 

--- a/docs/source/notebooks/g-computation-link-functions-pymc.ipynb
+++ b/docs/source/notebooks/g-computation-link-functions-pymc.ipynb
@@ -1,0 +1,298 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "7fb27b941602401d91542211134fc71a",
+   "metadata": {},
+   "source": [
+    "# G-computation with link functions in PyMC\n",
+    "\n",
+    "Gaussian {term}`Interrupted Time Series<Interrupted time series design>` models make the linear predictor, conditional expectation, and outcome scale look interchangeable. For generalized linear models they are not. CausalPy's default Bayesian impact subtracts a counterfactual **expected outcome** from the observed response (see {doc}`../knowledgebase/prediction-contract`). This notebook shows why link-scale contrasts fail, how to apply inverse links **draw by draw**, and how g-computation recovers response-scale causal effects from simulated Poisson and Bernoulli data.\n",
+    "\n",
+    ":::{important}\n",
+    "**Empirical estimand (this notebook):** the average difference in expected outcomes between treated and control conditions on the **response scale** (counts for Poisson, probabilities for Bernoulli). Risk ratios, odds ratios, and link-scale regression coefficients are different estimands and are not the default reporting scale in CausalPy.\n",
+    ":::"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acae54e37e7d407bbb7b55eff062a284",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import pymc as pm\n",
+    "import seaborn as sns\n",
+    "\n",
+    "FIG_WIDTH = 7\n",
+    "FIG_HEIGHT = 4\n",
+    "COLOR_TREATED = \"#d62728\"\n",
+    "COLOR_CONTROL = \"#1f77b4\"\n",
+    "COLOR_TRUE = \"black\"\n",
+    "\n",
+    "sample_kwargs = {\n",
+    "    \"chains\": 2,\n",
+    "    \"draws\": 300,\n",
+    "    \"tune\": 300,\n",
+    "    \"target_accept\": 0.9,\n",
+    "    \"random_seed\": 42,\n",
+    "    \"progressbar\": False,\n",
+    "}\n",
+    "rng = np.random.default_rng(42)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a63283cbaf04dbcab1f6479b197f3a8",
+   "metadata": {},
+   "source": [
+    "## Poisson counts: the wrong and right contrasts\n",
+    "\n",
+    "We simulate $n=200$ units with a binary treatment. The data-generating log-rate is $\\eta_i = \\beta_0 + \\beta_1 T_i$ with $\\beta_1 = 0.4$, so the true response-scale effect is $\\mathbb{E}[Y\\mid T{=}1] - \\mathbb{E}[Y\\mid T{=}0] = e^{\\beta_0+\\beta_1} - e^{\\beta_0}$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8dd0d8092fe74a7c96281538738b07e2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "n = 200\n",
+    "treatment = rng.binomial(1, 0.5, size=n)\n",
+    "beta0, beta1 = np.log(8.0), 0.4\n",
+    "eta = beta0 + beta1 * treatment\n",
+    "mu_true = np.exp(eta)\n",
+    "y = rng.poisson(mu_true)\n",
+    "\n",
+    "true_ate = np.exp(beta0 + beta1) - np.exp(beta0)\n",
+    "df_poisson = pd.DataFrame({\"treatment\": treatment, \"y\": y})\n",
+    "df_poisson.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72eea5119410473aa328ad9291626812",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with pm.Model() as poisson_model:\n",
+    "    X = pm.Data(\"X\", df_poisson[[\"treatment\"]].values)\n",
+    "    y_obs = pm.Data(\"y_obs\", df_poisson[\"y\"].values)\n",
+    "    beta = pm.Normal(\"beta\", mu=0, sigma=1, shape=2)\n",
+    "    eta_p = beta[0] + beta[1] * X[:, 0]\n",
+    "    mu_p = pm.Deterministic(\"mu\", pm.math.exp(eta_p))\n",
+    "    pm.Poisson(\"y_hat\", mu=mu_p, observed=y_obs)\n",
+    "    idata_p = pm.sample(**sample_kwargs)\n",
+    "\n",
+    "beta_draws = idata_p.posterior[\"beta\"].stack(sample=(\"chain\", \"draw\")).values\n",
+    "eta_treated = beta_draws[0] + beta_draws[1]\n",
+    "eta_control = beta_draws[0]\n",
+    "mu_treated = np.exp(eta_treated)\n",
+    "mu_control = np.exp(eta_control)\n",
+    "\n",
+    "ate_gcomp = mu_treated - mu_control\n",
+    "ate_wrong_link = eta_treated - eta_control\n",
+    "ate_wrong_avg = np.exp(eta_treated.mean()) - np.exp(eta_control.mean())\n",
+    "\n",
+    "summary = pd.DataFrame(\n",
+    "    {\n",
+    "        \"estimand\": [\n",
+    "            \"True simulation ATE\",\n",
+    "            \"G-computation (draw-wise exp then contrast)\",\n",
+    "            \"Wrong: link-scale contrast\",\n",
+    "            \"Wrong: contrast of link-scale means\",\n",
+    "        ],\n",
+    "        \"mean\": [\n",
+    "            true_ate,\n",
+    "            ate_gcomp.mean(),\n",
+    "            ate_wrong_link.mean(),\n",
+    "            ate_wrong_avg,\n",
+    "        ],\n",
+    "    }\n",
+    ")\n",
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8edb47106e1a46a883d545849b8ab81b",
+   "metadata": {},
+   "source": [
+    ":::{warning}\n",
+    "Subtracting link-scale predictors from observed counts (what happens if `mu` stores $\\eta$ instead of $e^\\eta$) mixes log-rates and counts. Averaging $\\eta$ before exponentiating is also biased by Jensen's inequality: $\\exp(\\mathbb{E}[\\eta]) \\neq \\mathbb{E}[\\exp(\\eta)]$.\n",
+    ":::\n",
+    "\n",
+    "The table shows only the draw-wise g-computation path recovers the simulated count-scale ATE within Monte Carlo error."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10185d26023b46108eb7d9f57d49d2b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(figsize=(FIG_WIDTH, FIG_HEIGHT))\n",
+    "sns.kdeplot(\n",
+    "    ate_gcomp,\n",
+    "    fill=True,\n",
+    "    alpha=0.35,\n",
+    "    color=COLOR_TREATED,\n",
+    "    label=\"G-computation ATE\",\n",
+    "    ax=ax,\n",
+    ")\n",
+    "sns.kdeplot(\n",
+    "    ate_wrong_link,\n",
+    "    fill=True,\n",
+    "    alpha=0.25,\n",
+    "    color=COLOR_CONTROL,\n",
+    "    label=\"Link-scale contrast\",\n",
+    "    ax=ax,\n",
+    ")\n",
+    "ax.axvline(true_ate, color=COLOR_TRUE, linestyle=\"--\", linewidth=1.5, label=\"True ATE\")\n",
+    "ax.set_xlabel(\"Average treatment effect (expected counts)\")\n",
+    "ax.set_ylabel(\"Posterior density\")\n",
+    "ax.legend(frameon=False)\n",
+    "fig.tight_layout()\n",
+    "fig"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8763a12b2bbd4a93a75aff182afb95dc",
+   "metadata": {},
+   "source": [
+    "**Figure:** Posterior distribution of the Poisson ATE on the count scale. The g-computation estimator (inverse link applied per draw, then contrasted) centers on the simulated truth; the link-scale contrast is shifted because it lives on the log-rate scale."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7623eae2785240b9bd12b16a66d81610",
+   "metadata": {},
+   "source": [
+    "## Bernoulli outcomes: probabilities, not logits\n",
+    "\n",
+    "The same logic applies to logit models. The response-scale estimand is a difference in **probabilities** $\\mathbb{E}[Y\\mid T{=}1] - \\mathbb{E}[Y\\mid T{=}0]$, not a difference in logits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7cdc8c89c7104fffa095e18ddfef8986",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "treatment_b = rng.binomial(1, 0.5, size=n)\n",
+    "b0, b1 = -0.2, 0.8\n",
+    "logit_p = b0 + b1 * treatment_b\n",
+    "p_true = 1 / (1 + np.exp(-logit_p))\n",
+    "y_b = rng.binomial(1, p_true)\n",
+    "true_ate_b = (1 / (1 + np.exp(-(b0 + b1)))) - (1 / (1 + np.exp(-b0)))\n",
+    "\n",
+    "with pm.Model() as logit_model:\n",
+    "    Xb = pm.Data(\"Xb\", treatment_b)\n",
+    "    yb = pm.Data(\"yb\", y_b)\n",
+    "    gamma = pm.Normal(\"gamma\", mu=0, sigma=1, shape=2)\n",
+    "    eta_b = gamma[0] + gamma[1] * Xb\n",
+    "    mu_b = pm.Deterministic(\"mu\", pm.math.sigmoid(eta_b))\n",
+    "    pm.Bernoulli(\"y_hat\", p=mu_b, observed=yb)\n",
+    "    idata_b = pm.sample(**sample_kwargs)\n",
+    "\n",
+    "gamma_draws = idata_b.posterior[\"gamma\"].stack(sample=(\"chain\", \"draw\")).values\n",
+    "p_treated = 1 / (1 + np.exp(-(gamma_draws[0] + gamma_draws[1])))\n",
+    "p_control = 1 / (1 + np.exp(-gamma_draws[0]))\n",
+    "ate_b = p_treated - p_control\n",
+    "ate_b_wrong = (gamma_draws[0] + gamma_draws[1]) - gamma_draws[0]\n",
+    "\n",
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"estimand\": [\"True simulation ATE\", \"G-computation\", \"Wrong: logit contrast\"],\n",
+    "        \"mean\": [true_ate_b, ate_b.mean(), ate_b_wrong.mean()],\n",
+    "    }\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b118ea5561624da68c537baed56e602f",
+   "metadata": {},
+   "source": [
+    "A treatment coefficient in a nonlinear model is **not** generally the ATE unless the link is identity and there are no interactions. G-computation averages unit-level potential outcomes over the target population explicitly."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "938c804e27f84196a10c8828c723f798",
+   "metadata": {},
+   "source": [
+    "## Expected outcome vs posterior predictive noise\n",
+    "\n",
+    "Causal impact in CausalPy uses `mu` (conditional expectation, no observation noise). Posterior predictive draws `y_hat` add sampling noise on top. For the Poisson model above, compare the width of $\\mu$ and $y$ for a single treated unit:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "504fb2a444614c0babb325280ed9130a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with poisson_model:\n",
+    "    ppc = pm.sample_posterior_predictive(\n",
+    "        idata_p, var_names=[\"mu\", \"y_hat\"], progressbar=False\n",
+    "    )\n",
+    "\n",
+    "mu_draws = ppc.posterior_predictive[\"mu\"].values.flatten()\n",
+    "yhat_draws = ppc.posterior_predictive[\"y_hat\"].values.flatten()\n",
+    "pd.Series({\"sd(mu)\": mu_draws.std(), \"sd(y_hat)\": yhat_draws.std()})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "59bbdb311c014d738909a11f9e486628",
+   "metadata": {},
+   "source": [
+    "`sd(y_hat)` is larger because it includes Poisson sampling variability. Impact plots and default summaries focus on systematic causal effects via `mu`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b43b363d81ae4b689946ece5c682cd59",
+   "metadata": {},
+   "source": [
+    "## Provider backends (`pymc-forecast`)\n",
+    "\n",
+    "The optional {class}`~causalpy.pymc_forecast_models.PyMCForecastModel` adapter passes upstream `mu` / `mu_future` latents through to CausalPy impact calculation. Until `pymc-forecast` exposes a dedicated expected-observation output ([upstream #52](https://github.com/pymc-labs/pymc-forecast/issues/52)), linked GLM forecasts must supply the **inverse-linked expectation** as the latent so CausalPy subtracts quantities in compatible units. See {doc}`../knowledgebase/prediction-contract` for the full backend table.\n",
+    "\n",
+    "## Summary\n",
+    "\n",
+    "- Define the response-scale estimand before fitting.\n",
+    "- Register inverse-linked expectations as `mu` in custom PyMC models.\n",
+    "- Transform link-scale draws with the inverse link **before** contrasts and averaging.\n",
+    "- Fast regression coverage lives in `causalpy/tests/test_prediction_contract.py`.\n",
+    "\n",
+    ":::{bibliography}\n",
+    ":filter: docname in docnames\n",
+    ":::"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "CausalPy",
+   "language": "python",
+   "name": "causalpy"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.11.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/notebooks/gallery.yaml
+++ b/docs/source/notebooks/gallery.yaml
@@ -72,6 +72,8 @@ groups:
             notebook: interrupted-time-series-lift-test
           - title: "Placebo-in-time and falsification: a UK CO₂ case study"
             notebook: interrupted-time-series-placebo-in-time-analysis
+          - title: G-computation and link functions for outcome-scale effects
+            notebook: g-computation-link-functions-pymc
       - title: Comparative Interrupted Time Series
         intro: |
           Comparative interrupted time series extends standard ITS by incorporating control units as predictors, helping disentangle treatment effects from coincidental changes that affect both treated and control units.

--- a/docs/source/notebooks/index.md
+++ b/docs/source/notebooks/index.md
@@ -191,6 +191,13 @@ A quasi-experimental design that uses time series methods to generate counterfac
 :link: interrupted-time-series-placebo-in-time-analysis
 :link-type: doc
 :::
+
+:::{grid-item-card} G-computation and link functions for outcome-scale effects
+:class-card: sd-card-h-100
+:img-top: ../_static/thumbnails/g-computation-link-functions-pymc.png
+:link: g-computation-link-functions-pymc
+:link-type: doc
+:::
 ::::
 
 ## Comparative Interrupted Time Series
@@ -445,6 +452,7 @@ interrupted-time-series-post-intervention-analysis.ipynb
 interrupted-time-series-covid.ipynb
 interrupted-time-series-lift-test.ipynb
 interrupted-time-series-placebo-in-time-analysis.ipynb
+g-computation-link-functions-pymc.ipynb
 :::
 
 :::{toctree}


### PR DESCRIPTION
## Summary

- Add `g-computation-link-functions-pymc.ipynb` with simulated Poisson and Bernoulli examples.
- Demonstrate link-scale vs response-scale contrasts, draw-wise inverse linking, and `mu` vs `y_hat` uncertainty.
- Document the `pymc-forecast` expected-observation requirement (upstream #52).
- Register the notebook in `gallery.yaml` and link from `prediction-contract.md`.

Stacked on #1020 (closes #1016 Phase 1). Merge #1020 first.

Closes #1017.

## Test plan

- [x] `make gallery` (notebook executed for thumbnail)
- [x] `prek run` on changed files
- [x] Contract tests remain in #1020 (`test_prediction_contract.py`)


Made with [Cursor](https://cursor.com)