### PR TITLE
Bump packaging & CI floors to the PyMC 6 stack (#1039)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.11", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Build the sdist and the wheel
         run: |
           pip install build
@@ -77,7 +77,7 @@ jobs:
           repository_url: https://test.pypi.org/legacy/
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
-          python-version: 3.11
+          python-version: 3.12
       - name: Test pip install from test.pypi
         run: |
           # Give time to test.pypi to update its index. If we don't wait,

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,7 +82,7 @@ repos:
         files: \.md$
         exclude: ^(docs/_build/|\.scratch/|docs/source/notebooks/index\.md)$
   # Regenerate environment.yml from pyproject.toml when deps change (run on commit; review diff).
-  # Dev env uses python>=3.11; conda-only deps (make, pip, pymc-bart, marimo[mcp]) are in args.
+  # Dev env uses python>=3.12; conda-only deps (make, pip, pymc-bart, marimo[mcp]) are in args.
   # Stay on 0.22.x until pyproject2conda fixes the 0.23.x CondaRequirement regression
   # (see check-environment-yml job in .github/workflows/ci.yml).
   - repo: https://github.com/usnistgov/pyproject2conda
@@ -102,7 +102,7 @@ repos:
           - -w
           - force
           - --python-include
-          - "python>=3.11"
+          - "python>=3.12"
           - -d
           - make
           - -d

--- a/environment.yml
+++ b/environment.yml
@@ -11,8 +11,8 @@ name: CausalPy
 channels:
   - conda-forge
 dependencies:
-  - python>=3.11
-  - arviz<1.0,>=0.14.0
+  - python>=3.12
+  - arviz<2,>=1.1
   - codespell
   - diff-cover
   - graphviz
@@ -29,8 +29,8 @@ dependencies:
   - prek
   - pymc-bart
   - pymc-extras>=0.3.0
-  - pymc<6,>=5.15.1
-  - pytensor<3,>=2.38.1
+  - pymc<7,>=6.0.1
+  - pytensor<4,>=3
   - pytest
   - pytest-cov
   - pyyaml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,14 +19,13 @@ description = "Causal inference for quasi-experiments in Python"
 readme = "README.md"
 license = { file = "LICENSE" }
 authors = [{ name = "Ben Vincent", email = "ben.vincent@pymc-labs.com" }]
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 keywords = ["causal inference", "statistics", "econometrics", "pymc", "bayesian"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
@@ -40,7 +39,7 @@ classifiers = [
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 dependencies = [
-    "arviz>=0.14.0,<1.0",
+    "arviz>=1.1,<2",
     "graphviz",
     "ipython!=8.7.0",
     "jinja2",
@@ -48,8 +47,11 @@ dependencies = [
     "numpy",
     "pandas",
     "patsy",
-    "pymc>=5.15.1,<6",
-    "pytensor>=2.38.1,<3",
+    # Floors per the PyMC 6 migration (#1039). Deliberately NOT pymc>=6.1
+    # (pymc-marketing v1.0.0 caps pymc<6.1.0, which would make the docs env
+    # unsolvable) and NOT pytensor>=3.2 (pymc 6.1.0 caps pytensor<3.2).
+    "pymc>=6.0.1,<7",
+    "pytensor>=3,<4",
     "scikit-learn>=1",
     "scipy",
     "seaborn>=0.11.2",


### PR DESCRIPTION
Part of #1038. First PR of the PyMC 6 migration — moves the declared floors to the PyMC 6 stack. Base is `pymc6_and_pymcmarketing1_migration`, per the migration workflow.

## Changes

**`pyproject.toml`**
- `requires-python = ">=3.12"` (was `>=3.11`); dropped the `3.11` classifier
- `pymc>=6.0.1,<7` (was `>=5.15.1,<6`)
- `pytensor>=3,<4` (was `>=2.38.1,<3`)
- `arviz>=1.1,<2` (was `>=0.14.0,<1.0`)
- Deliberately **not** floored at `pymc>=6.1` (pymc-marketing v1.0.0 caps `pymc<6.1.0`) nor `pytensor>=3.2` (pymc 6.1.0 caps `pytensor<3.2`) — documented in an inline comment
- `pymc-extras>=0.3.0` and `pymc-forecast[extras]>=0.2,<0.3` left as-is (issue allowed either; 0.12.x resolves against pymc 6 with the existing floor)

**`.pre-commit-config.yaml`** — `pyproject2conda-yaml` hook `--python-include` bumped to `"python>=3.12"` (comment updated to match)

**`environment.yml`** — regenerated via the hook; verified byte-identical on a second hook run, so the `check-environment-yml` CI job stays green

**`.github/workflows/ci.yml`** — test matrix `["3.11", "3.14"]` → `["3.12", "3.14"]`

**`.github/workflows/release.yml`** — both build/install checks 3.11 → 3.12

**`.readthedocs.yaml`** — verified already on 3.12; unchanged

## Validation

`uv pip install -e .` in a fresh Python 3.12 venv resolves with **no conflicts** to:

pymc 6.1.0 · pytensor 3.1.3 · arviz 1.2.0 (metapackage over arviz-base/-stats/-plots 1.2.0) · numpy 2.4.6 · pandas 3.0.5 · scipy 1.18.0 · xarray 2026.7.0 · pymc-extras 0.12.1 · numba 0.65.1 / llvmlite 0.47.0 (hard transitive deps — pytensor 3's default backend is numba)

This matches the empirical resolution recorded in #1039 (pandas advanced one patch, 3.0.3 → 3.0.5, since the issue was written). Dry-run resolution of the `[test]` extra is also clean (pymc-forecast 0.2.0). `prek run --all-files` passes on all hooks.

**Note on the `[docs]` extra:** it currently dry-run-resolves to pymc-marketing 0.18.2 (with pymc-extras backtracked to 0.8.0), because pymc-marketing 1.0.0's `pymc<6.1.0` cap loses to pymc 6.1.0 during resolution. That is a consequence of the deliberate `pymc>=6.0.1` floor per the issue; the docs-env pymc-marketing floor is a follow-up concern for the pymc-marketing 1.x port, not this PR.

## Expected CI state

Per #1039: **tests are expected red on this branch** until the arviz/DataTree core port issues land — the arviz 0→1 jump cannot be made incrementally compatible without throwaway shims. Lint (`prek`) and `check-environment-yml` jobs are green.

Closes #1039

🤖 Generated with [Claude Code](https://claude.com/claude-code)