### PR TITLE
Fix IV multiprocess sampling defaults

### DIFF
--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -88,8 +88,8 @@ class InstrumentalVariable(BaseExperiment):
     >>> sample_kwargs = {
     ...     "tune": 1,
     ...     "draws": 5,
-    ...     "chains": 1,
-    ...     "cores": 4,
+    ...     "chains": 2,
+    ...     "cores": 1,
     ...     "target_accept": 0.95,
     ...     "progressbar": False,
     ... }

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -1134,6 +1134,13 @@ class SyntheticDifferenceInDifferencesWeightFitter(PyMCModel):
 class InstrumentalVariableRegression(PyMCModel):
     """Custom PyMC model for instrumental linear regression.
 
+    Parameters
+    ----------
+    sample_kwargs : dict, optional
+        Keyword arguments forwarded to :func:`pymc.sample`.
+    priors : dict, optional
+        Prior configuration used by the model.
+
     Examples
     --------
     >>> import causalpy as cp
@@ -1155,7 +1162,7 @@ class InstrumentalVariableRegression(PyMCModel):
     ...     "tune": 5,
     ...     "draws": 10,
     ...     "chains": 2,
-    ...     "cores": 2,
+    ...     "cores": 1,
     ...     "target_accept": 0.95,
     ...     "progressbar": False,
     ... }
@@ -1176,6 +1183,26 @@ class InstrumentalVariableRegression(PyMCModel):
     ... )
     Inference data...
     """
+
+    def __init__(
+        self,
+        sample_kwargs: dict[str, Any] | None = None,
+        priors: dict[str, Any] | None = None,
+    ) -> None:
+        """Configure IV sampling defaults.
+
+        Parameters
+        ----------
+        sample_kwargs : dict, optional
+            Keyword arguments forwarded to :func:`pymc.sample`.
+        priors : dict, optional
+            Prior configuration passed to the base model.
+        """
+        kwargs = {} if sample_kwargs is None else dict(sample_kwargs)
+        # TEMPORARY: avoid macOS arm64/Python 3.14 PyMC 6.0.1–6.2.0 IV fork-worker crashes (CausalPy #1044, https://github.com/pymc-devs/pymc/issues/8377); remove per #1067 only after the upstream fix is verified and the supported floor excludes this range.
+        if kwargs.get("cores") is None:
+            kwargs["cores"] = 1
+        super().__init__(sample_kwargs=kwargs, priors=priors)
 
     def build_model(  # type: ignore
         self,
@@ -1362,21 +1389,26 @@ class InstrumentalVariableRegression(PyMCModel):
         ----------
         ppc_sampler : {"jax", "pymc"}, optional
             Backend used for posterior predictive sampling. ``"jax"`` (the
-            default) is much faster for the multivariate Normal likelihood;
-            ``"pymc"`` additionally samples the prior predictive.
+            default) requires JAX and samples only the posterior predictive distribution; ``"pymc"`` is the fallback and additionally samples the prior predictive.
         """
         random_seed = self.sample_kwargs.get("random_seed", None)
 
-        if ppc_sampler == "jax":
-            if self.idata is not None:
-                with self:
-                    self.idata.extend(
-                        pm.sample_posterior_predictive(
-                            self.idata,
-                            random_seed=random_seed,
-                            compile_kwargs={"mode": "JAX"},
-                        )
+        if ppc_sampler == "jax" and self.idata is not None:
+            try:
+                import jax  # noqa: F401
+            except ModuleNotFoundError as err:
+                raise ImportError(
+                    "ppc_sampler='jax' requires JAX. Install jax or use "
+                    "ppc_sampler='pymc'."
+                ) from err
+            with self:
+                self.idata.extend(
+                    pm.sample_posterior_predictive(
+                        self.idata,
+                        random_seed=random_seed,
+                        compile_kwargs={"mode": "JAX"},
                     )
+                )
         elif ppc_sampler == "pymc" and self.idata is not None:
             with self:
                 self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
@@ -1423,7 +1455,7 @@ class InstrumentalVariableRegression(PyMCModel):
         priors : dict
             Prior specification dictionary forwarded to :meth:`build_model`.
         ppc_sampler : {"jax", "pymc"}, optional
-            Backend for posterior predictive sampling. ``None`` skips it.
+            Backend for posterior predictive sampling. ``"jax"`` requires JAX, ``"pymc"`` is the fallback, and ``None`` skips it.
         vs_prior_type : {"spike_and_slab", "horseshoe", "normal"}, optional
             Variable-selection prior type, forwarded to :meth:`build_model`.
         vs_hyperparams : dict, optional

--- a/causalpy/tests/test_instrumental_variable.py
+++ b/causalpy/tests/test_instrumental_variable.py
@@ -15,8 +15,12 @@
 Tests for the InstrumentalVariable experiment class.
 """
 
