### PR TITLE
Align local patch coverage gate with Codecov (split from #1024)

### DIFF
--- a/.agents/skills/pr-workflows/reference/prek.md
+++ b/.agents/skills/pr-workflows/reference/prek.md
@@ -11,10 +11,10 @@ description: Run prek checks and handle auto-fix output.
 # Fast iteration on changed files
 prek run --files path/to/file.py
 
-# Full verification before push/commit
+# Full verification before commit
 prek run --all-files
 
-# Python source/test changes: local patch coverage gate
+# Patch coverage at PR-ready / large-task milestones (not every commit; ~90s+)
 make test-patch-cov
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,13 @@ Renamed or deleted how-to pages must keep a **permanent** entry in `rediraffe_re
 ## Code quality checks
 
 - **Before committing**: Use `prek run` during iterative edits and run `prek run --all-files` before committing to ensure all checks pass (linting, formatting, type checking)
-- **Patch coverage before handoff**: When Python source or tests change, run `$CONDA_EXE run -n CausalPy make test-patch-cov` before pushing or handing off. This keeps the default `prek run` fast while locally approximating the remote Codecov patch gate against `upstream/main` when available, falling back to `origin/main`. Override `DIFF_COVER_COMPARE_BRANCH` or `DIFF_COVER_FAIL_UNDER` only when the PR deliberately targets a different base or threshold.
+- **Patch coverage (milestones, not every commit)**: `make test-patch-cov` is intentionally **not** in `prek` — it runs the full test suite (~90s+) and needs the conda env. Run it at meaningful checkpoints when Python source or tests under `causalpy/` changed, not on every small commit:
+  - A PR is ready for review, or you are about to push for CI
+  - You finished a large or multi-file task touching production code
+  - You are handing off to another person or agent
+  - During iterative work, rely on `prek` and targeted `pytest` instead
+  - Command: `$CONDA_EXE run -n CausalPy make test-patch-cov`
+  - The gate measures **production code only** (`causalpy/tests/*` excluded) at **96%**, approximating the remote Codecov patch check against `upstream/main` when available, falling back to `origin/main`. Override `DIFF_COVER_COMPARE_BRANCH`, `DIFF_COVER_FAIL_UNDER`, or `DIFF_COVER_EXCLUDE` only when the PR deliberately targets a different base or threshold.
 - **Quick check**: Run `ruff check causalpy/` for fast linting feedback during development
 - **Auto-fix**: Run `ruff check --fix causalpy/` to automatically fix many linting issues
 - **Format**: Run `ruff format causalpy/` to format code according to project standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,13 +211,13 @@ We recommend that your contribution complies with the following guidelines befor
     make test
     ```
 
-- For pull requests that change Python source or tests, also run the local patch coverage gate before pushing:
+- For pull requests that change Python source or tests, run the local patch coverage gate before marking the PR ready for review or pushing for CI (not on every commit — it runs the full suite):
 
     ```bash
     make test-patch-cov
     ```
 
-    This runs the test suite with coverage, writes `coverage.xml`, and uses `diff-cover` to fail when changed lines fall below the local patch threshold. The compare branch defaults to `upstream/main` when that tracking branch exists and falls back to `origin/main` otherwise. If your branch targets a different base, set `DIFF_COVER_COMPARE_BRANCH`, for example `DIFF_COVER_COMPARE_BRANCH=upstream/release make test-patch-cov`.
+    This runs the test suite with coverage, writes `coverage.xml`, and uses `diff-cover` to fail when changed lines in production code (excluding `causalpy/tests/*`) fall below the local patch threshold (default 96%, aligned with Codecov’s patch gate). The compare branch defaults to `upstream/main` when that tracking branch exists and falls back to `origin/main` otherwise. If your branch targets a different base, set `DIFF_COVER_COMPARE_BRANCH`, for example `DIFF_COVER_COMPARE_BRANCH=upstream/release make test-patch-cov`.
 
 - When adding additional functionality, either edit an existing example, or create a new example (typically in the form of a Jupyter Notebook). Have a look at other examples for reference. Examples should demonstrate why the new functionality is useful in practice.
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ PACKAGE_DIR = causalpy
 .PHONY: init setup lint check_lint check-exports check-architecture test test-patch-cov uml gallery html cleandocs doctest run_notebooks_full help
 
 DIFF_COVER_COMPARE_BRANCH ?= $(shell if git show-ref --verify --quiet refs/remotes/upstream/main; then printf "upstream/main"; else printf "origin/main"; fi)
-DIFF_COVER_FAIL_UNDER ?= 95
+DIFF_COVER_FAIL_UNDER ?= 96
+DIFF_COVER_EXCLUDE ?= causalpy/tests/*
 
 init: ## Install the package in editable mode
 	python -m pip install -e . --no-deps
@@ -44,7 +45,7 @@ test: ## Run all tests with pytest
 
 test-patch-cov: ## Run tests and fail if patch coverage versus the base branch is too low
 	python -m pytest --cov-report=xml --no-cov-on-fail
-	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_COMPARE_BRANCH) --fail-under=$(DIFF_COVER_FAIL_UNDER)
+	diff-cover coverage.xml --compare-branch=$(DIFF_COVER_COMPARE_BRANCH) --fail-under=$(DIFF_COVER_FAIL_UNDER) --exclude '$(DIFF_COVER_EXCLUDE)'
 
 uml: ## Generate UML diagrams from code
 	pyreverse -o png causalpy --output-directory docs/source/_static --ignore tests

--- a/codecov.yml
+++ b/codecov.yml
@@ -17,3 +17,11 @@ coverage:
         if_ci_failed: error #success, failure, error, ignore
         informational: false
         only_pulls: false
+    patch:
+      default:
+        target: 95%
+        threshold: 0%
+        base: auto
+        paths:
+          - "causalpy/"
+        only_pulls: true


### PR DESCRIPTION
## Summary

- Excludes test files from the local `diff-cover` gate and raises the local fail-under to 96%, so `make test-patch-cov` measures production code only and approximates the remote gate.
- Pins the Codecov patch check to 95% on `causalpy/`.
- Documents `make test-patch-cov` as a milestone check (PR-ready, large-task handoff), not a per-commit step, in `AGENTS.md`, `CONTRIBUTING.md`, and the pr-workflows skill.

Split out of #1024 per review: these are repo-wide process changes unrelated to the GLR feature and complicate its review and revert.

## Test plan

- [x] `prek run --all-files`
- [x] `make test-patch-cov` runs with the new exclusion locally

Made with [Cursor](https://cursor.com)