### PR TITLE
Unify `_bayesian_plot` / `_ols_plot` into a single backend-agnostic `_plot`

### DIFF
--- a/.agents/skills/review-pr/resources/code-patterns.md
+++ b/.agents/skills/review-pr/resources/code-patterns.md
@@ -7,9 +7,8 @@ Use this resource when reviewing source-code diffs. It collects CausalPy contrac
 All experiment classes in `causalpy/experiments/` inherit from `BaseExperiment`.
 
 - Declare `supports_ols: bool` and `supports_bayes: bool`.
-- If Bayesian is supported, implement `_bayesian_plot()` and `get_plot_data_bayesian()`.
-- If OLS is supported, implement `_ols_plot()` and `get_plot_data_ols()`.
-- Dispatch by model type with `isinstance(self.model, PyMCModel)` and `isinstance(self.model, RegressorMixin)`.
+- Implement a single backend-agnostic `_plot()` (and `get_plot_data()` where applicable) that consumes the canonical prediction container.
+- Key uncertainty rendering on data properties (`has_posterior_draws()` from `causalpy.plot_utils`), not backend identity; any surviving `is_bayesian` branch needs written justification.
 - Keep the data index named `"obs_ind"`.
 - Parse formulas through patsy `dmatrices()`.
 - Use project exceptions from `causalpy.custom_exceptions` for formula, data, and index errors.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -46,7 +46,7 @@ The optional third backend, `PyMCForecastModel` (`causalpy/pymc_forecast_models.
 
 ## Experiment Lifecycle
 
-Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepare_data()` → `algorithm()`. There is no separate `.fit()` on the experiment. Each subclass's public `plot(*, ...)` delegates to `_render_plot()`, which dispatches to `_bayesian_plot()` or `_ols_plot()`. `effect_summary()` returns `EffectSummary(table, text)` using helpers from `causalpy.reporting`.
+Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepare_data()` → `algorithm()`. There is no separate `.fit()` on the experiment. Each subclass's public `plot(*, ...)` delegates to `_render_plot()`, which calls the subclass's backend-agnostic `_plot()`. Uncertainty rendering keys on data properties of the canonical prediction container (`has_posterior_draws()`), not on backend identity. `effect_summary()` returns `EffectSummary(table, text)` using helpers from `causalpy.reporting`.
 
 ## Experiment Inventory
 
@@ -91,7 +91,7 @@ Instantiation fits eagerly in `__init__`: `_build_design_matrices()` → `_prepa
 
 Copy the closest existing experiment or model and follow the `BaseExperiment` contract:
 
-- Declare `supports_ols` / `supports_bayes` (and `supports_pymc_forecast` to opt into the optional pymc-forecast backend); implement `_bayesian_plot()` / `_ols_plot()` only for supported backends
+- Declare `supports_ols` / `supports_bayes` (and `supports_pymc_forecast` to opt into the optional pymc-forecast backend); implement a single backend-agnostic `_plot()` (and `get_plot_data()`) that consumes the canonical prediction container, keying uncertainty rendering on `has_posterior_draws()` rather than backend identity
 - `algorithm()` with the fit/predict/impact flow; `effect_summary()` via helpers in `causalpy.reporting`
 - Public `plot(*, ...)` with a kwarg-only signature that delegates to `_render_plot()` — bare `*args` / `**kwargs` are forbidden on the public surface (enforced by `causalpy/tests/test_public_plot_signatures.py`). For experiments without a unified plot view (e.g. `InversePropensityWeighting`, `InstrumentalVariable`), declare an explicit `plot()` stub that raises `NotImplementedError`. For `hdi_prob` defaults, use ``Defaults to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).`` in the docstring.
 - Raise `FormulaException`, `DataException`, or `BadIndexException` from `causalpy.custom_exceptions` for formula, data, and index errors

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -376,12 +376,7 @@ class BaseExperiment(ABC):
         ... )
         """
         with plt.style.context(az.style.library["arviz-darkgrid"]):
-            if self._model_backend.is_bayesian:
-                fig, ax = self._bayesian_plot(**draw_kwargs)
-            elif self._model_backend.is_ols:
-                fig, ax = self._ols_plot(**draw_kwargs)
-            else:
-                raise ValueError("Unsupported model type")
+            fig, ax = self._plot(**draw_kwargs)
 
         # Apply legend customization if requested.  We mutate the existing
         # Legend object in place so that custom handles — especially the
@@ -410,6 +405,22 @@ class BaseExperiment(ABC):
             plt.show()
 
         return fig, ax
+
+    def _plot(self, **kwargs: Any) -> tuple:
+        """Draw the experiment figure; called by :meth:`_render_plot`.
+
+        Subclasses implement a single backend-agnostic ``_plot`` that consumes
+        the canonical prediction container. Experiments not yet migrated keep
+        paired ``_bayesian_plot`` / ``_ols_plot`` methods, which this default
+        dispatches to.
+        """
+        # ponytail: transitional dispatch while experiments migrate one at a
+        # time to a unified _plot (issue #1037); delete once all are migrated.
+        if self._model_backend.is_bayesian:
+            return self._bayesian_plot(**kwargs)
+        if self._model_backend.is_ols:
+            return self._ols_plot(**kwargs)
+        raise ValueError("Unsupported model type")
 
     def _bayesian_plot(self, *args: Any, **kwargs: Any) -> tuple:
         """Plot results for Bayesian models. Override in subclasses that support Bayesian."""

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -319,8 +319,7 @@ class BaseExperiment(ABC):
 
         1. Applies the ``arviz-darkgrid`` style for the duration of the
            draw call.
-        2. Dispatches to :meth:`_bayesian_plot` or :meth:`_ols_plot` based
-           on the model type.
+        2. Calls the subclass's backend-agnostic :meth:`_plot`.
         3. Mutates the resulting legend(s) in place when *legend_kwargs*
            is supplied, preserving custom handles built by the subclass.
         4. Optionally calls :func:`matplotlib.pyplot.show`.
@@ -347,8 +346,8 @@ class BaseExperiment(ABC):
             alongside ``bbox_to_anchor``.
         **draw_kwargs
             Subclass-specific drawing parameters forwarded verbatim to
-            ``_bayesian_plot`` / ``_ols_plot``. May include ``kind``,
-            ``ci_kind``, ``ci_prob``, and ``num_samples`` for
+            ``_plot``. May include ``kind``, ``ci_kind``, ``ci_prob``, and
+            ``num_samples`` for
             :func:`~causalpy.plot_utils.plot_posterior_over_x`.
 
         Notes
@@ -356,7 +355,7 @@ class BaseExperiment(ABC):
         **Legend handling and ``plot_posterior_over_x`` return types:** :func:`~causalpy.plot_utils.plot_posterior_over_x`
         returns ``(Line2D, PolyCollection)`` for ``kind="ribbon"`` but
         ``(list[Line2D], None)`` for ``kind="histogram"`` or ``"spaghetti"``.
-        Subclass ``_bayesian_plot`` / ``_ols_plot`` implementations that assemble
+        Subclass ``_plot`` implementations that assemble
         matplotlib legends from those return values should only pack
         ``(line, patch)`` tuples when calling ``plot_posterior_over_x`` with ``kind="ribbon"``
         (the default). Many current experiment plots always use the ribbon
@@ -410,48 +409,16 @@ class BaseExperiment(ABC):
         """Draw the experiment figure; called by :meth:`_render_plot`.
 
         Subclasses implement a single backend-agnostic ``_plot`` that consumes
-        the canonical prediction container. Experiments not yet migrated keep
-        paired ``_bayesian_plot`` / ``_ols_plot`` methods, which this default
-        dispatches to.
+        the canonical prediction container. Uncertainty rendering should key
+        on data properties (e.g.
+        :func:`~causalpy.plot_utils.has_posterior_draws`), not backend
+        identity.
         """
-        # ponytail: transitional dispatch while experiments migrate one at a
-        # time to a unified _plot (issue #1037); delete once all are migrated.
-        if self._model_backend.is_bayesian:
-            return self._bayesian_plot(**kwargs)
-        if self._model_backend.is_ols:
-            return self._ols_plot(**kwargs)
-        raise ValueError("Unsupported model type")
-
-    def _bayesian_plot(self, *args: Any, **kwargs: Any) -> tuple:
-        """Plot results for Bayesian models. Override in subclasses that support Bayesian."""
-        raise NotImplementedError("_bayesian_plot method not yet implemented")
-
-    def _ols_plot(self, *args: Any, **kwargs: Any) -> tuple:
-        """Plot results for OLS models. Override in subclasses that support OLS."""
-        raise NotImplementedError("_ols_plot method not yet implemented")
+        raise NotImplementedError("_plot method not yet implemented")
 
     def get_plot_data(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
         """Recover the data of an experiment along with the prediction and causal impact information.
 
-        Internally, this function dispatches to either :func:`get_plot_data_bayesian` or :func:`get_plot_data_ols`
-        depending on the model type.
-
-        Parameters
-        ----------
-        *args
-            Positional arguments forwarded to the model-specific implementation.
-        **kwargs
-            Keyword arguments forwarded to the model-specific implementation.
-        """
-        if self._model_backend.is_bayesian:
-            return self.get_plot_data_bayesian(*args, **kwargs)
-        if self._model_backend.is_ols:
-            return self.get_plot_data_ols(*args, **kwargs)
-        raise ValueError("Unsupported model type")
-
-    def get_plot_data_bayesian(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
-        """Return plot data for Bayesian models. Override in subclasses that support Bayesian.
-
         Parameters
         ----------
         *args
@@ -459,19 +426,7 @@ class BaseExperiment(ABC):
         **kwargs
             Keyword arguments forwarded to the subclass implementation.
         """
-        raise NotImplementedError("get_plot_data_bayesian method not yet implemented")
-
-    def get_plot_data_ols(self, *args: Any, **kwargs: Any) -> pd.DataFrame:
-        """Return plot data for OLS models. Override in subclasses that support OLS.
-
-        Parameters
-        ----------
-        *args
-            Positional arguments forwarded to the subclass implementation.
-        **kwargs
-            Keyword arguments forwarded to the subclass implementation.
-        """
-        raise NotImplementedError("get_plot_data_ols method not yet implemented")
+        raise NotImplementedError("get_plot_data method not yet implemented")
 
     @abstractmethod
     def effect_summary(
@@ -511,7 +466,7 @@ class BaseExperiment(ABC):
             ``hdi_prob = 1 - alpha``. Note that this is independent of the
             project-wide :data:`~causalpy.constants.HDI_PROB` constant
             (currently 0.94) used by :meth:`plot` and
-            :meth:`get_plot_data_bayesian`, so the same experiment may report
+            :meth:`get_plot_data`, so the same experiment may report
             a 95% HDI in :meth:`effect_summary` and a 94% HDI in :meth:`plot`
             with default settings.
         cumulative : bool, default=True

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -31,7 +31,11 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
-from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
+from causalpy.plot_utils import (
+    _PosteriorPlotStyle,
+    has_posterior_draws,
+    plot_posterior_over_x,
+)
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import (
     EffectSummary,
@@ -428,7 +432,7 @@ class DifferenceInDifferences(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,
@@ -441,13 +445,18 @@ class DifferenceInDifferences(BaseExperiment):
         """
         Plot the results.
 
+        Consumes the canonical prediction container from any backend. When the
+        container carries posterior draws, group fits render as uncertainty
+        bands with a counterfactual violin/band; point-estimate backends
+        (singleton ``chain``/``draw``) get point markers.
+
         Parameters
         ----------
         round_to : int, optional
             Number of decimals used to round results. Defaults to 2. Use ``None``
             to return raw numbers.
-        hdi_prob : float, optional
-            Probability mass of the highest density interval drawn around the
+        ci_prob : float, optional
+            Probability mass of the credible interval drawn around the
             posterior predictive bands for the control, treatment, and
             counterfactual trajectories. Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
