### PR TITLE
Fix order-dependent interaction-term lookup in DiD effect_summary

### DIFF
--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -1538,18 +1538,28 @@ def _compute_statistics_did_ols(
     n, p = X_da.shape
     df = n - p
 
-    # Find the interaction term coefficient index
-    interaction_term = (
-        f"{result.group_variable_name}:{result.post_treatment_variable_name}"
-    )
+    # Find the interaction term coefficient index. Match both variable names
+    # as independent substrings rather than a single concatenated string
+    # ("group:post_treatment"): patsy names the interaction column with
+    # whichever variable is written first in the formula, so a formula
+    # written as "post_treatment*group" produces a label like
+    # "post_treatment[T.True]:group", which the concatenated-string check
+    # would silently fail to match (mirrors the fix already applied to the
+    # OLS causal_impact lookup in DifferenceInDifferences.algorithm()).
     coeff_idx = None
     for i, label in enumerate(result.labels):
-        if interaction_term in label:
+        if (
+            result.group_variable_name in label
+            and result.post_treatment_variable_name in label
+        ):
             coeff_idx = i
             break
 
     if coeff_idx is None:
-        raise ValueError(f"Could not find interaction term {interaction_term} in model")
+        raise ValueError(
+            f"Could not find interaction term between '{result.group_variable_name}' "
+            f"and '{result.post_treatment_variable_name}' in model"
+        )
 
     X = X_da
     try:

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -394,6 +394,49 @@ def test_effect_summary_ols_did_residuals_are_per_observation(did_data):
 
 
 @pytest.mark.integration
+def test_effect_summary_ols_did_order_independent(did_data):
+    """``effect_summary()`` must not depend on which variable is written
+    first in the DiD interaction term.
+
+    ``_compute_statistics_did_ols`` looked up the interaction coefficient via
+    a single concatenated substring (``"group:post_treatment"``), which only
+    matches patsy's column naming when the formula writes the group variable
+    first. Writing the formula the other way round (``post_treatment*group``)
+    fits an identical model (``causal_impact`` was already order-independent,
+    fixed by #994 in ``DifferenceInDifferences.algorithm()``) but this
+    separate, still order-dependent lookup raised
+    ``ValueError: Could not find interaction term ...`` instead of returning
+    a result.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    df = did_data
+
+    result_group_first = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + group * post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    result_post_first = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + post_treatment * group",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    stats_group_first = result_group_first.effect_summary().table.loc[
+        "treatment_effect"
+    ]
+    stats_post_first = result_post_first.effect_summary().table.loc["treatment_effect"]
+
+    for col in ("mean", "ci_lower", "ci_upper", "p_value"):
+        assert stats_group_first[col] == pytest.approx(stats_post_first[col])
+
+
+@pytest.mark.integration
 def test_effect_summary_ols_sc(mock_pymc_sample, sc_data):
     """Test effect_summary with OLS model for Synthetic Control."""
     from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
## Summary
- `_compute_statistics_did_ols` (used by `DifferenceInDifferences.effect_summary()` for OLS-fitted models) matched the interaction coefficient via a single concatenated substring: `f"{group}:{post_treatment}" in label`.
- `patsy` names the interaction column with whichever variable is written first in the formula, so a formula written as `post_treatment*group` produces a label like `post_treatment[T.True]:group` instead of `group:post_treatment[T.True]`, which the concatenated-string check silently fails to match.
- `DifferenceInDifferences.algorithm()` already fixed this exact bug for the `causal_impact` (point estimate) lookup in #994, by checking both variable names as independent substrings instead. This separate lookup in `reporting.py`, used only for the SE/CI/p-value calculation, was never updated — so today, a valid reversed-order formula produces a correct `causal_impact` but `effect_summary()` raises `ValueError: Could not find interaction term group:post_treatment in model`.
- Fixes it the same way #994 did: match `group_variable_name` and `post_treatment_variable_name` as independent substrings.

Found while reviewing #993/#994 for unrelated reasons — reading #994's fix surfaced that a sibling function had the same bug pattern it fixed, just never updated.

**Known limitation** (not fixed here, to keep this PR minimal and mirror #994's exact approach): this substring match could in principle produce a false positive if some *other* (non-interaction) coefficient's label happened to contain both variable names as substrings — e.g. a covariate literally named `post_treatment_group_flag`. `diff_in_diff.py`'s own `_is_treatment_interaction()` helper (used elsewhere) is more rigorous — it splits on `:` and requires exact factor-name equality. The two lookups have diverged in rigor; unifying them would be a reasonable, separate follow-up.

## Test plan
- [x] Added `test_effect_summary_ols_did_order_independent`, asserting `effect_summary()` produces identical mean/ci_lower/ci_upper/p_value for `group*post_treatment` and `post_treatment*group`
- [x] `pytest causalpy/tests/test_reporting.py -k did` — 12 passed
- [x] Full suite: 1234 passed, 5 skipped
- [x] `make test-patch-cov` — 100% patch coverage
- [x] Independently verified: reproduced the exact pre-fix crash by stashing the fix, confirmed post-fix output is byte-identical between formula orderings