### PR TITLE
Strengthen PR review probes and summaries

### DIFF
--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -16,6 +16,16 @@ Use this skill to evaluate whether a PR is correct, safe, understandable, and me
 - Never post review comments, approve, request changes, or merge through GitHub without explicit human approval.
 - Do not duplicate mechanical checks already covered by hooks and CI. If a recurring issue is mechanically enforceable but not enforced, recommend a follow-up issue instead of treating each instance as bespoke review work.
 
+## Review Stance
+
+A review must actively try to falsify the PR's claims; passing CI is evidence, not the conclusion. Before reading the whole diff, state a private review brief with:
+
+- The user outcome and two to four concrete wins the PR intends to deliver.
+- The changed contracts, assumptions, and public surfaces most likely to regress.
+- At least three PR-specific failure hypotheses, each paired with the code path, caller, test, or runtime behavior that could disprove it.
+
+For every changed production behavior, trace both directions across its seam: its inputs/producers and its outputs/consumers. Compare old and new behavior at the most fragile boundary (multi-output, empty or degenerate data, optional backend, custom subclass, serialization, or backwards-compatible call) rather than only the happy path. Read existing PR comments as review leads, not as conclusions. Do not report “no findings” until these probes have either found a concrete issue or produced evidence that the concern is handled.
+
 ## Intake
 
 Follow `resources/workflow.md` for the full workflow. At a glance:
@@ -54,6 +64,7 @@ Read these when the PR touches the relevant surface:
 ## Universal Checks
 
 - Correctness: the implementation matches the PR's stated intent, handles important edge cases, and does not introduce silent behavior changes.
+- Active probing: review comments and the PR description identify concrete concerns; independently formulate and test additional failure hypotheses that fit the changed surface. For contract, adapter, or dispatch changes, audit every producer and consumer rather than only the files named in the PR.
 - Security and privacy: no secrets, credentials, tokens, private data, unsafe deserialization, command injection, path traversal, or unnecessary network access.
 - Causal/statistical accuracy: causal claims, model assumptions, estimands, priors, simulations, and examples are technically accurate and not overstated.
 - Public API: released APIs remain compatible unless the PR intentionally changes them and documents the change; new public APIs have explicit signatures and documentation.
@@ -73,11 +84,21 @@ Read these when the PR touches the relevant surface:
 
 ## Review Output
 
-Lead with findings, ordered by severity. If there are no findings, say so clearly and mention residual risk or checks not run.
+Lead with an executive summary. Explain the PR's user-facing value and the strongest evidence it delivers that value, then surface findings in severity order. If there are no findings, say which concrete probes were performed and what residual risk remains; never substitute generic praise for an evidence-backed win.
 
 Use this structure:
 
 ```markdown
+## Executive Summary
+Recommendation: approve / request changes / blocked / needs maintainer decision.
+
+Value delivered:
+- [Concrete user or maintainer win, tied to an implementation detail.]
+- [Second concrete win when applicable.]
+
+Review focus:
+- [Highest-risk assumption and the evidence that supports or challenges it.]
+
 ## Findings
 
 - [severity] `path`: issue, why it matters, and what should change.
@@ -88,7 +109,7 @@ Branch status: up to date or behind base; conflicts if any.
 CI status: green, failing, pending, skipped, or unavailable.
 
 ## PR Summary
-One short paragraph describing what the PR changes and why.
+One short paragraph describing the implementation, why it was needed, and its most important trade-off or compatibility impact.
 
 ## Test Evidence
 List local and remote checks observed. Include commands only when they were actually run.

--- a/.agents/skills/review-pr/resources/review-comments.md
+++ b/.agents/skills/review-pr/resources/review-comments.md
@@ -10,6 +10,17 @@ Use this resource when drafting, presenting, or posting review comments.
 - Use HEREDOCs for multiline GitHub comments so markdown renders correctly.
 - Preserve the distinction between the maintainer's voice and agent-authored review text.
 
+## Finding Quality Bar
+
+Be constructively critical and evidence-led. A non-nit finding must name:
+
+1. The concrete input, caller, backend, or state that triggers the problem.
+2. The observed or reasoned failure, including the violated contract when applicable.
+3. Why existing code or tests do not already prevent it.
+4. The smallest clear corrective action and whether it blocks merge.
+
+Do not turn untested possibilities into findings. Probe them first; if the evidence is insufficient, record the uncertainty as residual risk or an open question. Conversely, do not soften a verified defect into a vague “consider” comment.
+
 ## Comment Shapes
 
 Use PR issue-thread comments for:
@@ -34,6 +45,14 @@ Use formal reviews only with explicit approval:
 
 ```markdown
 Thanks for the PR. I have comments grouped by severity below.
