### PR TITLE
Dispatch remaining Bayesian/OLS branches on posterior size, not backend identity

### DIFF
--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -411,7 +411,7 @@ class BaseExperiment(ABC):
         Subclasses implement a single backend-agnostic ``_plot`` that consumes
         the canonical prediction container. Uncertainty rendering should key
         on data properties (e.g.
-        :func:`~causalpy.plot_utils.has_posterior_draws`), not backend
+        :func:`~causalpy.utils.has_posterior_draws`), not backend
         identity.
         """
         raise NotImplementedError("_plot method not yet implemented")

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -223,6 +223,9 @@ class DifferenceInDifferences(BaseExperiment):
         self.y_pred_counterfactual = self._model_backend.predict(np.asarray(new_x))
 
         # calculate causal impact
+        # Backend-identity branch is justified here: this is the adapter seam,
+        # extracting the treatment coefficient from backend-native storage
+        # (full posterior of `beta` from idata vs point coefficients).
         if self._model_backend.is_bayesian:
             assert self.model.idata is not None
             # This is the coefficient on the interaction term
@@ -663,11 +666,13 @@ class DifferenceInDifferences(BaseExperiment):
         Parameters
         ----------
         direction : {"increase", "decrease", "two-sided"}, default="increase"
-            Direction for tail probability calculation (PyMC only, ignored for OLS).
+            Direction for tail probability calculation (ignored for
+            point-estimate predictions).
         alpha : float, default=0.05
             Significance level for HDI/CI intervals (1-alpha confidence level).
         min_effect : float, optional
-            Region of Practical Equivalence (ROPE) threshold (PyMC only, ignored for OLS).
+            Region of Practical Equivalence (ROPE) threshold (ignored for
+            point-estimate predictions).
         **kwargs
             Reserved for forward-compatibility; not consumed by this
             implementation.
@@ -677,9 +682,7 @@ class DifferenceInDifferences(BaseExperiment):
         EffectSummary
             Object with .table (DataFrame) and .text (str) attributes
         """
