### PR TITLE
Vendor draw-wise Bayesian R² for ArViZ 1.x (#1040)

### DIFF
--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -73,10 +73,9 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import xarray as xr
-from arviz import r2_score
 
 from causalpy.constants import HDI_PROB
-from causalpy.utils import round_num
+from causalpy.utils import _bayesian_r2_score, round_num
 
 __all__ = ["PyMCForecastModel"]
 
@@ -396,7 +395,7 @@ class PyMCForecastModel:
         for i, unit in enumerate(mu.coords["treated_units"].values):
             unit_mu = mu.sel(treated_units=unit).transpose("sample", "obs_ind")
             unit_y = y.sel(treated_units=unit).data
-            unit_score = r2_score(unit_y, unit_mu.data)
+            unit_score = _bayesian_r2_score(unit_y, unit_mu.data)
             scores[f"unit_{i}_r2"] = unit_score["r2"]
             scores[f"unit_{i}_r2_std"] = unit_score["r2_std"]
         return pd.Series(scores)

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -23,12 +23,11 @@ import pandas as pd
 import pymc as pm
 import pytensor.tensor as pt
 import xarray as xr
-from arviz import r2_score
 from patsy import dmatrix
 from pymc_extras.prior import Prior
 
 from causalpy.constants import HDI_PROB
-from causalpy.utils import round_num
+from causalpy.utils import _bayesian_r2_score, round_num
 from causalpy.variable_selection_priors import VariableSelectionPrior
 
 
@@ -451,7 +450,7 @@ class PyMCModel(pm.Model):
         for i, unit in enumerate(mu_data.coords["treated_units"].values):
             unit_mu = mu_data.sel(treated_units=unit).T  # (sample, obs_ind)
             unit_y = y.sel(treated_units=unit).data
-            unit_score = r2_score(unit_y, unit_mu.data)
+            unit_score = _bayesian_r2_score(unit_y, unit_mu.data)
             scores[f"unit_{i}_r2"] = unit_score["r2"]
             scores[f"unit_{i}_r2_std"] = unit_score["r2_std"]
 

--- a/causalpy/tests/test_utils.py
+++ b/causalpy/tests/test_utils.py
@@ -20,9 +20,13 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 
 import causalpy as cp
+import causalpy.pymc_forecast_models as pymc_forecast_models
+import causalpy.pymc_models as pymc_models
 from causalpy.utils import (
+    _bayesian_r2_score,
     _is_variable_dummy_coded,
     _series_has_2_levels,
     check_convex_hull_violation,
@@ -31,6 +35,96 @@ from causalpy.utils import (
     plot_correlations,
     round_num,
 )
+
+
+def test_bayesian_r2_score_matches_arviz_022():
+    """Bayesian R-squared matches the seeded upstream ArviZ regression."""
+    x = np.linspace(0, 1, 100)
+    random_state = np.random.RandomState(0)
+    y_true = random_state.normal(x, 1)
+    y_pred = x + random_state.randn(300, 100)
+
+    result = _bayesian_r2_score(y_true, y_pred)
+
+    expected = pd.Series(
+        [0.34799324897794087, 0.0286823512640429], index=["r2", "r2_std"]
+    )
+    pd.testing.assert_series_equal(result, expected, rtol=1e-14, atol=0.0)
+
+
+def test_bayesian_r2_score_constant_input_warns_and_returns_nan():
+    """Degenerate constant inputs retain ArViZ's warning and NaN results."""
+    y_true = np.ones(3)
+    y_pred = np.ones((2, 3))
+
+    with pytest.warns(RuntimeWarning, match="invalid value encountered in divide"):
+        result = _bayesian_r2_score(y_true, y_pred)
+
+    expected = pd.Series([np.nan, np.nan], index=["r2", "r2_std"])
+    pd.testing.assert_series_equal(result, expected)
+
+
+@pytest.mark.parametrize(
+    ("model_module", "score_method"),
+    [
+        (pymc_models, pymc_models.PyMCModel.score),
+        (pymc_forecast_models, pymc_forecast_models.PyMCForecastModel.score),
+    ],
+    ids=["pymc-model", "pymc-forecast-model"],
+)
+def test_model_score_uses_draw_wise_bayesian_r2(
+    monkeypatch, model_module, score_method
+):
+    """Both model score methods preserve the per-unit Bayesian R-squared output."""
+    x = np.linspace(0, 1, 100)
+
+    unit_0_random_state = np.random.RandomState(0)
+    unit_0_y = unit_0_random_state.normal(x, 1)
+    unit_0_pred = x + unit_0_random_state.randn(300, 100)
+
+    unit_1_random_state = np.random.RandomState(1)
+    unit_1_y = unit_1_random_state.normal(-x, 0.5)
+    unit_1_pred = -x + 1.5 * unit_1_random_state.randn(300, 100)
+
+    treated_units = ["unit_0", "unit_1"]
+    y = xr.DataArray(
+        np.column_stack((unit_0_y, unit_1_y)),
+        dims=("obs_ind", "treated_units"),
+        coords={"obs_ind": np.arange(100), "treated_units": treated_units},
+    )
+    mu = xr.DataArray(
+        np.stack((unit_0_pred.T, unit_1_pred.T), axis=1),
+        dims=("obs_ind", "treated_units", "sample"),
+        coords={
+            "obs_ind": np.arange(100),
+            "treated_units": treated_units,
+            "sample": np.arange(300),
+        },
+    )
+
+    monkeypatch.setattr(model_module.az, "extract", lambda *args, **kwargs: mu)
+
+    class DummyPredictor:
+        def predict(self, X):
+            return None
+
+    result = score_method(DummyPredictor(), X=None, y=y)
+
+    expected = pd.Series(
+        [
+            0.34799324897794087,
+            0.0286823512640429,
+            0.4898352905573437,
+            0.01679067148443987,
+        ],
+        index=[
+            "unit_0_r2",
+            "unit_0_r2_std",
+            "unit_1_r2",
+            "unit_1_r2_std",
+        ],
+    )
+    pd.testing.assert_series_equal(result, expected, rtol=1e-14, atol=0.0)
 
 
 def test_dummy_coding():

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -49,6 +49,16 @@ def _as_scalar(value: Any) -> float:
     return float(np.asarray(value).reshape(()))
 
 
+def _bayesian_r2_score(y_true: np.ndarray, y_pred: np.ndarray) -> pd.Series:
+    """Compute Bayesian R-squared across posterior predictive draws."""
+    var_y_est = np.var(y_pred, axis=1, ddof=0)
+    var_e = np.var(y_true - y_pred, axis=1, ddof=0)
+    r2_samples = var_y_est / (var_y_est + var_e)
+    return pd.Series(
+        [r2_samples.mean(), r2_samples.std(ddof=0)], index=["r2", "r2_std"]
+    )
+
+
 def _is_variable_dummy_coded(series: pd.Series) -> bool:
     """Check if a data in the provided Series is dummy coded. It should be 0 or 1
     only."""


### PR DESCRIPTION
## Summary

Vendor the classic draw-wise Bayesian R² calculation removed from ArviZ 1.x, preserving CausalPy's existing score values and output schema for both PyMC backends.

Closes #1040

## Dependency

PR #1064 has merged. This PR now targets `pymc6_and_pymcmarketing1_migration` directly and contains only the #1040 changes.

## Changes

- Add private `_bayesian_r2_score` with the ArViZ 0.22 per-draw variance-ratio semantics and population standard deviation.
- Replace both removed `arviz.r2_score` imports and calls in `PyMCModel` and `PyMCForecastModel`.
- Add fixed legacy-value, degenerate-input, and deterministic multi-unit regressions for both score paths without sampling.

## Validation

- Python 3.12 / PyMC 6.2 / ArViZ 1.2: `import causalpy` succeeds.
- New R² regressions: 4 passed.
- Current CausalPy environment full suite: 1210 passed, 6 skipped.
- `prek run --all-files`: passed.
- Patch diff coverage: 100% across 46 changed executable lines.

## Expected migration state

The target-stack import still emits the planned `az.InferenceData` migration warning, and broader target-stack tests still fail at the unchanged `DataTree.extend` calls tracked by #1042. Those failures are outside #1040; this PR removes the first import blocker and preserves the score contract.

## Checklist

- [x] Branch is based directly on PR #1064.
- [x] Both production score paths use the vendored helper.
- [x] Numerical output matches the ArViZ 0.22 baseline.
- [x] Tests and repository hooks pass for the scoped change.