+
+## Executive summary
+
+This PR delivers:
+- [Concrete win, with evidence.]
+- [Concrete win, with evidence.]
+
+The review concentrated on [highest-risk behavior] because [failure consequence].
 
 ## Must-fix
 

--- a/.agents/skills/review-pr/resources/workflow.md
+++ b/.agents/skills/review-pr/resources/workflow.md
@@ -18,6 +18,16 @@ gh pr checks <num>
 
 If the user asks a narrow question, narrow the fetch. Do not pull every comment and full diff when the request is only to evaluate one latest response.
 
+### Form a Review Brief
+
+Before the diff pass, write a short internal brief:
+
+- **Value hypothesis:** the two to four concrete outcomes the PR should deliver for users or maintainers.
+- **Risk thesis:** the changed contract, invariant, or boundary with the highest cost if it is wrong.
+- **Attack plan:** at least three plausible PR-specific failure modes, each with the evidence needed to falsify it.
+
+Use the issue and existing PR comments as inputs to this brief. Add independent hypotheses; do not only repeat concerns already raised. For example, a canonical-container change should prompt probes for every backend producer, every direct consumer, multi-output or multi-unit behavior, and backwards-compatible callers.
+
 ## Step 2: Read the Relevant Subset
 
 Read every changed file needed to evaluate the PR. Also read surrounding context:
@@ -32,6 +42,15 @@ Read every changed file needed to evaluate the PR. Also read surrounding context
 
 This is what catches omissions that are invisible in the diff alone, such as subclass overrides that drop base-class kwargs.
 
+For each behavior-changing hunk, answer all of the following before moving on:
+
+1. What previous behavior or invariant is this replacing?
+2. Who produces the value this code assumes, and who consumes its result?
+3. What is the weakest supported input or backend shape for this path?
+4. Which test would fail if this hunk were removed or made subtly wrong?
+
+When the answer to a consumer or producer is “all backends,” enumerate them. When the answer to the test question is “none,” assess whether missing coverage is a must-fix.
+
 ## Step 3: Walk the Checklist
 
 Review against the universal checklist in `SKILL.md`, the PR-type resource files, and `review-patterns.md`. Group findings by severity:
@@ -40,6 +59,8 @@ Review against the universal checklist in `SKILL.md`, the PR-type resource files
 - Should-fix: design concerns, unclear API shape, hidden runtime or memory costs, weak but not absent evidence.
 - Nits: small clarity, naming, docstring, or cleanup suggestions that should not distract from substantive items.
 - What worked well: specific positives that help the contributor preserve the strongest parts of the PR.
+
+Do not stop at identifying a risk. Trace it to an observable failure, a violated contract, or evidence that the implementation already handles it. Where a concern is not a blocker, name the concrete follow-up or test that would improve confidence.
 
 ## Step 4: Verify Claims
 
@@ -55,6 +76,8 @@ Treat PR descriptions and contributor responses as hypotheses to test.
 | "Docs build" | Confirm the relevant docs/notebook command was run or remote CI proves it. |
 
 Flag incorrect claims respectfully and specifically. Vague disagreement is not useful review feedback.
+
+For each claimed win, retain one piece of direct evidence from the diff, tests, benchmark, documentation, or runtime behavior. Use those verified wins in the executive summary; this prevents the final review from reducing the PR to a changelog or a CI report.
 
 ## Step 5: Draft Feedback
 


### PR DESCRIPTION
## Summary
- Require PR-specific attack plans and producer/consumer tracing so reviews actively seek concrete regressions.
- Lead review output and drafted feedback with an evidence-backed executive summary of user and maintainer value.
- Set a clear quality bar for constructively critical, actionable findings.

## Test plan
- [x] `prek run --all-files`
- [x] Commit hooks passed

Made with [Cursor](https://cursor.com)