### PR TITLE
Fix residual-shape broadcasting bug in OLS DiD effect_summary (~70x SE inflation)

### DIFF
--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -1494,7 +1494,14 @@ def _compute_statistics_did_ols(
     X_da = result.design["X"]
     y_da = result.design["y"]
     y_pred = result.model.predict(X_da)
-    residuals = y_da - y_pred
+    # y_da has shape (n, 1) with dims (obs_ind, treated_units); y_pred is a
+    # bare (n,) array with no dimension names. Subtracting them directly lets
+    # xarray align y_pred positionally against the *last* axis (treated_units,
+    # size 1) instead of obs_ind, producing an (n, n) array of every
+    # observation's y minus every other observation's prediction instead of
+    # per-observation residuals. Flatten both to 1-D first so they align by
+    # position on obs_ind as intended.
+    residuals = np.asarray(y_da).reshape(-1) - np.asarray(y_pred).reshape(-1)
     mse = np.mean(residuals**2)
     n, p = X_da.shape
     df = n - p

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -333,6 +333,67 @@ def test_effect_summary_ols_did(mock_pymc_sample, did_data):
 
 
 @pytest.mark.integration
+def test_effect_summary_ols_did_residuals_are_per_observation(did_data):
+    """``_compute_statistics_did_ols`` must compute one residual per
+    observation, not an (n, n) array.
+
+    ``y_da`` (shape ``(n, 1)``, dims ``obs_ind x treated_units``) minus a bare
+    ``(n,)`` ``y_pred`` array used to broadcast positionally against the
+    *last* axis (``treated_units``, size 1) instead of ``obs_ind``, producing
+    an ``(n, n)`` array of every observation's y minus every *other*
+    observation's prediction. That inflated the reported SE by roughly 70x
+    on this dataset. This test checks the residual shape directly and checks
+    the reported SE against an independent statsmodels fit, up to the
+    still-present (separately tracked) mean/(n-p) denominator convention
+    difference, which is out of scope for this fix.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    df = did_data
+    formula = "y ~ 1 + group * post_treatment"
+
+    result = cp.DifferenceInDifferences(
+        df,
+        formula=formula,
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    X_da = result.design["X"]
+    y_da = result.design["y"]
+    y_pred = result.model.predict(X_da)
+    residuals = np.asarray(y_da).reshape(-1) - np.asarray(y_pred).reshape(-1)
+    n = X_da.shape[0]
+    assert residuals.shape == (n,)
+
+    stats = result.effect_summary()
+    row = stats.table.loc["treatment_effect"]
+
+    import statsmodels.formula.api as smf
+    from scipy.stats import t as t_dist
+
+    sm_fit = smf.ols(formula, data=df).fit()
+    interaction_col = next(
+        name for name in sm_fit.params.index if "group" in name and "post" in name
+    )
+    unbiased_se = sm_fit.bse[interaction_col]
+    # CausalPy still divides by n rather than (n - p) here (tracked
+    # separately), so the correctly-shaped residuals give an SE smaller than
+    # the unbiased statsmodels value by sqrt((n - p) / n), not an exact match.
+    p = X_da.shape[1]
+    expected_se_with_mean_denominator = unbiased_se * np.sqrt((n - p) / n)
+
+    t_crit = t_dist.ppf(1 - 0.05 / 2, df=n - p)
+    reported_se = (row["ci_upper"] - row["ci_lower"]) / (2 * t_crit)
+
+    assert reported_se == pytest.approx(expected_se_with_mean_denominator, rel=1e-6)
+    # Guard against regressing to the (n, n) broadcast bug: that variant
+    # inflated the SE by roughly 70x on this dataset.
+    assert reported_se < unbiased_se * 2
+
+
+@pytest.mark.integration
 def test_effect_summary_ols_sc(mock_pymc_sample, sc_data):
     """Test effect_summary with OLS model for Synthetic Control."""
     from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
## Summary
- `_compute_statistics_did_ols` computed `residuals = y_da - y_pred`, where `y_da` is an xarray `DataArray` of shape `(n, 1)` with dims `(obs_ind, treated_units)` and `y_pred` is a bare `(n,)` numpy array with no dimension names.
- xarray aligned `y_pred` positionally against the *last* axis (`treated_units`, size 1) instead of `obs_ind`, producing an `(n, n)` array of every observation's `y` minus every *other* observation's prediction instead of `n` proper residuals.
- On the built-in `did` dataset this inflated the reported SE by roughly 70x (SE ≈ 4.16 instead of ≈ 0.06), making the reported CI `[-7.98, 8.89]` instead of the correct `[0.34, 0.58]` — not a rounding nuance, essentially uninformative.
- Fixes it by flattening both operands to 1-D before differencing so they align by position on `obs_ind`.

This is independent of #1025 (which fixes a separate denominator-convention bug a couple of lines below) — both touch adjacent but non-overlapping lines and can merge in either order without conflict. This PR deliberately leaves the `mean`-based denominator as-is; #1025 handles that.

## Test plan
- [x] Added `test_effect_summary_ols_did_residuals_are_per_observation` in `causalpy/tests/test_reporting.py`, asserting residuals have shape `(n,)` and the reported SE matches the expected value up to the still-present (separately tracked) denominator convention
- [x] `pytest causalpy/tests/test_reporting.py -k did` — 11 passed
- [x] Full suite: 1225 passed, 5 skipped
- [x] `make test-patch-cov` — 100% patch coverage on the diff
- [x] Independently verified against `statsmodels` OLS: reported SE now matches `unbiased_se * sqrt((n-p)/n)` exactly, confirming the `(n,n)` broadcast is gone