+import builtins
+
+import arviz as az
 import numpy as np
 import pandas as pd
+import pymc as pm
 import pytest
 
 import causalpy as cp
@@ -81,6 +85,229 @@ def binary_treatment_data(rng):
         "formula": "y ~ 1 + T + Z1",
         "instruments_formula": "T ~ 1 + Z1 + Z2",
     }
+
+
+# =============================================================================
+# Test Sampling Defaults
+# =============================================================================
+
+
+@pytest.mark.parametrize(
+    ("sample_kwargs", "expected_cores"),
+    [
+        (None, 1),
+        ({}, 1),
+        ({"cores": None}, 1),
+        ({"cores": 2}, 2),
+        ({"cores": 0}, 0),
+    ],
+)
+def test_iv_sampling_defaults_copy_and_preserve_overrides(
+    sample_kwargs, expected_cores
+):
+    """Test IV sampling defaults are safe without changing caller configuration."""
+    original = None if sample_kwargs is None else dict(sample_kwargs)
+
+    model = cp.pymc_models.InstrumentalVariableRegression(sample_kwargs=sample_kwargs)
+
+    assert model.sample_kwargs["cores"] == expected_cores
+    if sample_kwargs is not None:
+        assert sample_kwargs == original
+        assert model.sample_kwargs is not sample_kwargs
+
+
+def test_iv_sampling_default_does_not_change_other_pymc_models():
+    """Test the temporary sampling default is limited to IV models."""
+    assert "cores" not in cp.pymc_models.LinearRegression().sample_kwargs
+
+
+def test_iv_default_sampling_kwargs_are_forwarded_without_ppc(monkeypatch):
+    """Test default IV sampling uses one core and skips posterior prediction."""
+    sampled_kwargs = {}
+    idata = az.InferenceData()
+
+    def sample(**kwargs):
+        sampled_kwargs.update(kwargs)
+        return idata
+
+    def posterior_predictive(*args, **kwargs):
+        pytest.fail("ppc_sampler=None must skip posterior predictive sampling")
+
+    monkeypatch.setattr(pm, "sample", sample)
+    monkeypatch.setattr(pm, "sample_posterior_predictive", posterior_predictive)
+    model = cp.pymc_models.InstrumentalVariableRegression(
+        sample_kwargs={"draws": 7, "tune": 3, "progressbar": False}
+    )
+    X = np.array([[1.0, 0.5], [1.0, 1.5]])
+    Z = np.array([[1.0, 0.2], [1.0, 0.8]])
+    y = np.array([[1.0], [2.0]])
+    t = np.array([[0.5], [1.5]])
+
+    model.fit(
+        X=X,
+        Z=Z,
+        y=y,
+        t=t,
+        coords={"instruments": ["Intercept", "Z"], "covariates": ["Intercept", "X"]},
+        priors={
+            "mus": [[0.0, 0.0], [0.0, 0.0]],
+            "sigmas": [1.0, 1.0],
+            "eta": 2,
+            "lkj_sd": 1,
+        },
+    )
+
+    assert sampled_kwargs["cores"] == 1
+    assert sampled_kwargs["draws"] == 7
+    assert sampled_kwargs["tune"] == 3
+    assert sampled_kwargs["progressbar"] is False
+    assert model.idata is idata
+
+
+def test_iv_default_model_uses_safe_sampling_kwargs(monkeypatch, iv_data):
+    """Test the experiment's default IV model receives the safe core default."""
+    sampled_kwargs = {}
+
+    def sample(**kwargs):
+        sampled_kwargs.update(kwargs)
+        return az.InferenceData()
+
+    monkeypatch.setattr(pm, "sample", sample)
+
+    result = cp.InstrumentalVariable(
+        instruments_data=iv_data["instruments_data"],
+        data=iv_data["data"],
+        instruments_formula=iv_data["instruments_formula"],
+        formula=iv_data["formula"],
+    )
+
+    assert result.model.sample_kwargs["cores"] == 1
+    assert sampled_kwargs["cores"] == 1
+
+
+def test_iv_default_sampling_completes_with_two_chains(iv_data):
+    """Test default IV sampling completes safely with two sequential chains."""
+    model = cp.pymc_models.InstrumentalVariableRegression(
+        sample_kwargs={
+            "tune": 5,
+            "draws": 5,
+            "chains": 2,
+            "progressbar": False,
+            "random_seed": 42,
+            "compute_convergence_checks": False,
+        }
+    )
+
+    result = cp.InstrumentalVariable(
+        instruments_data=iv_data["instruments_data"],
+        data=iv_data["data"],
+        instruments_formula=iv_data["instruments_formula"],
+        formula=iv_data["formula"],
+        model=model,
+    )
+
+    assert model.sample_kwargs["cores"] == 1
+    assert result.idata.posterior.sizes["chain"] == 2
+    assert result.idata.posterior.sizes["draw"] == 5
+
+
+def _set_jax_import(monkeypatch, jax_module):
+    """Patch the direct JAX import used by IV posterior prediction."""
+    original_import = builtins.__import__
+
+    def import_jax(name, *args, **kwargs):
+        if name == "jax":
+            if isinstance(jax_module, BaseException):
+                raise jax_module
+            return jax_module
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_jax)
+
+
+class _Idata:
+    """Minimal inference-data stand-in for posterior predictive tests."""
+
+    def extend(self, other):
+        """Record posterior predictive output."""
+        self.extended = other
+
+
+@pytest.mark.parametrize("use_default", [True, False])
+def test_iv_jax_ppc_reports_missing_jax_without_fallback(monkeypatch, use_default):
+    """Test requested JAX PPC has a clear missing-dependency error."""
+    model = cp.pymc_models.InstrumentalVariableRegression()
+    model.idata = object()
+    calls = 0
+
+    def posterior_predictive(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+
+    _set_jax_import(monkeypatch, ModuleNotFoundError("No module named 'jax'"))
+    monkeypatch.setattr(pm, "sample_posterior_predictive", posterior_predictive)
+
+    with pytest.raises(ImportError, match="requires JAX"):
+        if use_default:
+            model.sample_predictive_distribution()
+        else:
+            model.sample_predictive_distribution(ppc_sampler="jax")
+
+    assert calls == 0
+
+
+def test_iv_jax_ppc_uses_jax_compilation(monkeypatch):
+    """Test available JAX PPC uses the JAX compilation mode."""
+    model = cp.pymc_models.InstrumentalVariableRegression(
+        sample_kwargs={"random_seed": 42}
+    )
+    model.idata = _Idata()
+    posterior_predictive = object()
+    calls = {}
+    _set_jax_import(monkeypatch, object())
+
+    def sample(idata, **kwargs):
+        calls["idata"] = idata
+        calls.update(kwargs)
+        return posterior_predictive
+
+    monkeypatch.setattr(pm, "sample_posterior_predictive", sample)
+
+    model.sample_predictive_distribution()
+
+    assert calls == {
+        "idata": model.idata,
+        "random_seed": 42,
+        "compile_kwargs": {"mode": "JAX"},
+    }
+    assert model.idata.extended is posterior_predictive
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        ImportError("PPC import failure"),
+        RuntimeError("PPC runtime failure"),
+        ModuleNotFoundError("PPC module failure"),
+    ],
+)
+@pytest.mark.parametrize("use_default", [True, False])
+def test_iv_jax_ppc_preserves_non_dependency_errors(monkeypatch, use_default, error):
+    """Test JAX PPC failures are not rewritten as missing-JAX errors."""
+    model = cp.pymc_models.InstrumentalVariableRegression()
+    model.idata = _Idata()
+    _set_jax_import(monkeypatch, object())
+
+    def posterior_predictive(*args, **kwargs):
+        raise error
+
+    monkeypatch.setattr(pm, "sample_posterior_predictive", posterior_predictive)
+
+    with pytest.raises(type(error), match=str(error)):
+        if use_default:
+            model.sample_predictive_distribution()
+        else:
+            model.sample_predictive_distribution(ppc_sampler="jax")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- default `InstrumentalVariableRegression` sampling to `cores=1` only when omitted or `None`, preserving explicit user values
- add targeted JAX posterior-predictive dependency/error tests and a real two-chain IV regression
- integrate the IV JAX contract with DataTree-safe posterior prediction from the migration branch
- document safe IV docstring examples and the temporary workaround's upstream removal criteria

Closes #1044

Part of parent migration issue #1038.

## Upstream tracking
- PyMC crash report: https://github.com/pymc-devs/pymc/issues/8377
- Removal tracker: #1067

## Integration
- merged `pymc6_and_pymcmarketing1_migration` after Issue #1042 in self-contained resolution commit `d3bd449d`

## Testing
- `/opt/anaconda3/condabin/mamba run -n mamba_temp_env_issue_1044 python -m pytest --no-cov causalpy/tests/test_instrumental_variable.py` (41 passed)
- real JAX posterior-predictive smoke passed with PyMC 6.2.0, PyTensor 3.2.2, and JAX/JAXlib 0.11.0; the resulting DataTree contains `/posterior_predictive`
- JAX/JAXlib were removed after the smoke and absent-JAX behavior remains regression-tested

Read the Docs remains red only because third-party `pymc-extras` 0.13.1 imports `Variable` from the PyTensor top level, which PyTensor 3 no longer exports; this migration-wide external compatibility failure is unrelated to this IV-only PR.