-        is_pymc = self._model_backend.is_bayesian
-
-        if is_pymc:
+        if has_posterior_draws(self.y_pred_control):
             return _effect_summary_did(
                 self,
                 direction=direction,

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -392,12 +392,12 @@ class InterruptedTimeSeries(BaseExperiment):
         """
         from causalpy.reporting import _extract_hdi_bounds
 
-        is_pymc = self._model_backend.is_bayesian
+        has_draws = has_posterior_draws(self.intervention_impact)
         time_dim = "obs_ind"
         hdi_prob = 1 - alpha
         prob_persisted: float | None
 
-        if is_pymc:
+        if has_draws:
             # PyMC: Compute statistics for both periods
             intervention_avg = self.intervention_impact.mean(dim=time_dim)
             intervention_mean = _as_scalar(intervention_avg.mean(dim=["chain", "draw"]))
@@ -1044,10 +1044,10 @@ class InterruptedTimeSeries(BaseExperiment):
                 "This method is only available for three-period designs."
             )
 
-        is_pymc = self._model_backend.is_bayesian
+        has_draws = has_posterior_draws(self.intervention_impact)
         time_dim = "obs_ind"
 
-        if is_pymc:
+        if has_draws:
             # PyMC: Compute statistics using xarray operations
             from causalpy.reporting import _extract_hdi_bounds
 
@@ -1133,7 +1133,7 @@ class InterruptedTimeSeries(BaseExperiment):
 
         # Print results
         hdi_pct = int(hdi_prob * 100)
-        ci_label = "HDI" if is_pymc else "CI"
+        ci_label = "HDI" if has_draws else "CI"
         print("=" * 60)
         print("Effect Persistence Analysis")
         print("=" * 60)
@@ -1276,7 +1276,6 @@ class InterruptedTimeSeries(BaseExperiment):
             )
 
         return _effect_summary_timeseries(
-            self,
             windowed_impact,
             counterfactual,
             window_coords,

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -430,6 +430,8 @@ class PanelRegression(BaseExperiment):
             )
 
         print("\nModel Coefficients:")
+        # Backend-identity branch is justified: coefficient access is
+        # backend-native (PanelRegression stores no canonical container).
         if self._model_backend.is_bayesian:
             # PyMC print_coefficients uses coordinate-based lookup so a
             # filtered label list works correctly.
@@ -592,6 +594,8 @@ class PanelRegression(BaseExperiment):
 
         coeff_names = var_names if var_names is not None else self._get_non_fe_labels()
 
+        # Backend-identity branch is justified: coefficient posteriors live in
+        # backend-native storage (idata vs get_coeffs); no canonical container.
         if self._model_backend.is_bayesian:
             # Bayesian: use az.plot_forest directly
             axes = az.plot_forest(
@@ -729,6 +733,8 @@ class PanelRegression(BaseExperiment):
 
         fig, ax = plt.subplots(figsize=(10, 6))
 
+        # Backend-identity branch is justified: coefficient posteriors live in
+        # backend-native storage (idata vs get_coeffs); no canonical container.
         if self._model_backend.is_bayesian:
             # Bayesian: get posterior means
             beta = self.model.idata.posterior["beta"]  # type: ignore[union-attr]
@@ -822,7 +828,9 @@ class PanelRegression(BaseExperiment):
         if interval_type not in {"mean", "predictive"}:
             raise ValueError("interval_type must be 'mean' or 'predictive'")
 
-        # Check if model is Bayesian
+        # Backend-identity branch is justified: in-sample mu / y_hat draws
+        # live in backend-native idata (PanelRegression stores no canonical
+        # prediction container; see the ponytail note in get_plot_data).
         is_bayesian = self._model_backend.is_bayesian
 
         # Get posterior for HDI plotting (Bayesian only)

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -805,7 +805,6 @@ class PiecewiseITS(BaseExperiment):
             self, window_coords, treated_unit=treated_unit
         )
         return _effect_summary_timeseries(
-            self,
             windowed_impact,
             counterfactual,
             window_coords,

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -142,6 +142,8 @@ class PrePostNEGD(BaseExperiment):
         X = self.design["X"]
         y = self.design["y"]
 
+        # Backend-identity checks are justified here: capability validation
+        # (trust boundary), not statistical dispatch.
         if self._model_backend.is_ols:
             raise NotImplementedError("Not implemented for OLS model")
         if not self._model_backend.is_bayesian:

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -298,7 +298,7 @@ class RegressionDiscontinuity(BaseExperiment):
         print("\nResults:")
         discontinuity = (
             self.discontinuity_at_threshold
-            if self._model_backend.is_bayesian
+            if has_posterior_draws(self.discontinuity_at_threshold)
             else _as_scalar(self.discontinuity_at_threshold)
         )
         print(f"Discontinuity at threshold = {convert_to_string(discontinuity)}")

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -514,7 +514,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         is_pre_treatment = self.data["event_time"] < 0
         pretreatment_data = self.data[is_eventually_treated & is_pre_treatment].copy()
 
-        if self._model_backend.is_bayesian:
+        # The two helpers compute genuinely different statistics: HDI bounds
+        # need posterior draws, sample dispersion needs only point residuals.
+        if has_posterior_draws(self.y_pred):
             self._aggregate_effects_bayesian(treated_data, pretreatment_data)
         else:
             self._aggregate_effects_ols(treated_data, pretreatment_data)

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -121,6 +121,8 @@ class SyntheticControl(BaseExperiment):
         self.control_units = control_units
         self.labels = control_units
         self.treated_units = treated_units
+        # Backend-identity check is justified here: constructor-time
+        # capability validation (trust boundary), not statistical dispatch.
         if self._model_backend.is_ols and len(treated_units) > 1:
             raise ValueError(
                 "OLS/sklearn synthetic control supports only a single treated "
@@ -896,7 +898,6 @@ class SyntheticControl(BaseExperiment):
             self, window_coords, treated_unit=treated_unit
         )
         return _effect_summary_timeseries(
-            self,
             windowed_impact,
             counterfactual,
             window_coords,

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -248,6 +248,8 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         6. :meth:`_build_reporting_objects` constructs the xarray objects
            required by the reporting helpers.
         """
+        # Backend-identity check is justified here: capability validation
+        # (trust boundary), not statistical dispatch.
         if self._model_backend.is_ols:
             raise NotImplementedError(
                 "OLS estimation for SyntheticDifferenceInDifferences is not yet "

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -31,23 +31,9 @@ from pandas.api.extensions import ExtensionArray
 from causalpy.constants import HDI_PROB
 from causalpy.utils import _as_scalar
 
-
-def has_posterior_draws(Y: xr.DataArray) -> bool:
-    """Whether *Y* carries genuine posterior uncertainty.
-
-    The canonical prediction container has ``chain`` and ``draw`` dimensions
-    on every backend; point-estimate backends emit singleton dimensions (a
-    point estimate is a posterior with one atom). Plot code should key
-    uncertainty rendering (ribbons, HDI labels, ...) on this data property
-    rather than on backend identity.
-
-    Parameters
-    ----------
-    Y : xr.DataArray
-        A canonical prediction container with ``chain`` and ``draw``
-        dimensions.
-    """
-    return Y.sizes.get("chain", 1) * Y.sizes.get("draw", 1) > 1
+# Re-exported for existing importers; the canonical home is causalpy.utils so
+# non-plotting modules (e.g. reporting) can use it without importing plotting.
+from causalpy.utils import has_posterior_draws as has_posterior_draws
 
 
 def extract_r2_score(

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -33,7 +33,7 @@ import xarray as xr
 from scipy.stats import t
 
 from causalpy.constants import HDI_PROB
-from causalpy.utils import _as_scalar
+from causalpy.utils import _as_scalar, has_posterior_draws
 
 
 @dataclass
@@ -460,8 +460,8 @@ def _effect_summary_rd(
     """Generate effect summary for Regression Discontinuity experiments."""
     discontinuity = result.discontinuity_at_threshold
 
-    if result._model_backend.is_bayesian:
-        # PyMC model: use unified scalar functions
+    if has_posterior_draws(discontinuity):
+        # Posterior draws present: use unified scalar functions
         hdi_prob = 1 - alpha
         stats = _compute_statistics_scalar(
             discontinuity, hdi_prob=hdi_prob, direction=direction, min_effect=min_effect
@@ -634,7 +634,6 @@ def _extract_counterfactual(result, window_coords, treated_unit=None):
 
 
 def _effect_summary_timeseries(
-    result,
     windowed_impact: xr.DataArray,
     counterfactual: xr.DataArray,
     window_coords,
@@ -650,15 +649,14 @@ def _effect_summary_timeseries(
     """Build an :class:`EffectSummary` for time-series experiments (ITS, SC,
     Piecewise ITS) from canonical impact/counterfactual containers.
 
-    The single irreducible backend branch lives here: Bayesian backends
-    summarize posterior draws (HDIs, tail probabilities, ROPE), while OLS
-    backends report frequentist t-based intervals — an HDI computed from a
-    singleton draw would be silently meaningless.
+    The single irreducible statistical branch lives here, keyed on the
+    container itself: predictions carrying posterior draws are summarized
+    with HDIs, tail probabilities, and ROPE, while single-draw (point
+    estimate) predictions report frequentist t-based intervals — an HDI
+    computed from a singleton draw would be silently meaningless.
 
     Parameters
     ----------
-    result
-        Experiment result object exposing ``_model_backend``.
     windowed_impact : xr.DataArray
         Causal impact in the analysis window with canonical prediction
         dimensions.
@@ -683,7 +681,7 @@ def _effect_summary_timeseries(
         Experiment tag ("its", "sc", "piecewise_its") for tailored
         assumptions text.
     """
-    if result._model_backend.is_bayesian:
+    if has_posterior_draws(windowed_impact):
         hdi_prob = 1 - alpha
         stats = _compute_statistics(
             windowed_impact,
@@ -1491,6 +1489,26 @@ def _compute_statistics_ols(
     return stats
 
 
+def _point_residuals(result) -> np.ndarray:
+    """In-sample point residuals via the canonical prediction container.
+
+    Uses the model adapter's canonical ``predict`` output (a point estimate
+    is the first — and for point backends only — draw), so the t-based
+    point-summary path works for any backend, including a degenerate
+    single-draw Bayesian run.
+
+    ``y`` may have shape ``(n, 1)`` with dims ``(obs_ind, treated_units)``
+    while the fitted values are conceptually ``(n,)``; both are flattened to
+    1-D so they align positionally on ``obs_ind`` (letting xarray align them
+    would broadcast against ``treated_units`` and produce an ``(n, n)``
+    array).
+    """
+    y = np.asarray(result.design["y"]).reshape(-1)
+    pred = result._model_backend.predict(X=np.asarray(result.design["X"]))
+    y_fitted = np.asarray(pred.isel(chain=0, draw=0)).reshape(-1)
+    return y - y_fitted
+
+
 def _compute_statistics_did_ols(
     result,
     alpha=0.05,
@@ -1509,22 +1527,12 @@ def _compute_statistics_did_ols(
     dict
         Dictionary of statistics
     """
-    causal_impact = result.causal_impact  # scalar
+    causal_impact = _as_scalar(result.causal_impact)
 
     # Calculate standard error from model residuals
-    # Get fitted values and residuals
-    X_da = result.design["X"]
-    y_da = result.design["y"]
-    y_pred = result.model.predict(X_da)
-    # y_da has shape (n, 1) with dims (obs_ind, treated_units); y_pred is a
-    # bare (n,) array with no dimension names. Subtracting them directly lets
-    # xarray align y_pred positionally against the *last* axis (treated_units,
-    # size 1) instead of obs_ind, producing an (n, n) array of every
-    # observation's y minus every other observation's prediction instead of
-    # per-observation residuals. Flatten both to 1-D first so they align by
-    # position on obs_ind as intended.
-    residuals = np.asarray(y_da).reshape(-1) - np.asarray(y_pred).reshape(-1)
+    residuals = _point_residuals(result)
     mse = np.mean(residuals**2)
+    X_da = result.design["X"]
     n, p = X_da.shape
     df = n - p
 
@@ -1652,12 +1660,10 @@ def _compute_statistics_rd_ols(result, alpha=0.05):
     """Compute statistics for RD scalar effect with OLS model."""
     discontinuity = _as_scalar(result.discontinuity_at_threshold)
 
-    # Calculate standard error from model
-    X_da = result.design["X"]
-    y_da = result.design["y"]
-    y_pred = result.model.predict(X_da)
-    residuals = y_da - y_pred
+    # Calculate standard error from model residuals
+    residuals = _point_residuals(result)
     mse = np.mean(residuals**2)
+    X_da = result.design["X"]
     n, p = X_da.shape
     df = n - p
 

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -1492,10 +1492,12 @@ def _compute_statistics_ols(
 def _point_residuals(result) -> np.ndarray:
     """In-sample point residuals via the canonical prediction container.
 
-    Uses the model adapter's canonical ``predict`` output (a point estimate
-    is the first — and for point backends only — draw), so the t-based
-    point-summary path works for any backend, including a degenerate
-    single-draw Bayesian run.
+    Uses the model adapter's canonical ``predict`` output collapsed over
+    ``chain``/``draw``, so the t-based point-summary path works for any
+    backend. This path is only reached for singleton containers
+    (``chain * draw == 1``), where the mean is exactly the single point
+    estimate; taking the mean (rather than the first draw) keeps the helper
+    well-defined even if a many-draw container ever slips through.
 
     ``y`` may have shape ``(n, 1)`` with dims ``(obs_ind, treated_units)``
     while the fitted values are conceptually ``(n,)``; both are flattened to
@@ -1505,7 +1507,7 @@ def _point_residuals(result) -> np.ndarray:
     """
     y = np.asarray(result.design["y"]).reshape(-1)
     pred = result._model_backend.predict(X=np.asarray(result.design["X"]))
-    y_fitted = np.asarray(pred.isel(chain=0, draw=0)).reshape(-1)
+    y_fitted = np.asarray(pred.mean(dim=["chain", "draw"])).reshape(-1)
     return y - y_fitted
 
 

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -466,6 +466,58 @@ def test_effect_summary_rd_ols(mock_pymc_sample, rd_data):
 
 
 @pytest.mark.integration
+def test_effect_summary_ols_rd_residuals_are_per_observation(rd_data):
+    """Regression-pin for RD OLS ``effect_summary()`` intervals.
+
+    The pre-#1049 ``_compute_statistics_rd_ols`` subtracted a bare ``(n,)``
+    ``y_pred`` array from the ``(n, 1)`` y DataArray, broadcasting to an
+    ``(n, n)`` residual matrix (every observation's y minus every *other*
+    observation's prediction) and inflating the MSE ~9x on this dataset, so
+    the reported standard errors were ~3x too wide. ``_point_residuals``
+    fixed that; this test pins the corrected residual shape and SE against
+    an independent statsmodels fit so they cannot silently move again.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    from causalpy.reporting import _point_residuals
+
+    formula = "y ~ 1 + x + treated + x:treated"
+    result = cp.RegressionDiscontinuity(
+        rd_data,
+        formula=formula,
+        treatment_threshold=0.5,
+        model=LinearRegression(),
+    )
+
+    n, p = result.design["X"].shape
+    residuals = _point_residuals(result)
+    assert residuals.shape == (n,)
+
+    stats = result.effect_summary()
+    row = stats.table.loc["discontinuity"]
+
+    import statsmodels.formula.api as smf
+    from scipy.stats import t as t_dist
+
+    sm_fit = smf.ols(formula, data=result.fit_data).fit()
+    interaction_col = next(name for name in sm_fit.params.index if "x:treated" in name)
+    unbiased_se = sm_fit.bse[interaction_col]
+    # CausalPy divides the residual sum of squares by n rather than (n - p)
+    # (same convention as the DiD OLS path, tracked separately), so the
+    # correctly-shaped residuals give an SE smaller than the unbiased
+    # statsmodels value by sqrt((n - p) / n), not an exact match.
+    expected_se_with_mean_denominator = unbiased_se * np.sqrt((n - p) / n)
+
+    t_crit = t_dist.ppf(1 - 0.05 / 2, df=n - p)
+    reported_se = (row["ci_upper"] - row["ci_lower"]) / (2 * t_crit)
+
+    assert reported_se == pytest.approx(expected_se_with_mean_denominator, rel=1e-6)
+    # Guard against regressing to the (n, n) broadcast bug: that variant
+    # inflated the SE by roughly 3x on this dataset.
+    assert reported_se < unbiased_se * 2
+
+
+@pytest.mark.integration
 def test_effect_summary_rkink_pymc(mock_pymc_sample):
     """Test effect_summary with Regression Kink (PyMC)."""
     # Generate data for regression kink analysis

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -1380,6 +1380,45 @@ def test_select_treated_unit():
     assert "treated_units" not in result.dims
 
 
+def test_effect_summary_timeseries_dispatches_on_draws_not_backend():
+    """Contract: the container, not backend identity, decides the statistics.
+
+    A prediction container carrying posterior draws gets HDI summaries; a
+    singleton (chain=1, draw=1) container falls back to t-based intervals —
+    regardless of which backend produced it.
+    """
+    import xarray as xr
+
+    from causalpy.reporting import _effect_summary_timeseries
+
+    def containers(n_draws):
+        rng = np.random.default_rng(42)
+        obs_ind = [0, 1, 2, 3]
+        impact = xr.DataArray(
+            rng.normal(5.0, 0.5, size=(1, n_draws, 4)),
+            dims=["chain", "draw", "obs_ind"],
+            coords={"obs_ind": obs_ind},
+        )
+        counterfactual = xr.DataArray(
+            np.full((1, n_draws, 4), 10.0),
+            dims=["chain", "draw", "obs_ind"],
+            coords={"obs_ind": obs_ind},
+        )
+        return impact, counterfactual, pd.Index(obs_ind)
+
+    impact, counterfactual, window_coords = containers(n_draws=200)
+    summary = _effect_summary_timeseries(impact, counterfactual, window_coords)
+    assert isinstance(summary, EffectSummary)
+    assert "hdi_lower" in summary.table.columns
+    assert "ci_lower" not in summary.table.columns
+
+    impact, counterfactual, window_coords = containers(n_draws=1)
+    summary = _effect_summary_timeseries(impact, counterfactual, window_coords)
+    assert isinstance(summary, EffectSummary)
+    assert "ci_lower" in summary.table.columns
+    assert "hdi_lower" not in summary.table.columns
+
+
 # ==============================================================================
 # Tests for error handling
 # ==============================================================================

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -49,6 +49,26 @@ def _as_scalar(value: Any) -> float:
     return float(np.asarray(value).reshape(()))
 
 
+def has_posterior_draws(Y: xr.DataArray) -> bool:
+    """Whether *Y* carries genuine posterior uncertainty.
+
+    The canonical prediction container has ``chain`` and ``draw`` dimensions
+    on every backend; point-estimate backends emit singleton dimensions (a
+    point estimate is a posterior with one atom). Downstream code should key
+    statistical dispatch (HDI vs t-interval, ribbons, tail probabilities,
+    ...) on this data property rather than on backend identity, so any
+    backend that emits many draws gets posterior summaries for free and a
+    degenerate single-draw run falls back to point summaries.
+
+    Parameters
+    ----------
+    Y : xr.DataArray
+        A canonical prediction container with ``chain`` and ``draw``
+        dimensions.
+    """
+    return Y.sizes.get("chain", 1) * Y.sizes.get("draw", 1) > 1
+
+
 def _is_variable_dummy_coded(series: pd.Series) -> bool:
     """Check if a data in the provided Series is dummy coded. It should be 0 or 1
     only."""
@@ -431,10 +451,9 @@ def extract_lift_for_mmm(
             f"aggregate must be one of {_VALID_AGGREGATIONS}, got '{aggregate}'"
         )
 
-    from causalpy.pymc_models import PyMCModel
-
-    # Validate that we have a Bayesian model
-    if not isinstance(sc_result.model, PyMCModel):
+    # Key on the container, not backend identity: sigma needs genuine
+    # posterior dispersion, which a degenerate single-draw run also lacks.
+    if not has_posterior_draws(sc_result.post_impact):
         raise ValueError(
             "extract_lift_for_mmm requires a Bayesian (PyMC) model for uncertainty "
             "quantification. OLS models do not provide posterior distributions needed "


### PR DESCRIPTION
# Dispatch remaining Bayesian/OLS branches on posterior size, not backend identity

## Summary

Replaces the remaining `is_bayesian` / `is_ols` statistical dispatch in reporting and effect-summary code with a data-property check on the canonical prediction container: `has_posterior_draws(pred)` (`chain × draw > 1`). The branch condition is now honest — the statistics care about whether the container carries more than one draw, not which library fitted it. Any future many-draw backend (bootstrap-resampled sklearn, conformal prediction, SBI) gets HDIs, tail probabilities, and ROPE for free, and a degenerate single-draw Bayesian run correctly falls back to point summaries instead of emitting a meaningless HDI.

Fixes #1049

## Changes

- **Shared predicate**: `has_posterior_draws` moved from `plot_utils.py` to `causalpy/utils.py` (neutral home, so `reporting.py` does not import the plotting module), with a re-export in `plot_utils` so existing importers are unchanged. One definition, no per-file re-derivations.
- **Migrated dispatch sites** (backend flag → container property):
  - `reporting.py`: `_effect_summary_rd` keys on `discontinuity_at_threshold`; `_effect_summary_timeseries` keys on `windowed_impact` (its now-unused `result` parameter removed, ITS/SC/Piecewise callers updated)
  - `diff_in_diff.py` `effect_summary` keys on `y_pred_control`
  - `staggered_did.py` `_aggregate_effects` keys on `y_pred`
  - `interrupted_time_series.py` `_comparison_period_summary` and `analyze_persistence` key on `intervention_impact`
  - `regression_discontinuity.py` `summary()` keys on `discontinuity_at_threshold`
  - `utils.py` `extract_lift_for_mmm` checks `has_posterior_draws(post_impact)` instead of `isinstance(model, PyMCModel)` (also rejects degenerate runs that would silently produce `sigma = 0`)
- **Backend-agnostic point-summary fallback**: new `_point_residuals` helper computes in-sample residuals through the adapter's canonical `predict` instead of sklearn-native `result.model.predict`, and the DiD point path uses `_as_scalar(causal_impact)`. A degenerate single-draw Bayesian run now genuinely falls back to t-intervals.
- **Behavior change / bugfix — RD OLS intervals**: the old `_compute_statistics_rd_ols` subtracted a bare `(n,)` prediction array from the `(n, 1)` y DataArray, broadcasting to an `(n, n)` residual matrix and inflating the MSE ~9x (~3x too-wide standard errors, too-conservative p-values) — the same broadcast bug fixed for DiD OLS in #1026. `_point_residuals` flattens both sides, so RD OLS `effect_summary()` confidence intervals and p-values change (narrower/correct) for existing users. A regression test pins the corrected SE against an independent statsmodels fit. DiD OLS numbers are unchanged (already flattened by #1026).
- **Audited survivors, each with a written justification comment**:
  - Constructor-time capability validation (trust boundary): `synthetic_control`, `prepostnegd`, `synthetic_difference_in_differences`
  - Adapter-seam extraction from backend-native storage: `diff_in_diff` fit-time coefficient extraction
  - `panel_regression.py`: coefficient posteriors and in-sample `mu`/`y_hat` live in backend-native `idata` because PanelRegression stores no canonical container; the existing `ponytail:` note documents the upgrade path (store canonical in-sample predictions at fit time)
  - `placebo_in_time`, `prior_sensitivity`, `outcome_falsification`: Bayesian-only diagnostics needing `idata` (issue non-goal, already documented)

## Testing

- New contract test `test_effect_summary_timeseries_dispatches_on_draws_not_backend`: the same `_effect_summary_timeseries` call produces HDI columns with a 200-draw container and t-interval columns with a singleton container — the container, not the backend flag, decides.
- New regression pin `test_effect_summary_ols_rd_residuals_are_per_observation`: asserts per-observation residual shape and pins the RD OLS `effect_summary()` SE against an independent statsmodels fit (up to the documented RSS/n denominator convention), so the corrected numbers cannot silently move again.
- Full suite green. `prek run --all-files` clean. `make test-patch-cov`: 100% patch coverage (gate: 96%).

## Checklist

- [x] `prek run --all-files` passes
- [x] `make test-patch-cov` passes (100% on changed lines)
- [x] Remaining `is_bayesian` / `is_ols` uses individually justified in comments
- [x] No user-facing behavior change for existing backends, **except RD OLS `effect_summary()` intervals/p-values, which change deliberately** — the previous values were inflated by the `(n, n)` residual-broadcast bug (see above); the fix is pinned by a regression test