@@ -455,6 +464,7 @@ class DifferenceInDifferences(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``None``
             (use matplotlib's default).
         """
+        with_uncertainty = has_posterior_draws(self.y_pred_control)
         style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
@@ -462,208 +472,151 @@ class DifferenceInDifferences(BaseExperiment):
             "num_samples": num_samples,
         }
 
-        def _plot_causal_impact_arrow(results, ax):
-            """
-            draw a vertical arrow between `y_pred_counterfactual` and
-            `y_pred_counterfactual`
-            """
-            # Calculate y values to plot the arrow between
-            y_pred_treatment = results.y_pred_treatment.isel(obs_ind=1).mean().data
-            y_pred_counterfactual = results.y_pred_counterfactual.mean().data
-            y_pred_treatment_scalar = _as_scalar(y_pred_treatment)
-            y_pred_counterfactual_scalar = _as_scalar(y_pred_counterfactual)
-            # Calculate the x position to plot at
-            # Note that we force to be float to avoid a type error using np.ptp with boolean
-            # values
-            diff = np.ptp(
-                np.array(
-                    results.x_pred_treatment[results.time_variable_name].values
-                ).astype(float)
-            )
-            x = (
-                np.max(results.x_pred_treatment[results.time_variable_name].values)
-                + 0.1 * diff
-            )
-            # Plot the arrow
-            ax.annotate(
-                "",
-                xy=(x, y_pred_counterfactual_scalar),
-                xycoords="data",
-                xytext=(x, y_pred_treatment_scalar),
-                textcoords="data",
-                arrowprops={"arrowstyle": "<-", "color": "green", "lw": 3},
-            )
-            # Plot text annotation next to arrow
-            ax.annotate(
-                "causal\nimpact",
-                xy=(
-                    x,
-                    np.mean([y_pred_counterfactual_scalar, y_pred_treatment_scalar]),
-                ),
-                xycoords="data",
-                xytext=(5, 0),
-                textcoords="offset points",
-                color="green",
-                va="center",
-            )
-
         fig, ax = plt.subplots(figsize=figsize)
 
-        # Plot raw data
-        sns.scatterplot(
-            self.data,
-            x=self.time_variable_name,
-            y=self.outcome_variable_name,
-            hue=self.group_variable_name,
-            alpha=1,
-            legend=False,
-            markers=True,
-            ax=ax,
-        )
-
-        # Plot model fit to control group
-        time_points = self.x_pred_control[self.time_variable_name].values
-        h_line, h_patch = plot_posterior_over_x(
-            time_points,
-            self.y_pred_control.isel(treated_units=0),
-            ax=ax,
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
-            label="Control group",
-        )
-        handles = [(h_line, h_patch)]
-        labels = ["Control group"]
-
-        # Plot model fit to treatment group
-        time_points = self.x_pred_control[self.time_variable_name].values
-        h_line, h_patch = plot_posterior_over_x(
-            time_points,
-            self.y_pred_treatment.isel(treated_units=0),
-            ax=ax,
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-            label="Treatment group",
-        )
-        handles.append((h_line, h_patch))
-        labels.append("Treatment group")
-
-        # Plot counterfactual - post-test for treatment group IF no treatment
-        # had occurred.
-        time_points = self.x_pred_counterfactual[self.time_variable_name].values
-        if len(time_points) == 1:
-            violin_data = np.asarray(
-                self.y_pred_counterfactual.isel(treated_units=0)
-            ).reshape(-1)
-            parts = ax.violinplot(
-                [violin_data],
-                positions=self.x_pred_counterfactual[self.time_variable_name].values,
-                showmeans=False,
-                showmedians=False,
-                widths=0.2,
+        if with_uncertainty:
+            # Plot raw data
+            sns.scatterplot(
+                self.data,
+                x=self.time_variable_name,
+                y=self.outcome_variable_name,
+                hue=self.group_variable_name,
+                alpha=1,
+                legend=False,
+                markers=True,
+                ax=ax,
             )
-            for pc in parts["bodies"]:
-                pc.set_facecolor("C0")
-                pc.set_edgecolor("None")
-                pc.set_alpha(0.5)
-        else:
+
+            # Plot model fit to control group
+            time_points = self.x_pred_control[self.time_variable_name].values
             h_line, h_patch = plot_posterior_over_x(
                 time_points,
-                self.y_pred_counterfactual.isel(treated_units=0),
+                self.y_pred_control.isel(treated_units=0),
                 ax=ax,
                 **style,
-                plot_hdi_kwargs={"color": "C2"},
-                label="Counterfactual",
+                plot_hdi_kwargs={"color": "C0"},
+                label="Control group",
+            )
+            handles = [(h_line, h_patch)]
+            labels = ["Control group"]
+
+            # Plot model fit to treatment group
+            time_points = self.x_pred_control[self.time_variable_name].values
+            h_line, h_patch = plot_posterior_over_x(
+                time_points,
+                self.y_pred_treatment.isel(treated_units=0),
+                ax=ax,
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+                label="Treatment group",
             )
             handles.append((h_line, h_patch))
-            labels.append("Counterfactual")
+            labels.append("Treatment group")
 
-        # arrow to label the causal impact
-        _plot_causal_impact_arrow(self, ax)
+            # Plot counterfactual - post-test for treatment group IF no treatment
+            # had occurred.
+            time_points = self.x_pred_counterfactual[self.time_variable_name].values
+            if len(time_points) == 1:
+                violin_data = np.asarray(
+                    self.y_pred_counterfactual.isel(treated_units=0)
+                ).reshape(-1)
+                parts = ax.violinplot(
+                    [violin_data],
+                    positions=self.x_pred_counterfactual[
+                        self.time_variable_name
+                    ].values,
+                    showmeans=False,
+                    showmedians=False,
+                    widths=0.2,
+                )
+                for pc in parts["bodies"]:
+                    pc.set_facecolor("C0")
+                    pc.set_edgecolor("None")
+                    pc.set_alpha(0.5)
+            else:
+                h_line, h_patch = plot_posterior_over_x(
+                    time_points,
+                    self.y_pred_counterfactual.isel(treated_units=0),
+                    ax=ax,
+                    **style,
+                    plot_hdi_kwargs={"color": "C2"},
+                    label="Counterfactual",
+                )
+                handles.append((h_line, h_patch))
+                labels.append("Counterfactual")
+        else:
+            # Plot raw data
+            sns.lineplot(
+                self.data,
+                x=self.time_variable_name,
+                y=self.outcome_variable_name,
+                hue="group",
+                units="unit",
+                estimator=None,
+                alpha=0.25,
+                ax=ax,
+            )
+            # Plot model fit to control group
+            ax.plot(
+                self.x_pred_control[self.time_variable_name],
+                np.squeeze(self.y_pred_control),
+                "o",
+                c="C0",
+                markersize=10,
+                label="model fit (control group)",
+            )
+            # Plot model fit to treatment group
+            ax.plot(
+                self.x_pred_treatment[self.time_variable_name],
+                np.squeeze(self.y_pred_treatment),
+                "o",
+                c="C1",
+                markersize=10,
+                label="model fit (treatment group)",
+            )
+            # Plot counterfactual - post-test for treatment group IF no treatment
+            # had occurred.
+            ax.plot(
+                self.x_pred_counterfactual[self.time_variable_name],
+                np.squeeze(self.y_pred_counterfactual),
+                "go",
+                markersize=10,
+                label="counterfactual",
+            )
 
-        # formatting
-        ax.set(
-            xticks=self.x_pred_treatment[self.time_variable_name].values,
-            title=self._causal_impact_summary_stat(round_to),
+        # arrow to label the causal impact: drawn between the counterfactual
+        # and the post-period treatment-group prediction (posterior means for
+        # containers with draws; the point estimates coincide for singletons)
+        y_pred_treatment_scalar = _as_scalar(
+            self.y_pred_treatment.isel(obs_ind=1).mean().data
         )
-        ax.legend(
-            handles=(h_tuple for h_tuple in handles),
-            labels=labels,
-            fontsize=LEGEND_FONT_SIZE,
+        y_pred_counterfactual_scalar = _as_scalar(
+            self.y_pred_counterfactual.mean().data
         )
-        return fig, ax
-
-    def _ols_plot(
-        self,
-        round_to: int | None = 2,
-        figsize: tuple[float, float] | None = None,
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, plt.Axes]:
-        """Generate plot for difference-in-differences.
-
-        Parameters
-        ----------
-        round_to : int, optional
-            Number of decimals used to round results. Defaults to 2.
-        figsize : tuple of (float, float), optional
-            Width and height of the figure in inches. Defaults to ``None``
-            (use matplotlib's default).
-        """
-        fig, ax = plt.subplots(figsize=figsize)
-
-        # Plot raw data
-        sns.lineplot(
-            self.data,
-            x=self.time_variable_name,
-            y=self.outcome_variable_name,
-            hue="group",
-            units="unit",
-            estimator=None,
-            alpha=0.25,
-            ax=ax,
-        )
-        # Plot model fit to control group
-        ax.plot(
-            self.x_pred_control[self.time_variable_name],
-            np.squeeze(self.y_pred_control),
-            "o",
-            c="C0",
-            markersize=10,
-            label="model fit (control group)",
-        )
-        # Plot model fit to treatment group
-        ax.plot(
-            self.x_pred_treatment[self.time_variable_name],
-            np.squeeze(self.y_pred_treatment),
-            "o",
-            c="C1",
-            markersize=10,
-            label="model fit (treatment group)",
-        )
-        # Plot counterfactual - post-test for treatment group IF no treatment
-        # had occurred.
-        ax.plot(
-            self.x_pred_counterfactual[self.time_variable_name],
-            np.squeeze(self.y_pred_counterfactual),
-            "go",
-            markersize=10,
-            label="counterfactual",
-        )
-        y_pred_counterfactual_scalar = _as_scalar(self.y_pred_counterfactual)
-        y_pred_treatment_post_scalar = _as_scalar(self.y_pred_treatment.isel(obs_ind=1))
-        # arrow to label the causal impact
+        if with_uncertainty:
+            # Note that we force to be float to avoid a type error using np.ptp
+            # with boolean values
+            time_values = np.array(
+                self.x_pred_treatment[self.time_variable_name].values
+            ).astype(float)
+            arrow_x = np.max(time_values) + 0.1 * np.ptp(time_values)
+            arrow_style = "<-"
+        else:
+            arrow_x = 1.05
+            arrow_style = "<->"
         ax.annotate(
             "",
-            xy=(1.05, y_pred_counterfactual_scalar),
+            xy=(arrow_x, y_pred_counterfactual_scalar),
             xycoords="data",
-            xytext=(1.05, y_pred_treatment_post_scalar),
+            xytext=(arrow_x, y_pred_treatment_scalar),
             textcoords="data",
-            arrowprops={"arrowstyle": "<->", "color": "green", "lw": 3},
+            arrowprops={"arrowstyle": arrow_style, "color": "green", "lw": 3},
         )
         ax.annotate(
             "causal\nimpact",
             xy=(
-                1.05,
-                np.mean([y_pred_counterfactual_scalar, y_pred_treatment_post_scalar]),
+                arrow_x,
+                np.mean([y_pred_counterfactual_scalar, y_pred_treatment_scalar]),
             ),
             xycoords="data",
             xytext=(5, 0),
@@ -671,18 +624,29 @@ class DifferenceInDifferences(BaseExperiment):
             color="green",
             va="center",
         )
+
         # formatting
-        # In OLS context, causal_impact should be a float, but mypy doesn't know this
-        causal_impact_value = (
-            float(self.causal_impact) if self.causal_impact is not None else 0.0
-        )
-        ax.set(
-            xlim=[-0.05, 1.1],
-            xticks=[0, 1],
-            xticklabels=["pre", "post"],
-            title=f"Causal impact = {round_num(causal_impact_value, round_to)}",
-        )
-        ax.legend(fontsize=LEGEND_FONT_SIZE)
+        if with_uncertainty:
+            ax.set(
+                xticks=self.x_pred_treatment[self.time_variable_name].values,
+                title=self._causal_impact_summary_stat(round_to),
+            )
+            ax.legend(
+                handles=(h_tuple for h_tuple in handles),
+                labels=labels,
+                fontsize=LEGEND_FONT_SIZE,
+            )
+        else:
+            causal_impact_value = (
+                float(self.causal_impact) if self.causal_impact is not None else 0.0
+            )
+            ax.set(
+                xlim=[-0.05, 1.1],
+                xticks=[0, 1],
+                xticklabels=["pre", "post"],
+                title=f"Causal impact = {round_num(causal_impact_value, round_to)}",
+            )
+            ax.legend(fontsize=LEGEND_FONT_SIZE)
         return fig, ax
 
     def effect_summary(

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -776,16 +776,15 @@ class InterruptedTimeSeries(BaseExperiment):
             handles.append(h)
             labels.append("Causal impact")
 
-        # Title with R^2; scores with a dispersion entry render as Bayesian
+        # Title with R^2; scores carrying a dispersion entry render as Bayesian
         r2_val, r2_std_val = extract_r2_score(self.score)
-        if isinstance(self.score, pd.Series):
-            title_str = "Pre-intervention Bayesian $R^2$"
-            if r2_val is not None:
-                title_str += f": {round_num(r2_val, round_to)}"
-                if r2_std_val is not None:
-                    title_str += f"\n(std = {round_num(r2_std_val, round_to)})"
+        assert r2_val is not None  # both backends' score containers carry R^2
+        if r2_std_val is not None:
+            title_str = (
+                f"Pre-intervention Bayesian $R^2$: {round_num(r2_val, round_to)}"
+                f"\n(std = {round_num(r2_std_val, round_to)})"
+            )
         else:
-            assert r2_val is not None  # scalar scores always yield a value
             title_str = (
                 f"$R^2$ on pre-intervention data = {round_num(r2_val, round_to)}"
             )

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -31,7 +31,9 @@ from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
+    extract_r2_score,
     get_hdi_to_df,
+    has_posterior_draws,
     plot_posterior_over_x,
 )
 from causalpy.pymc_forecast_models import PyMCForecastModel
@@ -648,7 +650,7 @@ class InterruptedTimeSeries(BaseExperiment):
             zorder=3,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
@@ -661,13 +663,18 @@ class InterruptedTimeSeries(BaseExperiment):
         """
         Plot the results.
 
+        Consumes the canonical prediction container from any backend.
+        Uncertainty bands are drawn only when the container carries posterior
+        draws; point-estimate backends (singleton ``chain``/``draw``) get bare
+        lines.
+
         Parameters
         ----------
         round_to : int, optional
             Number of decimals used to round results. Defaults to 2. Use ``None``
             to return raw numbers.
-        hdi_prob : float, optional
-            Probability mass of the highest density interval drawn around the
+        ci_prob : float, optional
+            Probability mass of the credible interval drawn around the
             posterior predictive, causal impact, and cumulative impact bands.
             Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
@@ -675,6 +682,7 @@ class InterruptedTimeSeries(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``(7, 8)``.
         """
         counterfactual_label = "Counterfactual"
+        with_uncertainty = has_posterior_draws(self.pre_pred)
         single_post_obs = len(self.datapost) <= 1
         style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
@@ -683,149 +691,140 @@ class InterruptedTimeSeries(BaseExperiment):
             "num_samples": num_samples,
         }
 
+        pre_pred = self.pre_pred.isel(treated_units=0)
+        post_pred = self.post_pred.isel(treated_units=0)
+        pre_y = self.pre_design["y"].isel(treated_units=0)
+        post_y = self.post_design["y"].isel(treated_units=0)
+
         fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
         # TOP PLOT --------------------------------------------------
-        # pre-intervention period
-        pre_mu = self.pre_pred
-        pre_mu_plot = (
-            pre_mu.isel(treated_units=0) if "treated_units" in pre_mu.dims else pre_mu
-        )
-        h_line, h_patch = plot_posterior_over_x(
-            self.datapre.index,
-            pre_mu_plot,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
-        )
-        handles = [(h_line, h_patch)]
-        labels = ["Pre-intervention period"]
-
-        (h,) = ax[0].plot(
-            self.datapre.index,
-            self.pre_design["y"].isel(treated_units=0),
-            "k.",
-            label="Observations",
-        )
-        handles.append(h)
-        labels.append("Observations")
-
-        # post intervention period
-        post_mu = self.post_pred
-        post_mu_plot = (
-            post_mu.isel(treated_units=0)
-            if "treated_units" in post_mu.dims
-            else post_mu
-        )
-        h_line, h_patch = plot_posterior_over_x(
-            self.datapost.index,
-            post_mu_plot,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
-        if single_post_obs:
-            # plot_posterior_over_x's HDI ribbon collapses to a zero-area polygon for a
-            # single post-period datum; overlay an explicit median + HDI
-            # errorbar so the counterfactual is still visible. Use the
-            # errorbar artist itself as the legend handle so the legend
-            # matches what is actually drawn.
-            errbar = self._draw_singleton_hdi_marker(
-                ax[0], self.datapost.index, post_mu, color="C1"
+        handles: list[Any] = []
+        labels: list[str] = []
+        if with_uncertainty:
+            # pre-intervention period
+            h_line, h_patch = plot_posterior_over_x(
+                self.datapre.index,
+                pre_pred,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C0"},
             )
-            handles.append(errbar)
-        else:
             handles.append((h_line, h_patch))
-        labels.append(counterfactual_label)
+            labels.append("Pre-intervention period")
 
-        ax[0].plot(
-            self.datapost.index,
-            self.post_design["y"].isel(treated_units=0),
-            "k.",
-            zorder=3,
-        )
+            (h,) = ax[0].plot(
+                self.datapre.index,
+                pre_y,
+                "k.",
+                label="Observations",
+            )
+            handles.append(h)
+            labels.append("Observations")
+
+            # post intervention period
+            h_line, h_patch = plot_posterior_over_x(
+                self.datapost.index,
+                post_pred,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+            if single_post_obs:
+                # plot_posterior_over_x's HDI ribbon collapses to a zero-area polygon for a
+                # single post-period datum; overlay an explicit median + HDI
+                # errorbar so the counterfactual is still visible. Use the
+                # errorbar artist itself as the legend handle so the legend
+                # matches what is actually drawn.
+                errbar = self._draw_singleton_hdi_marker(
+                    ax[0], self.datapost.index, self.post_pred, color="C1"
+                )
+                handles.append(errbar)
+            else:
+                handles.append((h_line, h_patch))
+            labels.append(counterfactual_label)
+
+            ax[0].plot(self.datapost.index, post_y, "k.", zorder=3)
+        else:
+            ax[0].plot(self.datapre.index, pre_y, "k.")
+            ax[0].plot(
+                self.datapre.index,
+                pre_pred.mean(("chain", "draw")),
+                c="k",
+                label="model fit",
+            )
+            ax[0].plot(self.datapost.index, post_y, "k.")
+            ax[0].plot(
+                self.datapost.index,
+                post_pred.mean(("chain", "draw")),
+                label=counterfactual_label,
+                ls=":",
+                c="k",
+            )
+
         # Shaded causal effect (only meaningful when there are >=2 post-period
         # points; with a single datum the fill_between collapses to nothing,
         # so we omit the legend entry to avoid misleading the reader).
-        post_pred_mu = self.post_pred
-        if "treated_units" in post_pred_mu.dims:
-            post_pred_mu = post_pred_mu.isel(treated_units=0)
-        post_pred_mu = post_pred_mu.mean(("chain", "draw"))
         h = ax[0].fill_between(
             self.datapost.index,
-            y1=post_pred_mu,
-            y2=self.post_design["y"].isel(treated_units=0),
+            y1=post_pred.mean(("chain", "draw")),
+            y2=post_y,
             color="C0",
             alpha=0.25,
+            label="Causal impact",
         )
-        if not single_post_obs:
+        if with_uncertainty and not single_post_obs:
             handles.append(h)
             labels.append("Causal impact")
 
-        # Title with R^2, supporting both unit_0_r2 and r2 keys
-        r2_val = None
-        r2_std_val = None
-        try:
-            if isinstance(self.score, pd.Series):
-                if "unit_0_r2" in self.score.index:
-                    r2_val = self.score["unit_0_r2"]
-                    r2_std_val = self.score.get("unit_0_r2_std", None)
-                elif "r2" in self.score.index:
-                    r2_val = self.score["r2"]
-                    r2_std_val = self.score.get("r2_std", None)
-        except Exception:
-            pass
-        title_str = "Pre-intervention Bayesian $R^2$"
-        if r2_val is not None:
-            title_str += f": {round_num(r2_val, round_to)}"
-            if r2_std_val is not None:
-                title_str += f"\n(std = {round_num(r2_std_val, round_to)})"
+        # Title with R^2; scores with a dispersion entry render as Bayesian
+        r2_val, r2_std_val = extract_r2_score(self.score)
+        if isinstance(self.score, pd.Series):
+            title_str = "Pre-intervention Bayesian $R^2$"
+            if r2_val is not None:
+                title_str += f": {round_num(r2_val, round_to)}"
+                if r2_std_val is not None:
+                    title_str += f"\n(std = {round_num(r2_std_val, round_to)})"
+        else:
+            assert r2_val is not None  # scalar scores always yield a value
+            title_str = (
+                f"$R^2$ on pre-intervention data = {round_num(r2_val, round_to)}"
+            )
         ax[0].set(title=title_str)
 
         # MIDDLE PLOT -----------------------------------------------
-        pre_impact_plot = (
-            self.pre_impact.isel(treated_units=0)
-            if hasattr(self.pre_impact, "dims")
-            and "treated_units" in self.pre_impact.dims
-            else self.pre_impact
-        )
-        plot_posterior_over_x(
-            self.datapre.index,
-            pre_impact_plot,
-            ax=ax[1],
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
-        )
-        post_impact_plot = (
-            self.post_impact.isel(treated_units=0)
-            if hasattr(self.post_impact, "dims")
-            and "treated_units" in self.post_impact.dims
-            else self.post_impact
-        )
-        plot_posterior_over_x(
-            self.datapost.index,
-            post_impact_plot,
-            ax=ax[1],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
-        if single_post_obs:
-            self._draw_singleton_hdi_marker(
-                ax[1], self.datapost.index, self.post_impact, color="C1"
+        if with_uncertainty:
+            plot_posterior_over_x(
+                self.datapre.index,
+                self.pre_impact,
+                ax=ax[1],
+                **style,
+                plot_hdi_kwargs={"color": "C0"},
+            )
+            plot_posterior_over_x(
+                self.datapost.index,
+                self.post_impact,
+                ax=ax[1],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+            if single_post_obs:
+                self._draw_singleton_hdi_marker(
+                    ax[1], self.datapost.index, self.post_impact, color="C1"
+                )
+        else:
+            ax[1].plot(
+                self.datapre.index, self.pre_impact.mean(("chain", "draw")), "k."
+            )
+            ax[1].plot(
+                self.datapost.index,
+                self.post_impact.mean(("chain", "draw")),
+                "k.",
+                label=counterfactual_label,
             )
         ax[1].axhline(y=0, c="k")
-        post_impact_mean = (
-            self.post_impact.mean(["chain", "draw"])
-            if hasattr(self.post_impact, "mean")
-            else self.post_impact
-        )
-        if (
-            hasattr(post_impact_mean, "dims")
-            and "treated_units" in post_impact_mean.dims
-        ):
-            post_impact_mean = post_impact_mean.isel(treated_units=0)
         ax[1].fill_between(
             self.datapost.index,
-            y1=post_impact_mean,
+            y1=self.post_impact.mean(("chain", "draw")),
             color="C0",
             alpha=0.25,
             label="Causal impact",
@@ -833,25 +832,26 @@ class InterruptedTimeSeries(BaseExperiment):
         ax[1].set(title="Causal Impact")
 
         # BOTTOM PLOT -----------------------------------------------
-        ax[2].set(title="Cumulative Causal Impact")
-        post_cum_plot = (
-            self.post_impact_cumulative.isel(treated_units=0)
-            if hasattr(self.post_impact_cumulative, "dims")
-            and "treated_units" in self.post_impact_cumulative.dims
-            else self.post_impact_cumulative
-        )
-        plot_posterior_over_x(
-            self.datapost.index,
-            post_cum_plot,
-            ax=ax[2],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
-        if single_post_obs:
-            self._draw_singleton_hdi_marker(
-                ax[2], self.datapost.index, self.post_impact_cumulative, color="C1"
+        if with_uncertainty:
+            plot_posterior_over_x(
+                self.datapost.index,
+                self.post_impact_cumulative,
+                ax=ax[2],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+            if single_post_obs:
+                self._draw_singleton_hdi_marker(
+                    ax[2], self.datapost.index, self.post_impact_cumulative, color="C1"
+                )
+        else:
+            ax[2].plot(
+                self.datapost.index,
+                self.post_impact_cumulative.mean(("chain", "draw")),
+                c="k",
             )
         ax[2].axhline(y=0, c="k")
+        ax[2].set(title="Cumulative Causal Impact")
 
         # Intervention lines. Use a thin dashed black style and a zorder just
         # below the data so the treatment marker reads as a neutral
@@ -878,11 +878,15 @@ class InterruptedTimeSeries(BaseExperiment):
                     label="Treatment end" if i == 0 else None,
                 )
 
-        ax[0].legend(
-            handles=(h_tuple for h_tuple in handles),
-            labels=labels,
-            fontsize=LEGEND_FONT_SIZE,
-        )
+        if with_uncertainty:
+            ax[0].legend(
+                handles=(h_tuple for h_tuple in handles),
+                labels=labels,
+                fontsize=LEGEND_FONT_SIZE,
+            )
+        else:
+            # Collect labelled artists (including the treatment lines)
+            ax[0].legend(fontsize=LEGEND_FONT_SIZE)
 
         # Apply intelligent date formatting if data has datetime index
         if isinstance(self.datapre.index, pd.DatetimeIndex):
@@ -895,232 +899,80 @@ class InterruptedTimeSeries(BaseExperiment):
 
         return fig, ax
 
-    def _ols_plot(
-        self,
-        round_to: int | None = 2,
-        figsize: tuple[float, float] = (7, 8),
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """
-        Plot the results
-
-        :param round_to:
-            Number of decimals used to round results. Defaults to 2. Use "None" to return raw numbers.
-        :param figsize:
-            Width and height of the figure in inches. Defaults to ``(7, 8)``.
-        """
-        counterfactual_label = "Counterfactual"
-
-        fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
-
-        ax[0].plot(self.datapre.index, self.pre_design["y"], "k.")
-        ax[0].plot(
-            self.datapre.index,
-            np.squeeze(self.pre_pred),
-            c="k",
-            label="model fit",
-        )
-
-        ax[0].plot(self.datapost.index, self.post_design["y"], "k.")
-        ax[0].plot(
-            self.datapost.index,
-            np.squeeze(self.post_pred),
-            label=counterfactual_label,
-            ls=":",
-            c="k",
-        )
-        # Shaded causal effect
-        ax[0].fill_between(
-            self.datapost.index,
-            y1=np.squeeze(self.post_pred),
-            y2=np.squeeze(self.post_design["y"]),
-            color="C0",
-            alpha=0.25,
-            label="Causal impact",
-        )
-
-        ax[0].set(
-            title=f"$R^2$ on pre-intervention data = {round_num(_as_scalar(self.score), round_to)}"
-        )
-
-        ax[1].plot(self.datapre.index, np.squeeze(self.pre_impact), "k.")
-        ax[1].plot(
-            self.datapost.index,
-            np.squeeze(self.post_impact),
-            "k.",
-            label=counterfactual_label,
-        )
-        ax[1].axhline(y=0, c="k")
-        # Shaded causal effect
-        ax[1].fill_between(
-            self.datapost.index,
-            y1=np.squeeze(self.post_impact),
-            color="C0",
-            alpha=0.25,
-            label="Causal impact",
-        )
-        ax[1].set(title="Causal Impact")
-
-        ax[2].plot(self.datapost.index, np.squeeze(self.post_impact_cumulative), c="k")
-        ax[2].axhline(y=0, c="k")
-        ax[2].set(title="Cumulative Causal Impact")
-
-        # Intervention lines. Use a thin dashed black style and a zorder just
-        # below the data so the treatment marker reads as a neutral
-        # annotation rather than data, and never occludes data points.
-        for i in [0, 1, 2]:
-            ax[i].axvline(
-                x=self.treatment_time,
-                ls="--",
-                lw=1.5,
-                color="k",
-                zorder=1.5,
-                label="Treatment start" if i == 0 else None,
-            )
-            if self.treatment_end_time is not None:
-                ax[i].axvline(
-                    x=self.treatment_end_time,
-                    ls=":",
-                    lw=1.5,
-                    color="k",
-                    zorder=1.5,
-                    label="Treatment end" if i == 0 else None,
-                )
-
-        ax[0].legend(fontsize=LEGEND_FONT_SIZE)
-
-        # Apply intelligent date formatting if data has datetime index
-        if isinstance(self.datapre.index, pd.DatetimeIndex):
-            # Combine pre and post indices for full date range
-            full_index = _combine_datetime_indices(
-                pd.DatetimeIndex(self.datapre.index),
-                pd.DatetimeIndex(self.datapost.index),
-            )
-            format_date_axes(ax, full_index)
-
-        return (fig, ax)
-
-    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
+    def get_plot_data(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
         """
         Recover the data of the experiment along with the prediction and causal impact information.
+
+        HDI columns are included only when the prediction container carries
+        posterior draws (point-estimate backends return just ``prediction``
+        and ``impact``).
 
         Parameters
         ----------
         hdi_prob : float, default :data:`~causalpy.constants.HDI_PROB`
             Probability mass of the highest density interval. Defaults to the
             project-wide :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+            Ignored when the prediction container has no posterior draws.
         """
-        if self._model_backend.is_bayesian:
-            hdi_pct = int(round(hdi_prob * 100))
+        with_uncertainty = has_posterior_draws(self.pre_pred)
+        hdi_pct = int(round(hdi_prob * 100))
 
+        pre_data = self.datapre.copy()
+        post_data = self.datapost.copy()
+
+        pre_mu = self.pre_pred.isel(treated_units=0)
+        post_mu = self.post_pred.isel(treated_units=0)
+        pre_data["prediction"] = pre_mu.mean(("chain", "draw")).values
+        post_data["prediction"] = post_mu.mean(("chain", "draw")).values
+
+        if with_uncertainty:
             pred_lower_col = f"pred_hdi_lower_{hdi_pct}"
             pred_upper_col = f"pred_hdi_upper_{hdi_pct}"
-            impact_lower_col = f"impact_hdi_lower_{hdi_pct}"
-            impact_upper_col = f"impact_hdi_upper_{hdi_pct}"
-
-            pre_data = self.datapre.copy()
-            post_data = self.datapost.copy()
-
-            pre_mu = self.pre_pred
-            post_mu = self.post_pred
-            if "treated_units" in pre_mu.dims:
-                pre_mu = pre_mu.isel(treated_units=0)
-            if "treated_units" in post_mu.dims:
-                post_mu = post_mu.isel(treated_units=0)
-            pre_data["prediction"] = pre_mu.mean(("chain", "draw")).values
-            post_data["prediction"] = post_mu.mean(("chain", "draw")).values
-
             hdi_pre_pred = get_hdi_to_df(self.pre_pred, hdi_prob=hdi_prob)
             hdi_post_pred = get_hdi_to_df(self.post_pred, hdi_prob=hdi_prob)
-            # If treated_units present, select unit_0; otherwise use directly
-            if (
-                isinstance(hdi_pre_pred.index, pd.MultiIndex)
-                and "treated_units" in hdi_pre_pred.index.names
-            ):
-                pre_data[[pred_lower_col, pred_upper_col]] = hdi_pre_pred.xs(
-                    "unit_0", level="treated_units"
-                ).set_index(pre_data.index)
-                post_data[[pred_lower_col, pred_upper_col]] = hdi_post_pred.xs(
-                    "unit_0", level="treated_units"
-                ).set_index(post_data.index)
-            else:
-                pre_data[[pred_lower_col, pred_upper_col]] = hdi_pre_pred.set_index(
-                    pre_data.index
-                )
-                post_data[[pred_lower_col, pred_upper_col]] = hdi_post_pred.set_index(
-                    post_data.index
-                )
+            pre_data[[pred_lower_col, pred_upper_col]] = hdi_pre_pred.xs(
+                "unit_0", level="treated_units"
+            ).set_index(pre_data.index)
+            post_data[[pred_lower_col, pred_upper_col]] = hdi_post_pred.xs(
+                "unit_0", level="treated_units"
+            ).set_index(post_data.index)
 
-            pre_impact_mean = (
-                self.pre_impact.mean(dim=["chain", "draw"])
-                if hasattr(self.pre_impact, "mean")
-                else self.pre_impact
-            )
-            post_impact_mean = (
-                self.post_impact.mean(dim=["chain", "draw"])
-                if hasattr(self.post_impact, "mean")
-                else self.post_impact
-            )
-            if (
-                hasattr(pre_impact_mean, "dims")
-                and "treated_units" in pre_impact_mean.dims
-            ):
-                pre_impact_mean = pre_impact_mean.isel(treated_units=0)
-            if (
-                hasattr(post_impact_mean, "dims")
-                and "treated_units" in post_impact_mean.dims
-            ):
-                post_impact_mean = post_impact_mean.isel(treated_units=0)
-            pre_data["impact"] = pre_impact_mean.values
-            post_data["impact"] = post_impact_mean.values
+        pre_data["impact"] = self.pre_impact.mean(dim=["chain", "draw"]).values
+        post_data["impact"] = self.post_impact.mean(dim=["chain", "draw"]).values
 
+        if with_uncertainty:
+            impact_lower_col = f"impact_hdi_lower_{hdi_pct}"
+            impact_upper_col = f"impact_hdi_upper_{hdi_pct}"
             # Compute impact HDIs directly via quantiles over posterior dims to avoid column shape issues
             alpha = 1 - hdi_prob
             lower_q = alpha / 2
             upper_q = 1 - alpha / 2
 
-            pre_lower_da = self.pre_impact.quantile(lower_q, dim=["chain", "draw"])
-            pre_upper_da = self.pre_impact.quantile(upper_q, dim=["chain", "draw"])
-            post_lower_da = self.post_impact.quantile(lower_q, dim=["chain", "draw"])
-            post_upper_da = self.post_impact.quantile(upper_q, dim=["chain", "draw"])
-
-            # If a treated_units dim remains for some models, select unit_0
-            if hasattr(pre_lower_da, "dims") and "treated_units" in pre_lower_da.dims:
-                pre_lower_da = pre_lower_da.sel(treated_units="unit_0")
-                pre_upper_da = pre_upper_da.sel(treated_units="unit_0")
-            if hasattr(post_lower_da, "dims") and "treated_units" in post_lower_da.dims:
-                post_lower_da = post_lower_da.sel(treated_units="unit_0")
-                post_upper_da = post_upper_da.sel(treated_units="unit_0")
-
             pre_data[impact_lower_col] = (
-                pre_lower_da.to_series().reindex(pre_data.index).values
+                self.pre_impact.quantile(lower_q, dim=["chain", "draw"])
+                .to_series()
+                .reindex(pre_data.index)
+                .values
             )
             pre_data[impact_upper_col] = (
-                pre_upper_da.to_series().reindex(pre_data.index).values
+                self.pre_impact.quantile(upper_q, dim=["chain", "draw"])
+                .to_series()
+                .reindex(pre_data.index)
+                .values
             )
             post_data[impact_lower_col] = (
-                post_lower_da.to_series().reindex(post_data.index).values
+                self.post_impact.quantile(lower_q, dim=["chain", "draw"])
+                .to_series()
+                .reindex(post_data.index)
+                .values
             )
             post_data[impact_upper_col] = (
-                post_upper_da.to_series().reindex(post_data.index).values
+                self.post_impact.quantile(upper_q, dim=["chain", "draw"])
+                .to_series()
+                .reindex(post_data.index)
+                .values
             )
 
-            self.plot_data = pd.concat([pre_data, post_data])
-
-            return self.plot_data
-        else:
-            raise ValueError("Unsupported model type")
-
-    def get_plot_data_ols(self) -> pd.DataFrame:
-        """
-        Recover the data of the experiment along with the prediction and causal impact information.
-        """
-        pre_data = self.datapre.copy()
-        post_data = self.datapost.copy()
-        pre_data["prediction"] = np.squeeze(self.pre_pred)
-        post_data["prediction"] = np.squeeze(self.post_pred)
-        pre_data["impact"] = np.squeeze(self.pre_impact)
-        post_data["impact"] = np.squeeze(self.post_impact)
         self.plot_data = pd.concat([pre_data, post_data])
 
         return self.plot_data

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -549,18 +549,21 @@ class PanelRegression(BaseExperiment):
             hdi_prob=hdi_prob,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self, hdi_prob: float = HDI_PROB, **kwargs: Any
     ) -> tuple[plt.Figure, plt.Axes]:
-        """Create coefficient plot for Bayesian model.
+        """Create coefficient plot.
+
+        Bayesian models render a forest plot with HDI intervals; point-estimate
+        models render a bar plot of coefficient values.
 
         Parameters
         ----------
         hdi_prob : float, optional
             Probability mass of the highest density interval drawn around each
             posterior coefficient via :func:`arviz.plot_forest`. Must be in
-            ``(0, 1]``. Defaults to :data:`~causalpy.constants.HDI_PROB`
-            (currently 0.94).
+            ``(0, 1]``. Ignored for point-estimate models. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------
@@ -568,16 +571,6 @@ class PanelRegression(BaseExperiment):
             Figure and axes objects
         """
         return self._plot_coefficients_internal(hdi_prob=hdi_prob)
-
-    def _ols_plot(self, **kwargs: Any) -> tuple[plt.Figure, plt.Axes]:
-        """Create coefficient plot for OLS model.
-
-        Returns
-        -------
-        tuple[plt.Figure, plt.Axes]
-            Figure and axes objects
-        """
-        return self._plot_coefficients_internal()
 
     def _plot_coefficients_internal(
         self, var_names: list[str] | None = None, hdi_prob: float = HDI_PROB
@@ -627,8 +620,11 @@ class PanelRegression(BaseExperiment):
         plt.tight_layout()
         return fig, ax
 
-    def get_plot_data_bayesian(self, **kwargs: Any) -> pd.DataFrame:
-        """Get plot data for Bayesian model.
+    def get_plot_data(self, **kwargs: Any) -> pd.DataFrame:
+        """Get plot data with fitted values.
+
+        Bayesian models additionally return ``y_fitted_lower`` /
+        ``y_fitted_upper`` 95% credible-interval columns.
 
         Parameters
         ----------
@@ -639,58 +635,29 @@ class PanelRegression(BaseExperiment):
         Returns
         -------
         pd.DataFrame
-            DataFrame with fitted values and credible intervals
+            DataFrame with fitted values (and credible intervals when the
+            model carries posterior draws).
         """
-        # Get posterior predictions
+        columns: dict[str, Any] = {"y_actual": self.design["y"].values.flatten()}
+
+        # ponytail: PanelRegression stores no canonical prediction container,
+        # so in-sample fitted values must come from backend-native objects
+        # (idata mu vs sklearn predict); the branch is isolated here. Upgrade
+        # path: store canonical in-sample predictions at fit time.
         if self._model_backend.is_bayesian:
             mu = self.model.idata.posterior["mu"]  # type: ignore[union-attr]
-            pred_mean = mu.mean(dim=["chain", "draw"]).values.flatten()
-            pred_lower = mu.quantile(0.025, dim=["chain", "draw"]).values.flatten()
-            pred_upper = mu.quantile(0.975, dim=["chain", "draw"]).values.flatten()
+            columns["y_fitted"] = mu.mean(dim=["chain", "draw"]).values.flatten()
+            columns["y_fitted_lower"] = mu.quantile(
+                0.025, dim=["chain", "draw"]
+            ).values.flatten()
+            columns["y_fitted_upper"] = mu.quantile(
+                0.975, dim=["chain", "draw"]
+            ).values.flatten()
         else:
-            raise ValueError("Model is not a PyMC model")
+            columns["y_fitted"] = np.squeeze(self.model.predict(self.design["X"]))
+        columns[self.unit_fe_variable] = self.data[self.unit_fe_variable].values
 
-        plot_data = pd.DataFrame(
-            {
-                "y_actual": self.design["y"].values.flatten(),
-                "y_fitted": pred_mean,
-                "y_fitted_lower": pred_lower,
-                "y_fitted_upper": pred_upper,
-                self.unit_fe_variable: self.data[self.unit_fe_variable].values,
-            }
-        )
-
-        if self.time_fe_variable:
-            plot_data[self.time_fe_variable] = self.data[self.time_fe_variable].values
-
-        return plot_data
-
-    def get_plot_data_ols(self, **kwargs: Any) -> pd.DataFrame:
-        """Get plot data for OLS model.
-
-        Parameters
-        ----------
-        **kwargs
-            Reserved for forward-compatibility; not consumed by this
-            implementation.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with fitted values
-        """
-        if self._model_backend.is_ols:
-            y_fitted = np.squeeze(self.model.predict(self.design["X"]))
-        else:
-            raise ValueError("Model is not an OLS model")
-
-        plot_data = pd.DataFrame(
-            {
-                "y_actual": self.design["y"].values.flatten(),
-                "y_fitted": y_fitted,
-                self.unit_fe_variable: self.data[self.unit_fe_variable].values,
-            }
-        )
+        plot_data = pd.DataFrame(columns)
 
         if self.time_fe_variable:
             plot_data[self.time_fe_variable] = self.data[self.time_fe_variable].values
@@ -1014,11 +981,7 @@ class PanelRegression(BaseExperiment):
         tuple[plt.Figure, plt.Axes]
             Figure and axes objects
         """
-        # Get plot data
-        if self._model_backend.is_bayesian:
-            plot_data = self.get_plot_data_bayesian()
-        else:
-            plot_data = self.get_plot_data_ols()
+        plot_data = self.get_plot_data()
 
         # Calculate residuals
         residuals = plot_data["y_actual"] - plot_data["y_fitted"]

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -589,15 +589,11 @@ class PiecewiseITS(BaseExperiment):
                 linewidth=2,
             )
 
-        # Title with R^2; scores with per-metric entries render as Bayesian
-        r2_val, _ = extract_r2_score(self.score)
-        if isinstance(self.score, pd.Series):
-            title_str = "Piecewise ITS: Bayesian $R^2$"
-            if r2_val is not None:
-                title_str += f" = {round_num(r2_val, round_to)}"
-        else:
-            assert r2_val is not None  # scalar scores always yield a value
-            title_str = f"Piecewise ITS: $R^2$ = {round_num(r2_val, round_to)}"
+        # Title with R^2; scores carrying a dispersion entry render as Bayesian
+        r2_val, r2_std_val = extract_r2_score(self.score)
+        assert r2_val is not None  # both backends' score containers carry R^2
+        label = "Bayesian $R^2$" if r2_std_val is not None else "$R^2$"
+        title_str = f"Piecewise ITS: {label} = {round_num(r2_val, round_to)}"
         ax[0].set(title=title_str, ylabel=self.outcome_variable_name)
 
         # MIDDLE PLOT: Causal Effect

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -30,11 +30,16 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
-from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
+from causalpy.plot_utils import (
+    _PosteriorPlotStyle,
+    extract_r2_score,
+    has_posterior_draws,
+    plot_posterior_over_x,
+)
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.transforms import ramp, step  # noqa: F401
-from causalpy.utils import _as_scalar, round_num
+from causalpy.utils import round_num
 
 from .base import BaseExperiment
 
@@ -488,7 +493,7 @@ class PiecewiseITS(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
@@ -499,14 +504,19 @@ class PiecewiseITS(BaseExperiment):
         **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """
-        Plot the results for Bayesian models.
+        Plot the results.
+
+        Consumes the canonical prediction container from any backend.
+        Uncertainty bands are drawn only when the container carries posterior
+        draws; point-estimate backends (singleton ``chain``/``draw``) get bare
+        lines.
 
         Parameters
         ----------
         round_to : int, optional
             Number of decimals for rounding. Defaults to 2.
-        hdi_prob : float, optional
-            Probability mass of the highest density interval drawn around the
+        ci_prob : float, optional
+            Probability mass of the credible interval drawn around the
             fitted, counterfactual, causal effect, and cumulative effect bands.
             Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
@@ -520,6 +530,7 @@ class PiecewiseITS(BaseExperiment):
         ax : list[plt.Axes]
             List of axes objects.
         """
+        with_uncertainty = has_posterior_draws(self.y_pred)
         style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
@@ -527,82 +538,107 @@ class PiecewiseITS(BaseExperiment):
             "num_samples": num_samples,
         }
         time_values = self.data[self.time_col].values
+        y_pred_mu = self.y_pred.isel(treated_units=0)
+        y_cf_mu = self.y_counterfactual.isel(treated_units=0)
 
         fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
 
         # TOP PLOT: Observed, Fitted, and Counterfactual
-        # Observed data
         (h_obs,) = ax[0].plot(
             time_values,
             self.design["y"].isel(treated_units=0),
             "k.",
             label="Observations",
         )
+        if with_uncertainty:
+            # Fitted values (mu)
+            h_line_fit, h_patch_fit = plot_posterior_over_x(
+                time_values,
+                y_pred_mu,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C0"},
+            )
+            # Counterfactual
+            h_line_cf, h_patch_cf = plot_posterior_over_x(
+                time_values,
+                y_cf_mu,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+            handles: list[Any] = [
+                h_obs,
+                (h_line_fit, h_patch_fit),
+                (h_line_cf, h_patch_cf),
+            ]
+            labels_legend = ["Observations", "Fitted", "Counterfactual"]
+        else:
+            ax[0].plot(
+                time_values,
+                y_pred_mu.mean(dim=["chain", "draw"]),
+                "C0-",
+                label="Fitted",
+                linewidth=2,
+            )
+            ax[0].plot(
+                time_values,
+                y_cf_mu.mean(dim=["chain", "draw"]),
+                "C1--",
+                label="Counterfactual",
+                linewidth=2,
+            )
 
-        # Fitted values (mu)
-        y_pred_mu = self.y_pred.isel(treated_units=0)
-        h_line_fit, h_patch_fit = plot_posterior_over_x(
-            time_values,
-            y_pred_mu,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
-        )
-
-        # Counterfactual
-        y_cf_mu = self.y_counterfactual.isel(treated_units=0)
-        h_line_cf, h_patch_cf = plot_posterior_over_x(
-            time_values,
-            y_cf_mu,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
-
-        # Title with R^2
-        r2_val = None
-        try:
-            if isinstance(self.score, pd.Series):
-                if "unit_0_r2" in self.score.index:
-                    r2_val = self.score["unit_0_r2"]
-                elif "r2" in self.score.index:
-                    r2_val = self.score["r2"]
-        except Exception:
-            pass
-
-        title_str = "Piecewise ITS: Bayesian $R^2$"
-        if r2_val is not None:
-            title_str += f" = {round_num(r2_val, round_to)}"
+        # Title with R^2; scores with per-metric entries render as Bayesian
+        r2_val, _ = extract_r2_score(self.score)
+        if isinstance(self.score, pd.Series):
+            title_str = "Piecewise ITS: Bayesian $R^2$"
+            if r2_val is not None:
+                title_str += f" = {round_num(r2_val, round_to)}"
+        else:
+            assert r2_val is not None  # scalar scores always yield a value
+            title_str = f"Piecewise ITS: $R^2$ = {round_num(r2_val, round_to)}"
         ax[0].set(title=title_str, ylabel=self.outcome_variable_name)
 
-        handles = [h_obs, (h_line_fit, h_patch_fit), (h_line_cf, h_patch_cf)]
-        labels_legend = ["Observations", "Fitted", "Counterfactual"]
-
         # MIDDLE PLOT: Causal Effect
-        plot_posterior_over_x(
-            time_values,
-            self.effect,
-            ax=ax[1],
-            **style,
-            plot_hdi_kwargs={"color": "C2"},
-        )
-        ax[1].axhline(y=0, c="k", linestyle="--", alpha=0.5)
-        ax[1].fill_between(
-            time_values,
-            y1=self.effect.mean(dim=["chain", "draw"]).values,
-            alpha=0.25,
-            color="C2",
-        )
+        if with_uncertainty:
+            plot_posterior_over_x(
+                time_values,
+                self.effect,
+                ax=ax[1],
+                **style,
+                plot_hdi_kwargs={"color": "C2"},
+            )
+            ax[1].axhline(y=0, c="k", linestyle="--", alpha=0.5)
+            ax[1].fill_between(
+                time_values,
+                y1=self.effect.mean(dim=["chain", "draw"]).values,
+                alpha=0.25,
+                color="C2",
+            )
+        else:
+            effect_mean = self.effect.mean(dim=["chain", "draw"])
+            ax[1].plot(time_values, effect_mean, "C2-", linewidth=2)
+            ax[1].fill_between(time_values, y1=effect_mean, alpha=0.25, color="C2")
+            ax[1].axhline(y=0, c="k", linestyle="--", alpha=0.5)
         ax[1].set(title="Causal Effect", ylabel="Effect")
 
         # BOTTOM PLOT: Cumulative Effect
-        plot_posterior_over_x(
-            time_values,
-            self.cumulative_effect,
-            ax=ax[2],
-            **style,
-            plot_hdi_kwargs={"color": "C3"},
-        )
+        if with_uncertainty:
+            plot_posterior_over_x(
+                time_values,
+                self.cumulative_effect,
+                ax=ax[2],
+                **style,
+                plot_hdi_kwargs={"color": "C3"},
+            )
+        else:
+            ax[2].plot(
+                time_values,
+                self.cumulative_effect.mean(dim=["chain", "draw"]),
+                "C3-",
+                linewidth=2,
+            )
         ax[2].axhline(y=0, c="k", linestyle="--", alpha=0.5)
         ax[2].set(title="Cumulative Causal Effect", ylabel="Cumulative Effect")
 
@@ -617,104 +653,41 @@ class PiecewiseITS(BaseExperiment):
                     alpha=0.7,
                     label=f"Interruption {i}" if a == ax[0] else None,
                 )
-            handles.append(plt.Line2D([0], [0], color="red", lw=2))
-            labels_legend.append(f"Interruption {i}")
+            if with_uncertainty:
+                handles.append(plt.Line2D([0], [0], color="red", lw=2))
+                labels_legend.append(f"Interruption {i}")
 
-        ax[0].legend(handles=handles, labels=labels_legend, fontsize=LEGEND_FONT_SIZE)
-
-        plt.tight_layout()
-        return fig, ax
-
-    def _ols_plot(
-        self,
-        round_to: int | None = 2,
-        figsize: tuple[float, float] = (10, 10),
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """
-        Plot the results for OLS models.
-
-        Parameters
-        ----------
-        round_to : int, optional
-            Number of decimals for rounding. Defaults to 2.
-        figsize : tuple of (float, float), optional
-            Width and height of the figure in inches. Defaults to ``(10, 10)``.
-
-        Returns
-        -------
-        fig : plt.Figure
-            The matplotlib figure.
-        ax : list[plt.Axes]
-            List of axes objects.
-        """
-        time_values = self.data[self.time_col].values
-
-        fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
-
-        # TOP PLOT: Observed, Fitted, and Counterfactual
-        ax[0].plot(time_values, self.design["y"].values, "k.", label="Observations")
-        ax[0].plot(
-            time_values, np.squeeze(self.y_pred), "C0-", label="Fitted", linewidth=2
-        )
-        ax[0].plot(
-            time_values,
-            np.squeeze(self.y_counterfactual),
-            "C1--",
-            label="Counterfactual",
-            linewidth=2,
-        )
-
-        title_str = (
-            f"Piecewise ITS: $R^2$ = {round_num(_as_scalar(self.score), round_to)}"
-        )
-        ax[0].set(title=title_str, ylabel=self.outcome_variable_name)
-
-        # MIDDLE PLOT: Causal Effect
-        ax[1].plot(time_values, np.squeeze(self.effect), "C2-", linewidth=2)
-        ax[1].fill_between(
-            time_values, y1=np.squeeze(self.effect), alpha=0.25, color="C2"
-        )
-        ax[1].axhline(y=0, c="k", linestyle="--", alpha=0.5)
-        ax[1].set(title="Causal Effect", ylabel="Effect")
-
-        # BOTTOM PLOT: Cumulative Effect
-        ax[2].plot(time_values, np.squeeze(self.cumulative_effect), "C3-", linewidth=2)
-        ax[2].axhline(y=0, c="k", linestyle="--", alpha=0.5)
-        ax[2].set(title="Cumulative Causal Effect", ylabel="Cumulative Effect")
-
-        # Add vertical lines for interruptions
-        for i, t_k in enumerate(self.interruption_times):
-            for a in ax:
-                a.axvline(
-                    x=t_k,
-                    ls="-",
-                    lw=2,
-                    color="red",
-                    alpha=0.7,
-                    label=f"Interruption {i}" if a == ax[0] else None,
-                )
-
-        ax[0].legend(fontsize=LEGEND_FONT_SIZE)
+        if with_uncertainty:
+            ax[0].legend(
+                handles=handles, labels=labels_legend, fontsize=LEGEND_FONT_SIZE
+            )
+        else:
+            # Collect labelled artists (including the interruption lines)
+            ax[0].legend(fontsize=LEGEND_FONT_SIZE)
 
         plt.tight_layout()
         return fig, ax
 
-    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
+    def get_plot_data(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
         """
         Recover the data of the experiment along with prediction and effect information.
+
+        HDI columns are included only when the prediction container carries
+        posterior draws.
 
         Parameters
         ----------
         hdi_prob : float
             Probability for the highest density interval. Defaults to
-            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94). Ignored
+            when the prediction container has no posterior draws.
 
         Returns
         -------
         pd.DataFrame
             DataFrame containing observed data, predictions, and effects.
         """
+        with_uncertainty = has_posterior_draws(self.y_pred)
         hdi_pct = int(round(hdi_prob * 100))
 
         # Get time values
@@ -722,7 +695,6 @@ class PiecewiseITS(BaseExperiment):
 
         # Extract predictions
         y_pred_mu = self.y_pred.isel(treated_units=0)
-
         y_cf_mu = self.y_counterfactual.isel(treated_units=0)
 
         # Helper to extract HDI bounds from az.hdi() result (which returns a Dataset)
@@ -736,69 +708,45 @@ class PiecewiseITS(BaseExperiment):
             upper = hdi_data.sel(hdi="higher").values.flatten()
             return lower, upper
 
-        # Compute means and HDIs
-        fitted_mean = y_pred_mu.mean(dim=["chain", "draw"]).values
-        fitted_hdi = az.hdi(y_pred_mu, hdi_prob=hdi_prob)
-        fitted_lower, fitted_upper = _get_hdi_bounds(fitted_hdi)
+        # Build DataFrame column-by-column so HDI columns interleave with the
+        # quantities they describe
+        data: dict[str, Any] = {
+            self.time_col: time_values,
+            self.outcome_variable_name: self.design["y"].isel(treated_units=0).values,
+            "fitted": y_pred_mu.mean(dim=["chain", "draw"]).values,
+        }
+        if with_uncertainty:
+            fitted_lower, fitted_upper = _get_hdi_bounds(
+                az.hdi(y_pred_mu, hdi_prob=hdi_prob)
+            )
+            data[f"fitted_hdi_lower_{hdi_pct}"] = fitted_lower
+            data[f"fitted_hdi_upper_{hdi_pct}"] = fitted_upper
 
-        cf_mean = y_cf_mu.mean(dim=["chain", "draw"]).values
-        cf_hdi = az.hdi(y_cf_mu, hdi_prob=hdi_prob)
-        cf_lower, cf_upper = _get_hdi_bounds(cf_hdi)
+        data["counterfactual"] = y_cf_mu.mean(dim=["chain", "draw"]).values
+        if with_uncertainty:
+            cf_lower, cf_upper = _get_hdi_bounds(az.hdi(y_cf_mu, hdi_prob=hdi_prob))
+            data[f"counterfactual_hdi_lower_{hdi_pct}"] = cf_lower
+            data[f"counterfactual_hdi_upper_{hdi_pct}"] = cf_upper
 
-        effect_mean = self.effect.mean(dim=["chain", "draw"]).values
-        effect_hdi = az.hdi(self.effect, hdi_prob=hdi_prob)
-        effect_lower, effect_upper = _get_hdi_bounds(effect_hdi)
+        data["effect"] = self.effect.mean(dim=["chain", "draw"]).values
+        if with_uncertainty:
+            effect_lower, effect_upper = _get_hdi_bounds(
+                az.hdi(self.effect, hdi_prob=hdi_prob)
+            )
+            data[f"effect_hdi_lower_{hdi_pct}"] = effect_lower
+            data[f"effect_hdi_upper_{hdi_pct}"] = effect_upper
 
-        cum_effect_mean = self.cumulative_effect.mean(dim=["chain", "draw"]).values
-        cum_effect_hdi = az.hdi(self.cumulative_effect, hdi_prob=hdi_prob)
-        cum_effect_lower, cum_effect_upper = _get_hdi_bounds(cum_effect_hdi)
+        data["cumulative_effect"] = self.cumulative_effect.mean(
+            dim=["chain", "draw"]
+        ).values
+        if with_uncertainty:
+            cum_lower, cum_upper = _get_hdi_bounds(
+                az.hdi(self.cumulative_effect, hdi_prob=hdi_prob)
+            )
+            data[f"cumulative_effect_hdi_lower_{hdi_pct}"] = cum_lower
+            data[f"cumulative_effect_hdi_upper_{hdi_pct}"] = cum_upper
 
-        # Build DataFrame
-        result = pd.DataFrame(
-            {
-                self.time_col: time_values,
-                self.outcome_variable_name: self.design["y"]
-                .isel(treated_units=0)
-                .values,
-                "fitted": fitted_mean,
-                f"fitted_hdi_lower_{hdi_pct}": fitted_lower,
-                f"fitted_hdi_upper_{hdi_pct}": fitted_upper,
-                "counterfactual": cf_mean,
-                f"counterfactual_hdi_lower_{hdi_pct}": cf_lower,
-                f"counterfactual_hdi_upper_{hdi_pct}": cf_upper,
-                "effect": effect_mean,
-                f"effect_hdi_lower_{hdi_pct}": effect_lower,
-                f"effect_hdi_upper_{hdi_pct}": effect_upper,
-                "cumulative_effect": cum_effect_mean,
-                f"cumulative_effect_hdi_lower_{hdi_pct}": cum_effect_lower,
-                f"cumulative_effect_hdi_upper_{hdi_pct}": cum_effect_upper,
-            }
-        )
-
-        self.plot_data = result
-        return result
-
-    def get_plot_data_ols(self) -> pd.DataFrame:
-        """
-        Recover the data of the experiment along with prediction and effect information.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame containing observed data, predictions, and effects.
-        """
-        time_values = self.data[self.time_col].values
-
-        result = pd.DataFrame(
-            {
-                self.time_col: time_values,
-                self.outcome_variable_name: self.design["y"].values.flatten(),
-                "fitted": np.squeeze(self.y_pred),
-                "counterfactual": np.squeeze(self.y_counterfactual),
-                "effect": np.squeeze(self.effect),
-                "cumulative_effect": np.squeeze(self.cumulative_effect),
-            }
-        )
+        result = pd.DataFrame(data)
 
         self.plot_data = result
         return result

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -319,7 +319,7 @@ class PrePostNEGD(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -31,7 +31,12 @@ from causalpy.custom_exceptions import (
     FormulaException,
 )
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
-from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
+from causalpy.plot_utils import (
+    _PosteriorPlotStyle,
+    extract_r2_score,
+    has_posterior_draws,
+    plot_posterior_over_x,
+)
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_rd
 from causalpy.utils import (
@@ -381,7 +386,7 @@ class RegressionDiscontinuity(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
@@ -398,22 +403,23 @@ class RegressionDiscontinuity(BaseExperiment):
         round_to : int, optional
             Number of decimals used to round results. Defaults to 2. Use ``None``
             to return raw numbers.
-        hdi_prob : float, optional
+        ci_prob : float, optional
             Probability mass of the highest density interval drawn around the
             posterior predictive band, and the central credible interval
             reported in the figure title for the discontinuity at threshold.
-            Must be in ``(0, 1]``. Defaults to
-            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+            Must be in ``(0, 1]``. Ignored for point-estimate models. Defaults
+            to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+        kind : {"ribbon", "histogram", "spaghetti"}, optional
+            How posterior uncertainty is rendered. Defaults to ``"ribbon"``.
+        ci_kind : {"hdi", "eti"}, optional
+            Credible interval type when ``kind="ribbon"``. Defaults to ``"hdi"``.
+        num_samples : int, optional
+            Number of posterior draws when ``kind="spaghetti"``. Defaults to 50.
         figsize : tuple of (float, float), optional
             Width and height of the figure in inches. Defaults to ``None``
             (use matplotlib's default).
         """
-        style: _PosteriorPlotStyle = {
-            "ci_prob": ci_prob,
-            "kind": kind,
-            "ci_kind": ci_kind,
-            "num_samples": num_samples,
-        }
+        with_uncertainty = has_posterior_draws(self.pred)
         fig, ax = plt.subplots(figsize=figsize)
 
         # Plot data: use two layers only when there are excluded observations
@@ -437,109 +443,52 @@ class RegressionDiscontinuity(BaseExperiment):
         )
 
         # Plot model fit to data
-        plot_posterior_over_x(
-            self.x_pred[self.running_variable_name],
-            self.pred.isel(treated_units=0),
-            ax=ax,
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-            label="Posterior mean",
-        )
+        if with_uncertainty:
+            style: _PosteriorPlotStyle = {
+                "ci_prob": ci_prob,
+                "kind": kind,
+                "ci_kind": ci_kind,
+                "num_samples": num_samples,
+            }
+            plot_posterior_over_x(
+                self.x_pred[self.running_variable_name],
+                self.pred.isel(treated_units=0),
+                ax=ax,
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+                label="Posterior mean",
+            )
+        else:
+            ax.plot(
+                self.x_pred[self.running_variable_name],
+                self.pred.isel(chain=0, draw=0, treated_units=0),
+                "k",
+                markersize=10,
+                label="model fit",
+            )
 
         # create strings to compose title
-        title_info = f"{round_num(self.score['unit_0_r2'], round_to)} (std = {round_num(self.score['unit_0_r2_std'], round_to)})"
-        r2 = f"Bayesian $R^2$ on fit data = {title_info}"
-        percentiles = self.discontinuity_at_threshold.quantile(
-            [(1 - ci_prob) / 2, 1 - (1 - ci_prob) / 2]
-        ).values
-        ci = (
-            rf"$CI_{{{ci_prob * 100:.0f}\%}}$"
-            + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
-        )
-        discon = f"""
+        r2_val, r2_std_val = extract_r2_score(self.score)
+        assert r2_val is not None
+        if with_uncertainty:
+            assert r2_std_val is not None
+            title_info = f"{round_num(r2_val, round_to)} (std = {round_num(r2_std_val, round_to)})"
+            r2 = f"Bayesian $R^2$ on fit data = {title_info}"
+            percentiles = self.discontinuity_at_threshold.quantile(
+                [(1 - ci_prob) / 2, 1 - (1 - ci_prob) / 2]
+            ).values
+            ci = (
+                rf"$CI_{{{ci_prob * 100:.0f}\%}}$"
+                + f"[{round_num(percentiles[0], round_to)}, {round_num(percentiles[1], round_to)}]"
+            )
+            discon = f"""
             Discontinuity at threshold = {round_num(self.discontinuity_at_threshold.mean(), round_to)},
             """
-        ax.set(title=r2 + "\n" + discon + ci)
-
-        # Treatment threshold line
-        ax.axvline(
-            x=self.treatment_threshold,
-            ls="-",
-            lw=3,
-            color="r",
-            label="treatment threshold",
-        )
-
-        # Add donut hole boundary lines if donut_hole > 0
-        if self.donut_hole > 0:
-            ax.axvline(
-                x=self.treatment_threshold - self.donut_hole,
-                ls="--",
-                lw=2,
-                color="orange",
-                label="donut boundary",
-            )
-            ax.axvline(
-                x=self.treatment_threshold + self.donut_hole,
-                ls="--",
-                lw=2,
-                color="orange",
-            )
-
-        ax.legend(fontsize=LEGEND_FONT_SIZE)
-        return (fig, ax)
-
-    def _ols_plot(
-        self,
-        round_to: int | None = None,
-        figsize: tuple[float, float] | None = None,
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, plt.Axes]:
-        """Generate plot for regression discontinuity designs.
-
-        Parameters
-        ----------
-        round_to : int, optional
-            Number of decimals used to round results.
-        figsize : tuple of (float, float), optional
-            Width and height of the figure in inches. Defaults to ``None``
-            (use matplotlib's default).
-        """
-        fig, ax = plt.subplots(figsize=figsize)
-
-        # Plot data: use two layers only when there are excluded observations
-        has_exclusion = len(self.fit_data) < len(self.data)
-        if has_exclusion:
-            sns.scatterplot(
-                self.data,
-                x=self.running_variable_name,
-                y=self.outcome_variable_name,
-                color="lightgray",
-                ax=ax,
-                label="excluded data",
-            )
-        sns.scatterplot(
-            self.fit_data,
-            x=self.running_variable_name,
-            y=self.outcome_variable_name,
-            color="k",
-            ax=ax,
-            label="fit data" if has_exclusion else "data",
-        )
-
-        # Plot model fit to data
-        ax.plot(
-            self.x_pred[self.running_variable_name],
-            self.pred.isel(chain=0, draw=0, treated_units=0),
-            "k",
-            markersize=10,
-            label="model fit",
-        )
-
-        # create strings to compose title
-        r2 = f"$R^2$ on fit data = {round_num(_as_scalar(self.score), round_to)}"
-        discon = f"Discontinuity at threshold = {round_num(_as_scalar(self.discontinuity_at_threshold), round_to)}"
-        ax.set(title=r2 + "\n" + discon)
+            ax.set(title=r2 + "\n" + discon + ci)
+        else:
+            r2 = f"$R^2$ on fit data = {round_num(r2_val, round_to)}"
+            discon = f"Discontinuity at threshold = {round_num(_as_scalar(self.discontinuity_at_threshold), round_to)}"
+            ax.set(title=r2 + "\n" + discon)
 
         # Treatment threshold line
         ax.axvline(

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -336,7 +336,7 @@ class RegressionKink(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -32,6 +32,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.plot_utils import has_posterior_draws
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
 
@@ -854,7 +855,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             view="group_time",
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         hdi_prob: float | None = None,
         figsize: tuple[float, float] | None = (10, 6),
@@ -864,7 +865,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         include_placebo: bool = True,
         **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """Plot results for Bayesian model.
+        """Plot the event study or cohort trajectories.
 
         Parameters
         ----------
@@ -877,7 +878,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             the value must match the cached
             :attr:`~causalpy.experiments.staggered_did.StaggeredDiD.hdi_prob_`;
             otherwise a :class:`ValueError` is raised. Pass ``None`` (the
-            default) to plot using the cached value.
+            default) to plot using the cached value. Ignored for
+            point-estimate models.
         figsize : tuple of (float, float), optional
             Width and height of the figure in inches. Defaults to ``(10, 6)``.
         view : {"event_time", "group_time"}, optional
@@ -899,7 +901,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         tuple[plt.Figure, list[plt.Axes]]
             Figure and axes objects.
         """
-        if hdi_prob is not None and hdi_prob != self.hdi_prob_:
+        with_uncertainty = has_posterior_draws(self.y_pred)
+        if with_uncertainty and hdi_prob is not None and hdi_prob != self.hdi_prob_:
             raise ValueError(
                 "StaggeredDiD HDI bounds are computed during effect "
                 "aggregation, not at plot time. The cached HDI probability "
@@ -909,7 +912,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 "value, or omit hdi_prob to use the cached value."
             )
         if view == "group_time":
-            return self._bayesian_plot_group_time(
+            return self._plot_group_time(
                 figsize=figsize,
                 layout=layout,
                 x_axis=x_axis,
@@ -928,231 +931,86 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         # Plot pre-treatment placebo estimates (different style)
         if len(pre_treatment) > 0:
-            ax.errorbar(
-                pre_treatment["event_time"],
-                pre_treatment["att"],
-                yerr=[
-                    pre_treatment["att"] - pre_treatment["att_lower"],
-                    pre_treatment["att_upper"] - pre_treatment["att"],
-                ],
-                fmt="s",  # Square markers for placebo
-                capsize=4,
-                capthick=2,
-                markersize=7,
-                color="gray",
-                alpha=0.7,
-                label=f"Placebo estimate ({int(self.hdi_prob_ * 100)}% HDI)",
-            )
-
-        # Plot post-treatment ATT estimates
-        if len(post_treatment) > 0:
-            ax.errorbar(
-                post_treatment["event_time"],
-                post_treatment["att"],
-                yerr=[
-                    post_treatment["att"] - post_treatment["att_lower"],
-                    post_treatment["att_upper"] - post_treatment["att"],
-                ],
-                fmt="o",
-                capsize=4,
-                capthick=2,
-                markersize=8,
-                color="C0",
-                label=f"ATT estimate ({int(self.hdi_prob_ * 100)}% HDI)",
-            )
-
-        # Add horizontal line at zero
-        ax.axhline(y=0, color="black", linestyle="--", linewidth=1, alpha=0.7)
-
-        # Add vertical line at event_time = 0 (treatment onset)
-        ax.axvline(x=-0.5, color="red", linestyle="-", linewidth=2, alpha=0.7)
-
-        # Shade pre-treatment region
-        event_min = att_et["event_time"].min()
-        if event_min < 0:
-            ax.axvspan(
-                event_min - 0.5,
-                -0.5,
-                alpha=0.1,
-                color="gray",
-            )
-
-        # Labels and formatting
-        ax.set_xlabel("Event Time (periods relative to treatment)", fontsize=12)
-        ax.set_ylabel("Effect Estimate", fontsize=12)
-        ax.set_title("Staggered DiD Event Study", fontsize=14)
-        ax.legend(fontsize=LEGEND_FONT_SIZE)
-
-        # Set integer ticks for event time
-        ax.set_xticks(att_et["event_time"].values)
-
-        return fig, [ax]
-
-    def _bayesian_plot_group_time(
-        self,
-        figsize: tuple[float, float] | None = None,
-        layout: Literal["facet", "overlay"] = "facet",
-        x_axis: Literal["event_time", "calendar_time"] = "event_time",
-        include_placebo: bool = True,
-    ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """Plot Bayesian cohort-time ``ATT(g, t)`` trajectories."""
-        att_gt, x_col, x_label, y_label = self._get_group_time_plot_data(
-            x_axis=x_axis, include_placebo=include_placebo
-        )
-        cohort_groups = list(att_gt.groupby("cohort", sort=True))
-        sharex = x_axis == "event_time"
-        fig, axes = self._make_group_time_axes(
-            att_gt=att_gt,
-            layout=layout,
-            figsize=figsize,
-            sharex=sharex,
-            sharey=layout == "facet",
-        )
-
-        for cohort_idx, (cohort, cohort_data) in enumerate(cohort_groups):
-            ax = axes[cohort] if layout == "facet" else axes["overlay"]
-            self._plot_bayesian_group_time_segment(
-                ax=ax,
-                cohort_data=cohort_data[cohort_data["type"] == "placebo"],
-                x_col=x_col,
-                line_type="placebo",
-                color="gray" if layout == "facet" else f"C{cohort_idx % 10}",
-                label=(
-                    "Placebo estimate"
-                    if layout == "facet"
-                    else f"Cohort {cohort} placebo"
-                ),
-            )
-            self._plot_bayesian_group_time_segment(
-                ax=ax,
-                cohort_data=cohort_data[cohort_data["type"] == "ATT"],
-                x_col=x_col,
-                line_type="ATT",
-                color="C0" if layout == "facet" else f"C{cohort_idx % 10}",
-                label="ATT estimate" if layout == "facet" else f"Cohort {cohort} ATT",
-            )
-            self._format_group_time_axis(
-                ax=ax,
-                cohort=cohort if layout == "facet" else None,
-                x_label=self._get_group_time_axis_label(
-                    x_label=x_label,
-                    layout=layout,
-                    sharex=sharex,
-                    axis_index=cohort_idx,
-                    n_axes=len(cohort_groups),
-                ),
-                y_label=y_label,
-                x_axis=x_axis,
-                treatment_time=cohort,
-            )
-            ax.legend(fontsize=LEGEND_FONT_SIZE)
-
-        if layout == "overlay":
-            axes["overlay"].legend(title="Treatment cohort", fontsize=LEGEND_FONT_SIZE)
-
-        return fig, list(axes.values())
-
-    def _ols_plot(
-        self,
-        figsize: tuple[float, float] | None = (10, 6),
-        view: Literal["event_time", "group_time"] = "event_time",
-        layout: Literal["facet", "overlay"] = "facet",
-        x_axis: Literal["event_time", "calendar_time"] = "event_time",
-        include_placebo: bool = True,
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """Plot results for OLS model.
-
-        Parameters
-        ----------
-        figsize : tuple of (float, float), optional
-            Width and height of the figure in inches. Defaults to ``(10, 6)``.
-        view : {"event_time", "group_time"}, optional
-            Plot view to render. ``"event_time"`` draws the aggregated event
-            study and ``"group_time"`` draws cohort-specific ``ATT(g, t)``
-            trajectories. Defaults to ``"event_time"``.
-        layout : {"facet", "overlay"}, optional
-            Plot layout for the ``"group_time"`` view. Defaults to
-            ``"facet"``.
-        x_axis : {"event_time", "calendar_time"}, optional
-            Time scale for the ``"group_time"`` view. Defaults to
-            ``"event_time"``.
-        include_placebo : bool, optional
-            Whether to include pre-treatment residual estimates in the
-            ``"group_time"`` view. Defaults to ``True``.
-
-        Returns
-        -------
-        tuple[plt.Figure, list[plt.Axes]]
-            Figure and axes objects.
-        """
-        if view == "group_time":
-            return self._ols_plot_group_time(
-                figsize=figsize,
-                layout=layout,
-                x_axis=x_axis,
-                include_placebo=include_placebo,
-            )
-        if view != "event_time":
-            raise ValueError("view must be 'event_time' or 'group_time'")
-
-        fig, ax = plt.subplots(1, 1, figsize=figsize)
-
-        att_et = self.att_event_time_.copy()
-
-        # Separate pre-treatment (placebo) and post-treatment (ATT)
-        pre_treatment = att_et[att_et["event_time"] < 0]
-        post_treatment = att_et[att_et["event_time"] >= 0]
-
-        # Plot pre-treatment placebo estimates (different style)
-        if len(pre_treatment) > 0:
-            ax.scatter(
-                pre_treatment["event_time"],
-                pre_treatment["att"],
-                s=60,
-                color="gray",
-                marker="s",  # Square markers for placebo
-                zorder=3,
-                alpha=0.7,
-                label="Placebo estimate",
-            )
-            # Add error bars if std available
-            if "att_std" in pre_treatment.columns:
-                se = pre_treatment["att_std"] / np.sqrt(pre_treatment["n_obs"])
+            if with_uncertainty:
                 ax.errorbar(
                     pre_treatment["event_time"],
                     pre_treatment["att"],
-                    yerr=1.96 * se,
-                    fmt="none",
+                    yerr=[
+                        pre_treatment["att"] - pre_treatment["att_lower"],
+                        pre_treatment["att_upper"] - pre_treatment["att"],
+                    ],
+                    fmt="s",  # Square markers for placebo
                     capsize=4,
                     capthick=2,
+                    markersize=7,
                     color="gray",
-                    alpha=0.5,
+                    alpha=0.7,
+                    label=f"Placebo estimate ({int(self.hdi_prob_ * 100)}% HDI)",
                 )
+            else:
+                ax.scatter(
+                    pre_treatment["event_time"],
+                    pre_treatment["att"],
+                    s=60,
+                    color="gray",
+                    marker="s",  # Square markers for placebo
+                    zorder=3,
+                    alpha=0.7,
+                    label="Placebo estimate",
+                )
+                # Add error bars if std available
+                if "att_std" in pre_treatment.columns:
+                    se = pre_treatment["att_std"] / np.sqrt(pre_treatment["n_obs"])
+                    ax.errorbar(
+                        pre_treatment["event_time"],
+                        pre_treatment["att"],
+                        yerr=1.96 * se,
+                        fmt="none",
+                        capsize=4,
+                        capthick=2,
+                        color="gray",
+                        alpha=0.5,
+                    )
 
         # Plot post-treatment ATT estimates
         if len(post_treatment) > 0:
-            ax.scatter(
-                post_treatment["event_time"],
-                post_treatment["att"],
-                s=80,
-                color="C0",
-                zorder=3,
-                label="ATT estimate",
-            )
-            # Add error bars if std available
-            if "att_std" in post_treatment.columns:
-                se = post_treatment["att_std"] / np.sqrt(post_treatment["n_obs"])
+            if with_uncertainty:
                 ax.errorbar(
                     post_treatment["event_time"],
                     post_treatment["att"],
-                    yerr=1.96 * se,
-                    fmt="none",
+                    yerr=[
+                        post_treatment["att"] - post_treatment["att_lower"],
+                        post_treatment["att_upper"] - post_treatment["att"],
+                    ],
+                    fmt="o",
                     capsize=4,
                     capthick=2,
+                    markersize=8,
                     color="C0",
-                    alpha=0.7,
+                    label=f"ATT estimate ({int(self.hdi_prob_ * 100)}% HDI)",
                 )
+            else:
+                ax.scatter(
+                    post_treatment["event_time"],
+                    post_treatment["att"],
+                    s=80,
+                    color="C0",
+                    zorder=3,
+                    label="ATT estimate",
+                )
+                # Add error bars if std available
+                if "att_std" in post_treatment.columns:
+                    se = post_treatment["att_std"] / np.sqrt(post_treatment["n_obs"])
+                    ax.errorbar(
+                        post_treatment["event_time"],
+                        post_treatment["att"],
+                        yerr=1.96 * se,
+                        fmt="none",
+                        capsize=4,
+                        capthick=2,
+                        color="C0",
+                        alpha=0.7,
+                    )
 
         # Add horizontal line at zero
         ax.axhline(y=0, color="black", linestyle="--", linewidth=1, alpha=0.7)
@@ -1181,14 +1039,14 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         return fig, [ax]
 
-    def _ols_plot_group_time(
+    def _plot_group_time(
         self,
         figsize: tuple[float, float] | None = None,
         layout: Literal["facet", "overlay"] = "facet",
         x_axis: Literal["event_time", "calendar_time"] = "event_time",
         include_placebo: bool = True,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """Plot OLS cohort-time ``ATT(g, t)`` trajectories."""
+        """Plot cohort-time ``ATT(g, t)`` trajectories."""
         att_gt, x_col, x_label, y_label = self._get_group_time_plot_data(
             x_axis=x_axis, include_placebo=include_placebo
         )
@@ -1204,7 +1062,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
         for cohort_idx, (cohort, cohort_data) in enumerate(cohort_groups):
             ax = axes[cohort] if layout == "facet" else axes["overlay"]
-            self._plot_ols_group_time_segment(
+            self._plot_group_time_segment(
                 ax=ax,
                 cohort_data=cohort_data[cohort_data["type"] == "placebo"],
                 x_col=x_col,
@@ -1216,7 +1074,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                     else f"Cohort {cohort} placebo"
                 ),
             )
-            self._plot_ols_group_time_segment(
+            self._plot_group_time_segment(
                 ax=ax,
                 cohort_data=cohort_data[cohort_data["type"] == "ATT"],
                 x_col=x_col,
@@ -1278,8 +1136,12 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         return att_gt, "time", "Calendar Time", y_label
 
     def _get_group_time_placebo_data(self) -> pd.DataFrame:
-        """Return cohort-time placebo estimates for eventually-treated units."""
-        if self._model_backend.is_bayesian:
+        """Return cohort-time placebo estimates for eventually-treated units.
+
+        The two helpers compute genuinely different statistics: HDI bounds
+        need posterior draws, sample dispersion needs only point residuals.
+        """
+        if has_posterior_draws(self.y_pred):
             return self._get_group_time_placebo_data_bayesian()
         return self._get_group_time_placebo_data_ols()
 
@@ -1414,7 +1276,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             return ""
         return x_label
 
-    def _plot_bayesian_group_time_segment(
+    def _plot_group_time_segment(
         self,
         ax: plt.Axes,
         cohort_data: pd.DataFrame,
@@ -1423,45 +1285,36 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         color: str,
         label: str,
     ) -> None:
-        """Plot one Bayesian placebo or ATT segment for a cohort."""
+        """Plot one placebo or ATT segment for a cohort.
+
+        Uncertainty rendering keys on which columns the aggregation produced:
+        HDI bounds (``att_lower`` / ``att_upper``) draw a shaded band, sample
+        dispersion (``att_std`` / ``n_obs``) draws 1.96-SE error bars, and
+        bare point estimates draw a plain line.
+        """
         if len(cohort_data) == 0:
             return
 
         marker = "s" if line_type == "placebo" else "o"
         linestyle = "--" if line_type == "placebo" else "-"
-        alpha = 0.15 if line_type == "placebo" else 0.2
-        ax.plot(
-            cohort_data[x_col],
-            cohort_data["att"],
-            marker=marker,
-            linestyle=linestyle,
-            color=color,
-            label=label,
-        )
-        ax.fill_between(
-            cohort_data[x_col],
-            cohort_data["att_lower"],
-            cohort_data["att_upper"],
-            color=color,
-            alpha=alpha,
-        )
-
-    def _plot_ols_group_time_segment(
-        self,
-        ax: plt.Axes,
-        cohort_data: pd.DataFrame,
-        x_col: str,
-        line_type: Literal["placebo", "ATT"],
-        color: str,
-        label: str,
-    ) -> None:
-        """Plot one OLS placebo or ATT segment for a cohort."""
-        if len(cohort_data) == 0:
-            return
-
-        marker = "s" if line_type == "placebo" else "o"
-        linestyle = "--" if line_type == "placebo" else "-"
-        if {"att_std", "n_obs"}.issubset(cohort_data.columns):
+        if {"att_lower", "att_upper"}.issubset(cohort_data.columns):
+            alpha = 0.15 if line_type == "placebo" else 0.2
+            ax.plot(
+                cohort_data[x_col],
+                cohort_data["att"],
+                marker=marker,
+                linestyle=linestyle,
+                color=color,
+                label=label,
+            )
+            ax.fill_between(
+                cohort_data[x_col],
+                cohort_data["att_lower"],
+                cohort_data["att_upper"],
+                color=color,
+                alpha=alpha,
+            )
+        elif {"att_std", "n_obs"}.issubset(cohort_data.columns):
             se = cohort_data["att_std"] / np.sqrt(cohort_data["n_obs"])
             ax.errorbar(
                 cohort_data[x_col],
@@ -1483,25 +1336,31 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                 label=label,
             )
 
-    def get_plot_data_bayesian(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
-        """Get plotting data for Bayesian model.
+    def get_plot_data(self, hdi_prob: float = HDI_PROB) -> pd.DataFrame:
+        """Get event-time plotting data.
 
         Parameters
         ----------
         hdi_prob : float, optional
-            Probability for HDI interval. Defaults to
+            Probability for HDI interval. Only used by models carrying
+            posterior draws; when it differs from the value cached at fit
+            time, the intervals are recomputed. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------
         pd.DataFrame
-            DataFrame with event_time, att, att_lower, att_upper columns.
+            DataFrame with ``event_time`` and ``att`` columns plus
+            ``att_lower`` / ``att_upper`` HDI bounds (posterior draws) or
+            ``att_std`` / ``n_obs`` dispersion columns (point estimates).
             Includes both pre-treatment (placebo) and post-treatment effects.
         """
-        # If the requested hdi_prob matches what was used during aggregation,
-        # return the pre-computed results
+        # If there are no posterior draws, or the requested hdi_prob matches
+        # what was used during aggregation, return the pre-computed results
         stored_hdi_prob = getattr(self, "hdi_prob_", HDI_PROB)
-        if np.isclose(hdi_prob, stored_hdi_prob):
+        if not has_posterior_draws(self.y_pred) or np.isclose(
+            hdi_prob, stored_hdi_prob
+        ):
             return self.att_event_time_.copy()
 
         # Recompute intervals with the requested hdi_prob
@@ -1590,16 +1449,6 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             )
 
         return self._mark_non_identified_att_rows(pd.DataFrame(att_et_rows))
-
-    def get_plot_data_ols(self) -> pd.DataFrame:
-        """Get plotting data for OLS model.
-
-        Returns
-        -------
-        pd.DataFrame
-            DataFrame with event_time, att, att_std, n_obs columns.
-        """
-        return self.att_event_time_.copy()
 
     def effect_summary(
         self,

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -28,12 +28,14 @@ from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
+    extract_r2_score,
     get_hdi_to_df,
+    has_posterior_draws,
     plot_posterior_over_x,
 )
 from causalpy.pymc_models import PyMCModel, WeightedSumFitter
 from causalpy.reporting import EffectSummary
-from causalpy.utils import _as_scalar, check_convex_hull_violation, round_num
+from causalpy.utils import check_convex_hull_violation, round_num
 
 from .base import BaseExperiment
 
@@ -491,7 +493,7 @@ class SyntheticControl(BaseExperiment):
             figsize=figsize,
         )
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = None,
         treated_unit: str | None = None,
@@ -506,6 +508,11 @@ class SyntheticControl(BaseExperiment):
         """
         Plot the results for a specific treated unit.
 
+        Consumes the canonical prediction container from any backend.
+        Uncertainty bands are drawn only when the container carries posterior
+        draws; point-estimate backends (singleton ``chain``/``draw``) get bare
+        lines.
+
         Parameters
         ----------
         round_to : int, optional
@@ -514,8 +521,8 @@ class SyntheticControl(BaseExperiment):
         treated_unit : str, optional
             Which treated unit to plot. Must be a string name of the treated unit.
             If ``None``, plots the first treated unit.
-        hdi_prob : float, optional
-            Probability mass of the highest density interval drawn around the
+        ci_prob : float, optional
+            Probability mass of the credible interval drawn around the
             posterior predictive, causal impact, and cumulative impact bands.
             Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
@@ -525,16 +532,13 @@ class SyntheticControl(BaseExperiment):
             Width and height of the figure in inches. Defaults to ``(7, 8)``.
         """
         counterfactual_label = "Counterfactual"
+        with_uncertainty = has_posterior_draws(self.pre_pred)
         style: _PosteriorPlotStyle = {
             "ci_prob": ci_prob,
             "kind": kind,
             "ci_kind": ci_kind,
             "num_samples": num_samples,
         }
-
-        fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
-        # TOP PLOT --------------------------------------------------
-        # pre-intervention period
 
         # Get treated unit name - default to first unit if None
         treated_unit = (
@@ -548,76 +552,112 @@ class SyntheticControl(BaseExperiment):
 
         pre_pred = self.pre_pred.sel(treated_units=treated_unit)
         post_pred = self.post_pred.sel(treated_units=treated_unit)
-
-        h_line, h_patch = plot_posterior_over_x(
-            self.datapre.index,
-            pre_pred,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
+        pre_impact = self.pre_impact.sel(treated_units=treated_unit)
+        post_impact = self.post_impact.sel(treated_units=treated_unit)
+        post_impact_cumulative = self.post_impact_cumulative.sel(
+            treated_units=treated_unit
         )
-        handles = [(h_line, h_patch)]
-        labels = ["Pre-intervention period"]
+        pre_treated = self.pre_design["treated"].sel(treated_units=treated_unit)
+        post_treated = self.post_design["treated"].sel(treated_units=treated_unit)
 
-        # Plot observations for primary treated unit
-        (h,) = ax[0].plot(
-            self.datapre.index,
-            self.pre_design["treated"].sel(treated_units=treated_unit),
-            "k.",
-            label="Observations",
-        )
-        handles.append(h)
-        labels.append("Observations")
+        fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
+        # TOP PLOT --------------------------------------------------
+        handles: list[Any] = []
+        labels: list[str] = []
+        if with_uncertainty:
+            # pre-intervention period
+            h_line, h_patch = plot_posterior_over_x(
+                self.datapre.index,
+                pre_pred,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C0"},
+            )
+            handles.append((h_line, h_patch))
+            labels.append("Pre-intervention period")
 
-        # post intervention period
-        h_line, h_patch = plot_posterior_over_x(
-            self.datapost.index,
-            post_pred,
-            ax=ax[0],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
-        handles.append((h_line, h_patch))
-        labels.append(counterfactual_label)
+            # Plot observations for primary treated unit
+            (h,) = ax[0].plot(
+                self.datapre.index,
+                pre_treated,
+                "k.",
+                label="Observations",
+            )
+            handles.append(h)
+            labels.append("Observations")
 
-        ax[0].plot(
-            self.datapost.index,
-            self.post_design["treated"].sel(treated_units=treated_unit),
-            "k.",
-        )
-        # Shaded causal effect for primary treated unit
+            # post intervention period
+            h_line, h_patch = plot_posterior_over_x(
+                self.datapost.index,
+                post_pred,
+                ax=ax[0],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+            handles.append((h_line, h_patch))
+            labels.append(counterfactual_label)
+
+            ax[0].plot(self.datapost.index, post_treated, "k.")
+        else:
+            ax[0].plot(pre_treated["obs_ind"], pre_treated, "k.")
+            ax[0].plot(post_treated["obs_ind"], post_treated, "k.")
+            ax[0].plot(
+                self.datapre.index,
+                pre_pred.mean(dim=["chain", "draw"]),
+                c="k",
+                label="model fit",
+            )
+            ax[0].plot(
+                self.datapost.index,
+                post_pred.mean(dim=["chain", "draw"]),
+                label=counterfactual_label,
+                ls=":",
+                c="k",
+            )
+
+        # Shaded causal effect
         h = ax[0].fill_between(
             self.datapost.index,
             y1=post_pred.mean(dim=["chain", "draw"]).values,
-            y2=self.post_design["treated"].sel(treated_units=treated_unit).values,
+            y2=post_treated.values,
             color="C0",
             alpha=0.25,
             label="Causal impact",
         )
-        handles.append(h)
-        labels.append("Causal impact")
+        if with_uncertainty:
+            handles.append(h)
+            labels.append("Causal impact")
 
         ax[0].set(title=f"{self._get_score_title(treated_unit, round_to)}")
 
         # MIDDLE PLOT -----------------------------------------------
-        plot_posterior_over_x(
-            self.datapre.index,
-            self.pre_impact.sel(treated_units=treated_unit),
-            ax=ax[1],
-            **style,
-            plot_hdi_kwargs={"color": "C0"},
-        )
-        plot_posterior_over_x(
-            self.datapost.index,
-            self.post_impact.sel(treated_units=treated_unit),
-            ax=ax[1],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
+        if with_uncertainty:
+            plot_posterior_over_x(
+                self.datapre.index,
+                pre_impact,
+                ax=ax[1],
+                **style,
+                plot_hdi_kwargs={"color": "C0"},
+            )
+            plot_posterior_over_x(
+                self.datapost.index,
+                post_impact,
+                ax=ax[1],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+        else:
+            ax[1].plot(self.datapre.index, pre_impact.mean(dim=["chain", "draw"]), "k.")
+            ax[1].plot(
+                self.datapost.index,
+                post_impact.mean(dim=["chain", "draw"]),
+                "k.",
+                label=counterfactual_label,
+            )
         ax[1].axhline(y=0, c="k")
         ax[1].fill_between(
             self.datapost.index,
-            y1=self.post_impact.mean(["chain", "draw"]).sel(treated_units=treated_unit),
+            y1=post_impact.mean(dim=["chain", "draw"]),
             color="C0",
             alpha=0.25,
             label="Causal impact",
@@ -625,15 +665,22 @@ class SyntheticControl(BaseExperiment):
         ax[1].set(title="Causal Impact")
 
         # BOTTOM PLOT -----------------------------------------------
-        ax[2].set(title="Cumulative Causal Impact")
-        plot_posterior_over_x(
-            self.datapost.index,
-            self.post_impact_cumulative.sel(treated_units=treated_unit),
-            ax=ax[2],
-            **style,
-            plot_hdi_kwargs={"color": "C1"},
-        )
+        if with_uncertainty:
+            plot_posterior_over_x(
+                self.datapost.index,
+                post_impact_cumulative,
+                ax=ax[2],
+                **style,
+                plot_hdi_kwargs={"color": "C1"},
+            )
+        else:
+            ax[2].plot(
+                self.datapost.index,
+                post_impact_cumulative.mean(dim=["chain", "draw"]),
+                c="k",
+            )
         ax[2].axhline(y=0, c="k")
+        ax[2].set(title="Cumulative Causal Impact")
 
         # Intervention line
         for i in [0, 1, 2]:
@@ -645,13 +692,18 @@ class SyntheticControl(BaseExperiment):
                 ls="-",
                 lw=3,
                 color="r",
+                label=None if with_uncertainty else "Treatment time",
             )
 
-        ax[0].legend(
-            handles=(h_tuple for h_tuple in handles),
-            labels=labels,
-            fontsize=LEGEND_FONT_SIZE,
-        )
+        if with_uncertainty:
+            ax[0].legend(
+                handles=(h_tuple for h_tuple in handles),
+                labels=labels,
+                fontsize=LEGEND_FONT_SIZE,
+            )
+        else:
+            # Collect labelled artists (including the treatment line)
+            ax[0].legend(fontsize=LEGEND_FONT_SIZE)
 
         if plot_predictors:
             # plot control units as well
@@ -681,176 +733,28 @@ class SyntheticControl(BaseExperiment):
 
         return fig, ax
 
-    def _ols_plot(
-        self,
-        round_to: int | None = None,
-        treated_unit: str | None = None,
-        figsize: tuple[float, float] = (7, 8),
-        **kwargs: Any,
-    ) -> tuple[plt.Figure, list[plt.Axes]]:
-        """
-        Plot the results for OLS model for a specific treated unit
-
-        :param round_to:
-            Number of decimals used to round results. Defaults to 2. Use "None" to return raw numbers.
-        :param treated_unit:
-            Which treated unit to plot. Must be a string name of the treated unit.
-            If None, plots the first treated unit.
-        :param figsize:
-            Width and height of the figure in inches. Defaults to ``(7, 8)``.
-        """
-        counterfactual_label = "Counterfactual"
-
-        # Get treated unit name - default to first unit if None
-        treated_unit = (
-            treated_unit if treated_unit is not None else self.treated_units[0]
-        )
-
-        if treated_unit not in self.treated_units:
-            raise ValueError(
-                f"treated_unit '{treated_unit}' not found. Available units: {self.treated_units}"
-            )
-
-        # Point estimates from the singleton chain/draw dimensions
-        pre_pred = self.pre_pred.isel(chain=0, draw=0).sel(treated_units=treated_unit)
-        post_pred = self.post_pred.isel(chain=0, draw=0).sel(treated_units=treated_unit)
-        pre_impact = self.pre_impact.isel(chain=0, draw=0).sel(
-            treated_units=treated_unit
-        )
-        post_impact = self.post_impact.isel(chain=0, draw=0).sel(
-            treated_units=treated_unit
-        )
-        post_impact_cumulative = self.post_impact_cumulative.isel(chain=0, draw=0).sel(
-            treated_units=treated_unit
-        )
-
-        fig, ax = plt.subplots(3, 1, sharex=True, figsize=figsize)
-
-        ax[0].plot(
-            self.pre_design["treated"]["obs_ind"],
-            self.pre_design["treated"].sel(treated_units=treated_unit),
-            "k.",
-        )
-        ax[0].plot(
-            self.post_design["treated"]["obs_ind"],
-            self.post_design["treated"].sel(treated_units=treated_unit),
-            "k.",
-        )
-
-        ax[0].plot(self.datapre.index, pre_pred, c="k", label="model fit")
-        ax[0].plot(
-            self.datapost.index,
-            post_pred,
-            label=counterfactual_label,
-            ls=":",
-            c="k",
-        )
-        ax[0].set(title=f"{self._get_score_title(treated_unit, round_to)}")
-        # Shaded causal effect
-        ax[0].fill_between(
-            self.datapost.index,
-            y1=post_pred,
-            y2=self.post_design["treated"].sel(treated_units=treated_unit),
-            color="C0",
-            alpha=0.25,
-            label="Causal impact",
-        )
-
-        ax[1].plot(self.datapre.index, pre_impact, "k.")
-        ax[1].plot(
-            self.datapost.index,
-            post_impact,
-            "k.",
-            label=counterfactual_label,
-        )
-        ax[1].axhline(y=0, c="k")
-        ax[1].set(title="Causal Impact")
-
-        ax[2].plot(self.datapost.index, post_impact_cumulative, c="k")
-        ax[2].axhline(y=0, c="k")
-        ax[2].set(title="Cumulative Causal Impact")
-
-        # Shaded causal effect
-        ax[1].fill_between(
-            self.datapost.index,
-            y1=post_impact,
-            color="C0",
-            alpha=0.25,
-            label="Causal impact",
-        )
-
-        # Intervention line
-        for i in [0, 1, 2]:
-            treatment_time = self._convert_treatment_time_for_axis(
-                ax[i], self.treatment_time
-            )
-            ax[i].axvline(
-                x=treatment_time,
-                ls="-",
-                lw=3,
-                color="r",
-                label="Treatment time",
-            )
-
-        ax[0].legend(fontsize=LEGEND_FONT_SIZE)
-
-        # Apply intelligent date formatting if data has datetime index
-        if isinstance(self.datapre.index, pd.DatetimeIndex):
-            # Combine pre and post indices for full date range
-            full_index = _combine_datetime_indices(
-                pd.DatetimeIndex(self.datapre.index),
-                pd.DatetimeIndex(self.datapost.index),
-            )
-            format_date_axes(ax, full_index)
-
-        return (fig, ax)
-
-    def get_plot_data_ols(self) -> pd.DataFrame:
-        """
-        Recover the data of the experiment along with the prediction and causal impact information.
-        """
-        pre_data = self.datapre.copy()
-        post_data = self.datapost.copy()
-        pre_data["prediction"] = self.pre_pred.isel(
-            chain=0, draw=0, treated_units=0
-        ).values
-        post_data["prediction"] = self.post_pred.isel(
-            chain=0, draw=0, treated_units=0
-        ).values
-        pre_data["impact"] = self.pre_impact.isel(
-            chain=0, draw=0, treated_units=0
-        ).values
-        post_data["impact"] = self.post_impact.isel(
-            chain=0, draw=0, treated_units=0
-        ).values
-        self.plot_data = pd.concat([pre_data, post_data])
-
-        return self.plot_data
-
-    def get_plot_data_bayesian(
+    def get_plot_data(
         self, hdi_prob: float = HDI_PROB, treated_unit: str | None = None
     ) -> pd.DataFrame:
         """
-        Recover the data of the PrePostFit experiment along with the prediction and causal impact information.
+        Recover the data of the experiment along with the prediction and causal impact information.
+
+        HDI columns are included only when the prediction container carries
+        posterior draws (point-estimate backends return just ``prediction``
+        and ``impact``).
 
         Parameters
         ----------
         hdi_prob : float, default :data:`~causalpy.constants.HDI_PROB`
             Probability mass of the highest density interval. Defaults to
-            the project-wide :data:`~causalpy.constants.HDI_PROB`.
+            the project-wide :data:`~causalpy.constants.HDI_PROB`. Ignored
+            when the prediction container has no posterior draws.
         treated_unit : str, optional
             Which treated unit to extract data for. Must be a string name
             of the treated unit. If ``None``, uses the first treated unit.
         """
-        if not self._model_backend.is_bayesian:
-            raise ValueError("Unsupported model type")
-
+        with_uncertainty = has_posterior_draws(self.pre_pred)
         hdi_pct = int(round(hdi_prob * 100))
-
-        pred_lower_col = f"pred_hdi_lower_{hdi_pct}"
-        pred_upper_col = f"pred_hdi_upper_{hdi_pct}"
-        impact_lower_col = f"impact_hdi_lower_{hdi_pct}"
-        impact_upper_col = f"impact_hdi_upper_{hdi_pct}"
 
         pre_data = self.datapre.copy()
         post_data = self.datapost.copy()
@@ -865,60 +769,39 @@ class SyntheticControl(BaseExperiment):
                 f"treated_unit '{treated_unit}' not found. Available units: {self.treated_units}"
             )
 
-        # Extract predictions for the specified treated unit
-        pre_data["prediction"] = (
-            self.pre_pred.sel(treated_units=treated_unit)
-            .mean(dim=["chain", "draw"])
-            .values
-        )
-        post_data["prediction"] = (
-            self.post_pred.sel(treated_units=treated_unit)
-            .mean(dim=["chain", "draw"])
-            .values
-        )
+        pre_pred = self.pre_pred.sel(treated_units=treated_unit)
+        post_pred = self.post_pred.sel(treated_units=treated_unit)
+        pre_impact = self.pre_impact.sel(treated_units=treated_unit)
+        post_impact = self.post_impact.sel(treated_units=treated_unit)
 
-        # HDI intervals for predictions (always use treated_units dimension)
-        pre_hdi = get_hdi_to_df(
-            self.pre_pred.sel(treated_units=treated_unit),
-            hdi_prob=hdi_prob,
-        )
-        post_hdi = get_hdi_to_df(
-            self.post_pred.sel(treated_units=treated_unit),
-            hdi_prob=hdi_prob,
-        )
+        pre_data["prediction"] = pre_pred.mean(dim=["chain", "draw"]).values
+        post_data["prediction"] = post_pred.mean(dim=["chain", "draw"]).values
 
-        # Extract only the lower and upper columns and ensure proper indexing
-        pre_lower_upper = pre_hdi.iloc[:, [0, -1]].values  # Get first and last columns
-        post_lower_upper = post_hdi.iloc[:, [0, -1]].values
+        if with_uncertainty:
+            pred_lower_col = f"pred_hdi_lower_{hdi_pct}"
+            pred_upper_col = f"pred_hdi_upper_{hdi_pct}"
+            pre_hdi = get_hdi_to_df(pre_pred, hdi_prob=hdi_prob)
+            post_hdi = get_hdi_to_df(post_pred, hdi_prob=hdi_prob)
+            # Extract only the lower and upper columns
+            pre_data[[pred_lower_col, pred_upper_col]] = pre_hdi.iloc[:, [0, -1]].values
+            post_data[[pred_lower_col, pred_upper_col]] = post_hdi.iloc[
+                :, [0, -1]
+            ].values
 
-        pre_data[[pred_lower_col, pred_upper_col]] = pre_lower_upper
-        post_data[[pred_lower_col, pred_upper_col]] = post_lower_upper
+        pre_data["impact"] = pre_impact.mean(dim=["chain", "draw"]).values
+        post_data["impact"] = post_impact.mean(dim=["chain", "draw"]).values
 
-        # Impact data - always use primary unit for main dataframe
-        pre_data["impact"] = (
-            self.pre_impact.mean(dim=["chain", "draw"])
-            .sel(treated_units=treated_unit)
-            .values
-        )
-        post_data["impact"] = (
-            self.post_impact.mean(dim=["chain", "draw"])
-            .sel(treated_units=treated_unit)
-            .values
-        )
-        # Impact HDI intervals (always use treated_units dimension)
-        pre_impact_hdi = get_hdi_to_df(
-            self.pre_impact.sel(treated_units=treated_unit), hdi_prob=hdi_prob
-        )
-        post_impact_hdi = get_hdi_to_df(
-            self.post_impact.sel(treated_units=treated_unit), hdi_prob=hdi_prob
-        )
-
-        # Extract only the lower and upper columns for impact HDI
-        pre_impact_lower_upper = pre_impact_hdi.iloc[:, [0, -1]].values
-        post_impact_lower_upper = post_impact_hdi.iloc[:, [0, -1]].values
-
-        pre_data[[impact_lower_col, impact_upper_col]] = pre_impact_lower_upper
-        post_data[[impact_lower_col, impact_upper_col]] = post_impact_lower_upper
+        if with_uncertainty:
+            impact_lower_col = f"impact_hdi_lower_{hdi_pct}"
+            impact_upper_col = f"impact_hdi_upper_{hdi_pct}"
+            pre_impact_hdi = get_hdi_to_df(pre_impact, hdi_prob=hdi_prob)
+            post_impact_hdi = get_hdi_to_df(post_impact, hdi_prob=hdi_prob)
+            pre_data[[impact_lower_col, impact_upper_col]] = pre_impact_hdi.iloc[
+                :, [0, -1]
+            ].values
+            post_data[[impact_lower_col, impact_upper_col]] = post_impact_hdi.iloc[
+                :, [0, -1]
+            ].values
 
         self.plot_data = pd.concat([pre_data, post_data])
 
@@ -926,21 +809,17 @@ class SyntheticControl(BaseExperiment):
 
     def _get_score_title(self, treated_unit: str, round_to: int | None = 2) -> str:
         """Generate appropriate score title for the specified treated unit"""
-        if self._model_backend.is_bayesian:
-            # Bayesian model - get unit-specific R² scores using unified format
-            unit_index = self.treated_units.index(treated_unit)
-            r2_val = round_num(
-                self.score[f"unit_{unit_index}_r2"],
-                round_to if round_to is not None else 2,
+        r_to = round_to if round_to is not None else 2
+        r2_val, r2_std_val = extract_r2_score(
+            self.score, unit_index=self.treated_units.index(treated_unit)
+        )
+        assert r2_val is not None  # both backends' score containers carry R^2
+        if r2_std_val is not None:
+            return (
+                f"Pre-intervention Bayesian $R^2$: {round_num(r2_val, r_to)} "
+                f"(std = {round_num(r2_std_val, r_to)})"
             )
-            r2_std_val = round_num(
-                self.score[f"unit_{unit_index}_r2_std"],
-                round_to if round_to is not None else 2,
-            )
-            return f"Pre-intervention Bayesian $R^2$: {r2_val} (std = {r2_std_val})"
-        else:
-            # OLS model - simple float score
-            return f"$R^2$ on pre-intervention data = {round_num(_as_scalar(self.score), round_to if round_to is not None else 2)}"
+        return f"$R^2$ on pre-intervention data = {round_num(r2_val, r_to)}"
 
     def effect_summary(
         self,

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -668,13 +668,14 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         except (TypeError, ValueError):
             return treatment_time
 
-    def _bayesian_plot(
+    def _plot(
         self,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
+        **kwargs: Any,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """Plot the results: counterfactual, impact, and cumulative impact.
 
@@ -832,13 +833,6 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             format_date_axes(ax, full_index)
 
         return fig, ax
-
-    def _ols_plot(self, *args: Any, **kwargs: Any) -> tuple:
-        """OLS not supported for SDiD."""
-        raise NotImplementedError(
-            "OLS models are not supported for "
-            "SyntheticDifferenceInDifferences. Use a Bayesian model."
-        )
 
     def effect_summary(
         self,

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -29,6 +29,54 @@ from matplotlib.lines import Line2D
 from pandas.api.extensions import ExtensionArray
 
 from causalpy.constants import HDI_PROB
+from causalpy.utils import _as_scalar
+
+
+def has_posterior_draws(Y: xr.DataArray) -> bool:
+    """Whether *Y* carries genuine posterior uncertainty.
+
+    The canonical prediction container has ``chain`` and ``draw`` dimensions
+    on every backend; point-estimate backends emit singleton dimensions (a
+    point estimate is a posterior with one atom). Plot code should key
+    uncertainty rendering (ribbons, HDI labels, ...) on this data property
+    rather than on backend identity.
+
+    Parameters
+    ----------
+    Y : xr.DataArray
+        A canonical prediction container with ``chain`` and ``draw``
+        dimensions.
+    """
+    return Y.sizes.get("chain", 1) * Y.sizes.get("draw", 1) > 1
+
+
+def extract_r2_score(
+    score: pd.Series | float, unit_index: int = 0
+) -> tuple[float | None, float | None]:
+    """Extract ``(r2, r2_std)`` from a backend score container.
+
+    Bayesian backends return a :class:`pandas.Series` with
+    ``unit_{i}_r2`` / ``unit_{i}_r2_std`` (or plain ``r2`` / ``r2_std``)
+    entries; point-estimate backends return a scalar. ``r2_std`` is ``None``
+    when the container carries no dispersion, so callers can render
+    ``(std = ...)`` only when it exists.
+
+    Parameters
+    ----------
+    score : pd.Series or float
+        Backend score container as stored on ``experiment.score``.
+    unit_index : int, optional
+        Index of the treated unit whose score to extract. Defaults to 0.
+    """
+    if isinstance(score, pd.Series):
+        key = f"unit_{unit_index}_r2"
+        if key not in score.index:
+            key = "r2"
+        if key not in score.index:
+            return None, None
+        std = score.get(f"{key}_std")
+        return float(score[key]), None if std is None else float(std)
+    return float(_as_scalar(score)), None
 
 
 class _PosteriorPlotStyle(TypedDict):

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -80,7 +80,7 @@ def extract_r2_score(
 
 
 class _PosteriorPlotStyle(TypedDict):
-    """Typed kwargs bundle forwarded from ``_bayesian_plot`` to every ``plot_posterior_over_x`` call."""
+    """Typed kwargs bundle forwarded from experiment ``_plot`` methods to every ``plot_posterior_over_x`` call."""
 
     ci_prob: float
     kind: Literal["ribbon", "histogram", "spaghetti"]

--- a/causalpy/tests/test_default_models.py
+++ b/causalpy/tests/test_default_models.py
@@ -216,16 +216,10 @@ def test_missing_default_model_class_raises_valueerror():
         supports_bayes = True
         supports_ols = True
 
-        def _bayesian_plot(self):
+        def _plot(self):
             pass
 
-        def _ols_plot(self):
-            pass
-
-        def get_plot_data_bayesian(self):
-            pass
-
-        def get_plot_data_ols(self):
+        def get_plot_data(self):
             pass
 
         def effect_summary(self):

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -522,7 +522,7 @@ def test_deprecated_hdi_prob_alias_emits_futurewarning(
 # StaggeredDifferenceInDifferences has different semantics: HDI bounds are
 # computed during effect aggregation (at fit time), not at plot time. The
 # plot reads cached ``att_lower``/``att_upper`` columns. To prevent silent
-# kwarg swallowing, ``_bayesian_plot`` raises a clear ``ValueError`` when the
+# kwarg swallowing, ``_plot`` raises a clear ``ValueError`` when the
 # caller supplies an ``hdi_prob`` that does not match the cached value.
 # ---------------------------------------------------------------------------
 

--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -686,7 +686,7 @@ def test_sdid(mock_pymc_sample):
 @pytest.mark.integration
 def test_sdid_datetime_index_and_effect_summary(mock_pymc_sample):
     """SDiD with a DatetimeIndex panel exercises the datetime branch in
-    ``_bayesian_plot`` and the full ``effect_summary`` body, including the
+    ``_plot`` and the full ``effect_summary`` body, including the
     ``period``-warning path and the ``cumulative=False`` branch.
     """
     df = cp.load_data("sc").copy()
@@ -703,7 +703,7 @@ def test_sdid_datetime_index_and_effect_summary(mock_pymc_sample):
         ),
     )
 
-    # DatetimeIndex branch in _bayesian_plot calls format_date_axes.
+    # DatetimeIndex branch in _plot calls format_date_axes.
     fig, _ = result.plot(show=False)
     assert isinstance(fig, plt.Figure)
 

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -806,34 +806,6 @@ def test_plot_trajectories_single_unit(small_panel_data):
     plt.close(fig)
 
 
-def test_get_plot_data_bayesian_raises_on_ols(small_panel_data):
-    """get_plot_data_bayesian() should raise ValueError for non-PyMC models."""
-    result = cp.PanelRegression(
-        data=small_panel_data,
-        formula="y ~ C(unit) + treatment + x1",
-        unit_fe_variable="unit",
-        fe_method="dummies",
-        model=LinearRegression(),
-    )
-
-    with pytest.raises(ValueError, match="not a PyMC model"):
-        result.get_plot_data_bayesian()
-
-
-def test_get_plot_data_ols_raises_on_pymc(mock_pymc_sample, small_panel_data):
-    """get_plot_data_ols() should raise ValueError for non-OLS models."""
-    result = cp.PanelRegression(
-        data=small_panel_data,
-        formula="y ~ C(unit) + treatment + x1",
-        unit_fe_variable="unit",
-        fe_method="dummies",
-        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
-    )
-
-    with pytest.raises(ValueError, match="not an OLS model"):
-        result.get_plot_data_ols()
-
-
 def test_plot_unit_effects_no_fe_labels(small_panel_data):
     """plot_unit_effects() raises when formula has no C(unit) terms."""
     result = cp.PanelRegression(

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -190,7 +190,7 @@ class TestRoundTripAgainstPyMCBackend:
         assert "Model parameters:" in capsys.readouterr().out
         summary = forecast_result.effect_summary()
         assert len(summary.text) > 0
-        plot_df = forecast_result.get_plot_data_bayesian()
+        plot_df = forecast_result.get_plot_data()
         assert {"prediction", "impact"}.issubset(plot_df.columns)
 
     def test_experiment_reports_bayesian_backend(self, forecast_result):

--- a/causalpy/tests/test_staggered_did.py
+++ b/causalpy/tests/test_staggered_did.py
@@ -324,7 +324,7 @@ def test_staggered_did_bayesian_plot_data_accepts_transformed_outcome(
     )
 
     assert not result._get_group_time_placebo_data().empty
-    assert not result.get_plot_data_bayesian(hdi_prob=0.8).empty
+    assert not result.get_plot_data(hdi_prob=0.8).empty
 
 
 # ==============================================================================
@@ -827,7 +827,7 @@ def test_staggered_did_get_plot_data_bayesian_masks_non_identified_on_recompute(
             model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
         )
 
-    plot_data = result.get_plot_data_bayesian(hdi_prob=0.80)
+    plot_data = result.get_plot_data(hdi_prob=0.80)
 
     assert "identified" in plot_data.columns
     non_identified_post = plot_data[
@@ -1538,8 +1538,8 @@ def test_staggered_did_training_data_shape():
 
 
 @pytest.mark.integration
-def test_staggered_did_get_plot_data_bayesian(mock_pymc_sample):
-    """Test get_plot_data_bayesian method."""
+def test_staggered_did_get_plot_data_pymc(mock_pymc_sample):
+    """Test get_plot_data returns HDI columns for models with posterior draws."""
     df = generate_staggered_did_data(
         n_units=30,
         n_time_periods=15,
@@ -1556,7 +1556,7 @@ def test_staggered_did_get_plot_data_bayesian(mock_pymc_sample):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    plot_data = result.get_plot_data_bayesian()
+    plot_data = result.get_plot_data()
 
     assert isinstance(plot_data, pd.DataFrame)
     assert "event_time" in plot_data.columns
@@ -1567,7 +1567,7 @@ def test_staggered_did_get_plot_data_bayesian(mock_pymc_sample):
 
 @pytest.mark.integration
 def test_staggered_did_get_plot_data_bayesian_hdi_prob_respected(mock_pymc_sample):
-    """Test that get_plot_data_bayesian respects the hdi_prob parameter.
+    """Test that get_plot_data respects the hdi_prob parameter.
 
     This verifies the fix for the bug where hdi_prob was accepted but ignored,
     always returning pre-computed 94% intervals.
@@ -1589,13 +1589,13 @@ def test_staggered_did_get_plot_data_bayesian_hdi_prob_respected(mock_pymc_sampl
     )
 
     # Get intervals with default 94% HDI
-    plot_data_94 = result.get_plot_data_bayesian(hdi_prob=0.94)
+    plot_data_94 = result.get_plot_data(hdi_prob=0.94)
 
     # Get intervals with narrower 80% HDI
-    plot_data_80 = result.get_plot_data_bayesian(hdi_prob=0.80)
+    plot_data_80 = result.get_plot_data(hdi_prob=0.80)
 
     # Get intervals with wider 99% HDI
-    plot_data_99 = result.get_plot_data_bayesian(hdi_prob=0.99)
+    plot_data_99 = result.get_plot_data(hdi_prob=0.99)
 
     # Verify structure is correct for all
     for df_plot in [plot_data_94, plot_data_80, plot_data_99]:
@@ -1624,7 +1624,7 @@ def test_staggered_did_get_plot_data_bayesian_hdi_prob_respected(mock_pymc_sampl
 
 
 def test_staggered_did_get_plot_data_ols():
-    """Test get_plot_data_ols method."""
+    """Test get_plot_data returns dispersion columns for point-estimate models."""
     df = generate_staggered_did_data(
         n_units=30,
         n_time_periods=15,
@@ -1641,7 +1641,7 @@ def test_staggered_did_get_plot_data_ols():
         model=LinearRegression(),
     )
 
-    plot_data = result.get_plot_data_ols()
+    plot_data = result.get_plot_data()
 
     assert isinstance(plot_data, pd.DataFrame)
     assert "event_time" in plot_data.columns


### PR DESCRIPTION
Closes #1037.

## Summary

Now that every backend emits the canonical prediction container (`chain`/`draw`/`obs_ind`/`treated_units` DataArray), the paired `_bayesian_plot` / `_ols_plot` and `get_plot_data_bayesian` / `get_plot_data_ols` methods were dispatch-at-use: near-identical bodies that differed only in container unpacking and uncertainty rendering. This PR merges each pair into one `_plot` / `get_plot_data` per experiment and deletes the backend dispatch from `BaseExperiment`.

Uncertainty rendering now keys on **data properties, not backend identity**: the new `has_posterior_draws()` helper (`chain × draw > 1`) decides whether ribbons/HDI labels are drawn, and `extract_r2_score()` normalizes score-container access. A point estimate is a posterior with one atom, so the point-estimate path is the degenerate case of the general one; where OLS styling deliberately differs (black fit line, no band, plain R² title), the branch is a single `with_uncertainty` guard inside the one method rather than a duplicated method.

## Pixel equivalence

Every migrated experiment was verified pixel-identical (byte-identical PNGs via `cmp`) before/after on both backends using a seeded batch plot-generation script (19 figures: ITS, SC, DiD, PiecewiseITS, RD, StaggeredDiD event-study + group-time, Panel, SDiD, PrePostNEGD, RKink). The script and plot-regression test files will land from a separate feature branch to keep this PR a pure refactor.

## Code simplification record

| Commit | Experiment | Net lines |
|---|---|---|
| ITS | InterruptedTimeSeries (+ helpers, base transition) | −89 |
| SC | SyntheticControl | −121 |
| DiD | DifferenceInDifferences | −36 |
| PITS | PiecewiseITS | −52 |
| RD | RegressionDiscontinuity | −51 |
| Panel | PanelRegression | −65 |
| SDiD | StaggeredDiD | −151 |
| Bayes-only | SDiD/RKink/PrePostNEGD renames | −6 |
| Base | Remove dispatch + stubs, docs | −52 |
| **Total** | | **−623** (986 insertions, 1609 deletions) |

## Surviving backend branches (with justification)

- `PanelRegression.get_plot_data` / `_plot_coefficients_internal`: the experiment stores no canonical in-sample prediction container, so fitted values come from backend-native objects (`idata.posterior["mu"]` vs sklearn `predict`), and `az.plot_forest` genuinely requires `idata`. Both branches are isolated in single methods with `ponytail:` upgrade-path comments.
- `StaggeredDiD._get_group_time_placebo_data`: HDI bounds need posterior draws, sample dispersion needs only point residuals — genuinely different statistics, dispatched on `has_posterior_draws`, isolated to one seam.

## Test plan

- [x] Full suite: 1223 passed, 5 skipped
- [x] `prek run --all-files` clean
- [x] `make test-patch-cov`: 99% patch coverage (gate 96%)
- [x] 19/19 baseline-vs-after PNGs byte-identical on both backends
