### PR TITLE
Port PyMC inference results to xarray DataTree

### DIFF
--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -603,7 +603,7 @@ class PlaceboInTime:
 
         Returns
         -------
-        tuple[InferenceData, np.ndarray]
+        tuple[DataTree, np.ndarray]
             ``(idata, theta_new_samples)`` where ``theta_new_samples``
             are draws from the posterior predictive for a new null
             period.

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -227,8 +227,8 @@ class BaseExperiment(ABC):
         raise NotImplementedError("fit method not implemented")
 
     @property
-    def idata(self) -> az.InferenceData:
-        """Return the InferenceData object of the model. Only relevant for PyMC models."""
+    def idata(self) -> xr.DataTree:
+        """Return the model's DataTree. Only relevant for PyMC models."""
         return self._model_backend.idata
 
     def print_coefficients(self, round_to: int | None = None) -> None:

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -361,22 +361,23 @@ class InterruptedTimeSeries(BaseExperiment):
 
             # 3. Split post_pred into intervention_pred and post_intervention_pred
             # These are slices of post_pred, not new computations
-            # For PyMC models, post_pred is guaranteed to be az.InferenceData
-            # (regular PyMC models return it directly, BSTS-like models are wrapped in __init__)
-            intervention_pred_dataset = self.post_pred.posterior_predictive.sel(
+            # For PyMC models, post_pred is guaranteed to be a DataTree
+            # (regular PyMC models return it directly, BSTS-like models are wrapped in __init__).
+            posterior_predictive = self.post_pred["posterior_predictive"].to_dataset()
+            intervention_pred_dataset = posterior_predictive.sel(
                 {time_dim: intervention_coords}
             )
-            post_intervention_pred_dataset = self.post_pred.posterior_predictive.sel(
+            post_intervention_pred_dataset = posterior_predictive.sel(
                 {time_dim: post_intervention_coords}
             )
 
-            # Create new InferenceData objects with the sliced posterior_predictive
-            # This maintains the same structure as post_pred
-            self.intervention_pred = az.InferenceData(
-                posterior_predictive=intervention_pred_dataset
+            # Create DataTrees with the sliced posterior_predictive dataset.
+            # This maintains the same structure as post_pred.
+            self.intervention_pred = xr.DataTree.from_dict(
+                {"posterior_predictive": intervention_pred_dataset}
             )
-            self.post_intervention_pred = az.InferenceData(
-                posterior_predictive=post_intervention_pred_dataset
+            self.post_intervention_pred = xr.DataTree.from_dict(
+                {"posterior_predictive": post_intervention_pred_dataset}
             )
 
             # 4. Split post_impact into intervention_impact and post_intervention_impact

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -20,6 +20,7 @@ import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import xarray as xr
 from matplotlib.lines import Line2D
 from patsy import PatsyError
 from sklearn.linear_model import LinearRegression as sk_lin_reg
@@ -462,7 +463,7 @@ class InversePropensityWeighting(BaseExperiment):
         return ate, trt, ntrt
 
     def get_ate(
-        self, i: int, idata: az.InferenceData, method: str = "doubly_robust"
+        self, i: int, idata: xr.DataTree, method: str = "doubly_robust"
     ) -> list[float | np.floating]:
         """Compute the Average Treatment Effect for a single posterior sample.
 
@@ -473,8 +474,8 @@ class InversePropensityWeighting(BaseExperiment):
         ----------
         i : int
             Index of the posterior sample to process.
-        idata : az.InferenceData
-            ArviZ InferenceData object containing the posterior samples.
+        idata : xr.DataTree
+            DataTree containing the posterior samples.
         method : str, optional
             Weighting scheme to use. One of 'robust', 'raw', 'overlap',
             or 'doubly_robust'. Defaults to 'doubly_robust'.
@@ -541,7 +542,7 @@ class InversePropensityWeighting(BaseExperiment):
 
     def plot_ate(
         self,
-        idata: az.InferenceData | None = None,
+        idata: xr.DataTree | None = None,
         method: str | None = None,
         prop_draws: int = 100,
         ate_draws: int = 300,
@@ -563,8 +564,8 @@ class InversePropensityWeighting(BaseExperiment):
 
         Parameters
         ----------
-        idata : az.InferenceData | None, optional
-            ArviZ InferenceData with posterior propensity score samples.
+        idata : xr.DataTree | None, optional
+            DataTree with posterior propensity score samples.
             If ``None``, uses ``self.model.idata``.
         method : str | None, optional
             Weighting scheme to apply.  One of ``'robust'``, ``'raw'``,
@@ -751,7 +752,7 @@ class InversePropensityWeighting(BaseExperiment):
     def plot_balance_ecdf(
         self,
         covariate: str,
-        idata: az.InferenceData | None = None,
+        idata: xr.DataTree | None = None,
         weighting_scheme: str | None = None,
     ) -> tuple[plt.Figure, list[plt.Axes]]:
         """Plot the empirical CDF of a covariate before and after IPW adjustment.
@@ -766,8 +767,8 @@ class InversePropensityWeighting(BaseExperiment):
         covariate : str
             Name of the covariate column (must be one of the model's design
             matrix labels) to check for balance.
-        idata : az.InferenceData | None, optional
-            ArviZ InferenceData containing posterior propensity score samples.
+        idata : xr.DataTree | None, optional
+            DataTree containing posterior propensity score samples.
             If ``None``, uses ``self.model.idata``.
         weighting_scheme : str | None, optional
             Weighting scheme to apply.  One of ``'raw'``, ``'robust'``, or

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -20,7 +20,6 @@ import warnings
 from abc import ABC, abstractmethod
 from typing import Any, Literal
 
-import arviz as az
 import numpy as np
 import xarray as xr
 from sklearn.base import RegressorMixin, clone
@@ -107,8 +106,8 @@ class ModelAdapter(ABC):
 
     @property
     @abstractmethod
-    def idata(self) -> az.InferenceData:
-        """Return InferenceData for Bayesian models."""
+    def idata(self) -> xr.DataTree:
+        """Return a DataTree for Bayesian models."""
 
     @abstractmethod
     def fit(
@@ -206,8 +205,8 @@ class PyMCModelAdapter(ModelAdapter):
         return "pymc"
 
     @property
-    def idata(self) -> az.InferenceData:
-        """Return the model's InferenceData object."""
+    def idata(self) -> xr.DataTree:
+        """Return the model's DataTree."""
         return self._model.idata
 
     def fit(
@@ -216,7 +215,7 @@ class PyMCModelAdapter(ModelAdapter):
         y: Any,
         *,
         coords: dict[str, Any] | None = None,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Fit the PyMC model.
 
         Parameters
@@ -309,8 +308,8 @@ class SklearnModelAdapter(ModelAdapter):
         return "sklearn"
 
     @property
-    def idata(self) -> az.InferenceData:
-        """OLS models do not expose InferenceData."""
+    def idata(self) -> xr.DataTree:
+        """OLS models do not expose a DataTree."""
         raise AttributeError("OLS models do not have idata.")
 
     def fit(
@@ -414,8 +413,8 @@ class PyMCForecastAdapter(ModelAdapter):
         return "pymc-forecast"
 
     @property
-    def idata(self) -> az.InferenceData:
-        """Return the model's InferenceData (posterior draws)."""
+    def idata(self) -> xr.DataTree:
+        """Return the model's DataTree (posterior draws)."""
         if self._model.idata is None:
             raise RuntimeError("Model has not been fit yet.")
         return self._model.idata
@@ -426,7 +425,7 @@ class PyMCForecastAdapter(ModelAdapter):
         y: Any,
         *,
         coords: dict[str, Any] | None = None,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Fit the forecasting model on the pre-period.
 
         Parameters

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -106,8 +106,8 @@ class PrePostNEGD(BaseExperiment):
         super().__init__(model=model)
         self.causal_impact: xr.DataArray
         self.pred_xi: np.ndarray
-        self.pred_untreated: az.InferenceData
-        self.pred_treated: az.InferenceData
+        self.pred_untreated: xr.DataTree
+        self.pred_treated: xr.DataTree
         self.data = data
         self.expt_type = "Pretest/posttest Nonequivalent Group Design"
         self.formula = formula

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -18,7 +18,6 @@ Synthetic Difference-in-Differences Experiment.
 import warnings
 from typing import Any, Literal
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import xarray as xr

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -460,7 +460,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
         Sets the following attributes on ``self``:
 
-        - ``pre_pred`` / ``post_pred``: ``az.InferenceData`` objects holding
+        - ``pre_pred`` / ``post_pred``: ``xr.DataTree`` objects holding
           the synthetic-control predictions in a ``posterior_predictive``
           group.
         - ``pre_impact`` / ``post_impact``: ``xr.DataArray`` of observed
@@ -525,10 +525,10 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         index: pd.Index,
         n_chains: int,
         n_draws: int,
-    ) -> az.InferenceData:
-        """Build an InferenceData-like object with posterior_predictive group.
+    ) -> xr.DataTree:
+        """Build a DataTree with a posterior_predictive group.
 
-        Constructs a minimal InferenceData containing a ``mu`` variable in the
+        Constructs a minimal DataTree containing a ``mu`` variable in the
         ``posterior_predictive`` group, shaped to be compatible with the
         reporting helpers that expect SC-style predictions.
 
@@ -545,8 +545,8 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
         Returns
         -------
-        az.InferenceData
-            InferenceData with posterior_predictive group containing ``mu``.
+        xr.DataTree
+            DataTree with posterior_predictive group containing ``mu``.
         """
         # Add a singleton treated_units dim: (chain, draw, T, 1)
         mu_4d = mu_vals[..., np.newaxis]
@@ -562,7 +562,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             },
         )
         ds = xr.Dataset({"mu": mu_da})
-        return az.InferenceData(posterior_predictive=ds)
+        return xr.DataTree.from_dict({"posterior_predictive": ds})
 
     def summary(self, round_to: int | None = None) -> None:
         """Print summary of main results.

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -61,7 +61,7 @@ as `pymc-forecast#50 <https://github.com/pymc-labs/pymc-forecast/issues/50>`_.
 
 Inference diagnostics: :attr:`PyMCForecastModel.idata` holds the thinned,
 draw-coherent posterior subsample used for prediction; the *full* fit result
-(e.g. the complete NUTS ``InferenceData`` with sample stats) is exposed as
+(e.g. the complete NUTS ``DataTree`` with sample stats) is exposed as
 :attr:`PyMCForecastModel.fit_idata`.
 """
 
@@ -190,7 +190,7 @@ class PyMCForecastModel:
             random_seed=self.random_seed,
             **self.forecaster_kwargs,
         )
-        self.idata: az.InferenceData | None = None
+        self.idata: xr.DataTree | None = None
         self._posterior: xr.Dataset | None = None
         self._treated_units: list[str] = ["unit_0"]
         self._has_covariates = False
@@ -212,11 +212,11 @@ class PyMCForecastModel:
         )
 
     @property
-    def fit_idata(self) -> az.InferenceData:
+    def fit_idata(self) -> xr.DataTree:
         """Full inference result of the underlying forecaster fit.
 
         For the default NUTS backend this is the complete MCMC
-        ``InferenceData`` (posterior, sample stats, diagnostics) — as
+        ``DataTree`` (posterior, sample stats, diagnostics) — as
         distinct from :attr:`idata`, which holds the thinned posterior
         subsample shared by every predictive call for draw coherence.
 
@@ -225,7 +225,7 @@ class PyMCForecastModel:
         RuntimeError
             If the model has not been fit yet.
         AttributeError
-            If the forecaster does not retain an ``InferenceData`` fit
+            If the forecaster does not retain a ``DataTree`` fit
             result (e.g. variational fits, which expose ``.approx`` /
             ``.losses`` on ``.forecaster`` instead).
         """
@@ -235,7 +235,7 @@ class PyMCForecastModel:
         if fit_result is None:
             raise AttributeError(
                 f"{type(self.forecaster).__name__} does not retain a full "
-                "InferenceData fit result; inspect the forecaster directly "
+                "DataTree fit result; inspect the forecaster directly "
                 "via `.forecaster` (e.g. `.approx` / `.losses` for "
                 "variational fits)."
             )
@@ -245,7 +245,7 @@ class PyMCForecastModel:
 
     def fit(
         self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Construct and fit the forecasting model on the pre-period.
 
         Parameters
@@ -278,7 +278,7 @@ class PyMCForecastModel:
         self._posterior = self.forecaster.draw_posterior(
             self.num_samples, random_seed=self.random_seed
         )
-        self.idata = az.InferenceData(posterior=self._posterior)
+        self.idata = xr.DataTree.from_dict({"posterior": self._posterior})
         return self.idata
 
     @staticmethod
@@ -296,7 +296,7 @@ class PyMCForecastModel:
         coords: dict[str, Any] | None = None,
         out_of_sample: bool | None = False,
         **kwargs: Any,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Predict in-sample (pre-period) or forecast the counterfactual.
 
         Parameters
@@ -316,7 +316,7 @@ class PyMCForecastModel:
 
         Returns
         -------
-        az.InferenceData
+        xr.DataTree
             With a ``posterior_predictive`` group holding draw-level ``mu``
             (the noise-free latent predictor) and ``y_hat`` (the posterior
             predictive of the observed variable) with dims
@@ -355,8 +355,8 @@ class PyMCForecastModel:
 
     def _to_inference_data(
         self, mu: xr.DataArray, y_hat: xr.DataArray, obs_ind: np.ndarray
-    ) -> az.InferenceData:
-        """Rename schema dims onto CausalPy coords and wrap as InferenceData."""
+    ) -> xr.DataTree:
+        """Rename schema dims onto CausalPy coords and wrap as a DataTree."""
 
         def normalize(samples: xr.DataArray) -> xr.DataArray:
             if "series" in samples.dims:
@@ -368,7 +368,7 @@ class PyMCForecastModel:
             )
 
         ds = xr.Dataset({"mu": normalize(mu), "y_hat": normalize(y_hat)})
-        return az.InferenceData(posterior_predictive=ds)
+        return xr.DataTree.from_dict({"posterior_predictive": ds})
 
     # -- scoring and impact ------------------------------------------------
 
@@ -401,7 +401,7 @@ class PyMCForecastModel:
         return pd.Series(scores)
 
     def calculate_impact(
-        self, y_true: xr.DataArray, y_pred: az.InferenceData
+        self, y_true: xr.DataArray, y_pred: xr.DataTree
     ) -> xr.DataArray:
         """Causal impact as observed minus counterfactual, at the draw level.
 
@@ -409,7 +409,7 @@ class PyMCForecastModel:
         ----------
         y_true : xr.DataArray
             Observed outcomes with dims ``["obs_ind", "treated_units"]``.
-        y_pred : az.InferenceData
+        y_pred : xr.DataTree
             Counterfactual prediction from :meth:`predict`.
         """
         y_hat = y_pred["posterior_predictive"]["mu"]

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -68,6 +68,23 @@ def _call_seasonality_component_apply(
     """Call seasonality components across tensor and xtensor variants."""
     return _call_time_component_apply(seasonality_component, dayofperiod)
 
+def _extend_datatree_left(idata: xr.DataTree, other: xr.DataTree) -> xr.DataTree:
+    """Add DataTree groups without replacing groups already in ``idata``."""
+    for group, node in other.children.items():
+        if group not in idata:
+            idata[group] = node
+    return idata
+
+
+def _assign_group_coords(
+    idata: xr.DataTree, group: str, **coords: Any
+) -> xr.DataTree:
+    """Assign coordinates to a DataTree group through its Dataset."""
+    idata[group] = idata[group].to_dataset().assign_coords(**coords)
+    return idata
+
+
+
 
 class PyMCModel(pm.Model):
     """A wrapper class for PyMC models. This provides a scikit-learn like interface with
@@ -312,11 +329,11 @@ class PyMCModel(pm.Model):
         obs_coords = np.arange(new_no_of_observations)
 
         with self:
-            # Get the number of treated units from the model coordinates
-            treated_units_coord = getattr(self, "coords", {}).get(
-                "treated_units", ["unit_0"]
-            )
-            n_treated_units = len(treated_units_coord)
+            treated_units_coord = getattr(self, "coords", {}).get("treated_units")
+            if treated_units_coord is None:
+                n_treated_units = getattr(self, "_n_treated_units", 1)
+            else:
+                n_treated_units = len(treated_units_coord)
 
             pm.set_data(
                 {"X": X, "y": np.zeros((new_no_of_observations, n_treated_units))},
@@ -325,7 +342,7 @@ class PyMCModel(pm.Model):
 
     def fit(
         self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Draw samples from posterior, prior predictive, and posterior
         predictive distributions.
 
@@ -341,9 +358,14 @@ class PyMCModel(pm.Model):
 
         Returns
         -------
-        az.InferenceData
-            InferenceData object containing the samples.
+        xr.DataTree
+            DataTree containing the samples.
         """
+
+        coords = {} if coords is None else coords.copy()
+        for data in (X, y):
+            for dimension in data.dims:
+                coords.setdefault(dimension, data.get_index(dimension))
 
         # Ensure random_seed is used in sample_prior_predictive() and
         # sample_posterior_predictive() if provided in sample_kwargs.
@@ -353,16 +375,20 @@ class PyMCModel(pm.Model):
         # Data-driven priors are computed first, then user-specified priors override them
         self.priors = {**self.priors_from_data(X, y), **self.priors}
 
+        self._n_treated_units = y.sizes.get("treated_units", 1)
         self.build_model(X, y, coords)
         with self:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is None:
                 raise RuntimeError("pm.sample() returned None")
-            self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
-            self.idata.extend(
-                pm.sample_posterior_predictive(
-                    self.idata, progressbar=False, random_seed=random_seed
-                )
+            self.idata = _extend_datatree_left(
+                self.idata, pm.sample_prior_predictive(random_seed=random_seed)
+            )
+            pm.sample_posterior_predictive(
+                self.idata,
+                progressbar=False,
+                random_seed=random_seed,
+                extend_inferencedata=True,
             )
         return self.idata
 
@@ -412,9 +438,7 @@ class PyMCModel(pm.Model):
         # to preserve the original coordinates (e.g., datetime indices) for proper
         # alignment with other xarray operations like calculate_impact()
         if isinstance(X, xr.DataArray) and "obs_ind" in X.coords:
-            pp["posterior_predictive"] = pp["posterior_predictive"].assign_coords(
-                obs_ind=X.obs_ind
-            )
+            _assign_group_coords(pp, "posterior_predictive", obs_ind=X.obs_ind)
 
         return pp
 
@@ -457,7 +481,7 @@ class PyMCModel(pm.Model):
         return pd.Series(scores)
 
     def calculate_impact(
-        self, y_true: xr.DataArray, y_pred: az.InferenceData
+        self, y_true: xr.DataArray, y_pred: xr.DataTree
     ) -> xr.DataArray:
         """
         Calculate the causal impact as the difference between observed and predicted values.
@@ -473,7 +497,7 @@ class PyMCModel(pm.Model):
         ----------
         y_true : xr.DataArray
             The observed outcome values with dimensions ["obs_ind", "treated_units"].
-        y_pred : az.InferenceData
+        y_pred : xr.DataTree
             The posterior predictive samples containing the "mu" variable, which
             represents the expected value (mean) of the outcome.
 
@@ -1370,21 +1394,21 @@ class InstrumentalVariableRegression(PyMCModel):
         if ppc_sampler == "jax":
             if self.idata is not None:
                 with self:
-                    self.idata.extend(
-                        pm.sample_posterior_predictive(
-                            self.idata,
-                            random_seed=random_seed,
-                            compile_kwargs={"mode": "JAX"},
-                        )
-                    )
-        elif ppc_sampler == "pymc" and self.idata is not None:
-            with self:
-                self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
-                self.idata.extend(
                     pm.sample_posterior_predictive(
                         self.idata,
                         random_seed=random_seed,
+                        compile_kwargs={"mode": "JAX"},
+                        extend_inferencedata=True,
                     )
+        elif ppc_sampler == "pymc" and self.idata is not None:
+            with self:
+                self.idata = _extend_datatree_left(
+                    self.idata, pm.sample_prior_predictive(random_seed=random_seed)
+                )
+                pm.sample_posterior_predictive(
+                    self.idata,
+                    random_seed=random_seed,
+                    extend_inferencedata=True,
                 )
 
     def fit(  # type: ignore[override]
@@ -1399,7 +1423,7 @@ class InstrumentalVariableRegression(PyMCModel):
         vs_prior_type: Literal["spike_and_slab", "horseshoe", "normal"] | None = None,
         vs_hyperparams: dict[str, Any] | None = None,
         binary_treatment: bool = False,
-    ) -> az.InferenceData:  # type: ignore[override]
+    ) -> xr.DataTree:
         """Draw samples from posterior distribution and potentially
         from the prior and posterior predictive distributions. The
         fit call can take values for the
@@ -1524,7 +1548,7 @@ class PropensityScore(PyMCModel):
         coords: dict[str, Any],
         prior: dict[str, list] | None = None,
         noncentred: bool = True,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Draw samples from posterior, prior predictive, and posterior predictive
         distributions. We overwrite the base method because the base method assumes
         a variable y and we use t to indicate the treatment variable here.
@@ -1552,11 +1576,14 @@ class PropensityScore(PyMCModel):
         with self:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is not None:
-                self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
-                self.idata.extend(
-                    pm.sample_posterior_predictive(
-                        self.idata, progressbar=False, random_seed=random_seed
-                    )
+                self.idata = _extend_datatree_left(
+                    self.idata, pm.sample_prior_predictive(random_seed=random_seed)
+                )
+                pm.sample_posterior_predictive(
+                    self.idata,
+                    progressbar=False,
+                    random_seed=random_seed,
+                    extend_inferencedata=True,
                 )
         return self.idata
 
@@ -1571,7 +1598,7 @@ class PropensityScore(PyMCModel):
         spline_component: bool = False,
         winsorize_boundary: float = 0.0,
         spline_knots: int = 30,
-    ) -> tuple[az.InferenceData, pm.Model]:
+    ) -> tuple[xr.DataTree, pm.Model]:
         """
         Fit a Bayesian outcome model using covariates and previously estimated propensity scores.
 
@@ -1617,7 +1644,7 @@ class PropensityScore(PyMCModel):
 
         Returns
         -------
-        idata_outcome : arviz.InferenceData
+        idata_outcome : xr.DataTree
             The posterior and prior predictive samples from the outcome model.
 
         model_outcome : pm.Model
@@ -1709,7 +1736,7 @@ class PropensityScore(PyMCModel):
                 )
 
             idata_outcome = pm.sample_prior_predictive(random_seed=random_seed)
-            idata_outcome.extend(pm.sample(**self.sample_kwargs))
+            idata_outcome.update(pm.sample(**self.sample_kwargs))
 
         return idata_outcome, model_outcome
 
@@ -2059,7 +2086,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
 
     def fit(
         self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """Draw samples from posterior, prior predictive, and posterior predictive
         distributions, placing them in the model's idata attribute.
 
@@ -2078,14 +2105,15 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
         with self:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is not None:
-                self.idata.extend(pm.sample_prior_predictive(random_seed=random_seed))
-                self.idata.extend(
-                    pm.sample_posterior_predictive(
-                        self.idata,
-                        var_names=["y_hat", "mu"],
-                        progressbar=self.sample_kwargs.get("progressbar", True),
-                        random_seed=random_seed,
-                    )
+                self.idata = _extend_datatree_left(
+                    self.idata, pm.sample_prior_predictive(random_seed=random_seed)
+                )
+                pm.sample_posterior_predictive(
+                    self.idata,
+                    var_names=["y_hat", "mu"],
+                    progressbar=self.sample_kwargs.get("progressbar", True),
+                    random_seed=random_seed,
+                    extend_inferencedata=True,
                 )
         return self.idata  # type: ignore[return-value]
 
@@ -2158,7 +2186,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
         coords: dict[str, Any] | None = None,
         out_of_sample: bool | None = False,
         **kwargs: Any,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """
         Predict data given input X.
 
@@ -2177,7 +2205,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
 
         Returns
         -------
-        az.InferenceData
+        xr.DataTree
             Posterior predictive samples.
         """
         random_seed = self.sample_kwargs.get("random_seed", None)
@@ -2192,9 +2220,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
 
         # Assign coordinates from input X for proper alignment
         if isinstance(X, xr.DataArray) and "obs_ind" in X.coords:
-            post_pred["posterior_predictive"] = post_pred[
-                "posterior_predictive"
-            ].assign_coords(obs_ind=X.obs_ind)
+            _assign_group_coords(post_pred, "posterior_predictive", obs_ind=X.obs_ind)
 
         return post_pred
 
@@ -2275,6 +2301,7 @@ class StateSpaceTimeSeries(PyMCModel):
         self.level_order = level_order
         self.seasonal_length = seasonal_length
         self.mode = mode
+        self._treated_units = ["unit_0"]
         self.ss_mod: Any = None
         self.second_model: pm.Model | None = None  # Created in build_model()
         self._validate_and_initialize_components()
@@ -2379,6 +2406,19 @@ class StateSpaceTimeSeries(PyMCModel):
                 "y must be provided for StateSpaceTimeSeries.build_model()"
             )
 
+        if "treated_units" not in y.dims:
+            raise ValueError(
+                "StateSpaceTimeSeries requires a treated_units dimension with exactly "
+                "one unit."
+            )
+        n_treated_units = y.sizes["treated_units"]
+        if n_treated_units != 1:
+            raise ValueError(
+                "StateSpaceTimeSeries supports exactly one treated unit, got "
+                f"{n_treated_units}."
+            )
+        self._treated_units = list(y.get_index("treated_units"))
+
         # Extract datetime index from y coordinates
         if "obs_ind" not in y.coords:
             raise ValueError("y must have 'obs_ind' coordinate.")
@@ -2462,7 +2502,7 @@ class StateSpaceTimeSeries(PyMCModel):
         X: xr.DataArray | None = None,
         y: xr.DataArray | None = None,
         coords: dict[str, Any] | None = None,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """
         Fit the model, drawing posterior samples.
 
@@ -2479,8 +2519,8 @@ class StateSpaceTimeSeries(PyMCModel):
 
         Returns
         -------
-        az.InferenceData
-            InferenceData with parameter draws.
+        xr.DataTree
+            DataTree with parameter draws.
         """
         if y is None:
             raise ValueError("y must be provided for StateSpaceTimeSeries.fit()")
@@ -2490,16 +2530,15 @@ class StateSpaceTimeSeries(PyMCModel):
         with self.second_model:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is not None:
-                self.idata.extend(
-                    pm.sample_posterior_predictive(
-                        self.idata,
-                    )
+                pm.sample_posterior_predictive(
+                    self.idata,
+                    extend_inferencedata=True,
                 )
         self.conditional_idata = self._smooth()
         return self._prepare_idata()
 
-    def _prepare_idata(self) -> az.InferenceData:
-        """Prepare InferenceData with proper dimensions including treated_units."""
+    def _prepare_idata(self) -> xr.DataTree:
+        """Prepare DataTree with proper dimensions including treated_units."""
         if self.idata is None:
             raise RuntimeError("Model must be fit before smoothing.")
 
@@ -2517,12 +2556,16 @@ class StateSpaceTimeSeries(PyMCModel):
             y_hat_final = y_hat_summed
 
         # Add treated_units dimension for consistency with other models
-        y_hat_with_units = y_hat_final.expand_dims({"treated_units": ["unit_0"]})
+        y_hat_with_units = y_hat_final.expand_dims(
+            {"treated_units": self._treated_units}
+        ).transpose("chain", "draw", "obs_ind", "treated_units")
 
-        new_idata["posterior_predictive"]["y_hat"] = y_hat_with_units
-        new_idata["posterior_predictive"]["mu"] = y_hat_with_units
+        new_idata["posterior_predictive"] = xr.Dataset(
+            {"y_hat": y_hat_with_units, "mu": y_hat_with_units}
+        )
 
-        return new_idata
+        self.idata = new_idata
+        return self.idata
 
     def _smooth(self) -> xr.Dataset:
         """
@@ -2531,7 +2574,12 @@ class StateSpaceTimeSeries(PyMCModel):
         """
         if self.idata is None:
             raise RuntimeError("Model must be fit before smoothing.")
-        return self.ss_mod.sample_conditional_posterior(self.idata)
+        conditional_idata = self.ss_mod.sample_conditional_posterior(self.idata)
+        return (
+            conditional_idata.to_dataset()
+            if isinstance(conditional_idata, xr.DataTree)
+            else conditional_idata
+        )
 
     def _forecast(self, start: pd.Timestamp, periods: int) -> xr.Dataset:
         """
@@ -2543,7 +2591,8 @@ class StateSpaceTimeSeries(PyMCModel):
             raise RuntimeError("Model must be fit before forecasting.")
         if self.ss_mod is None:
             raise RuntimeError("State space model not initialized")
-        return self.ss_mod.forecast(self.idata, start=start, periods=periods)
+        forecast = self.ss_mod.forecast(self.idata, start=start, periods=periods)
+        return forecast.to_dataset() if isinstance(forecast, xr.DataTree) else forecast
 
     def predict(
         self,
@@ -2551,7 +2600,7 @@ class StateSpaceTimeSeries(PyMCModel):
         coords: dict[str, Any] | None = None,
         out_of_sample: bool | None = False,
         **kwargs: Any,
-    ) -> az.InferenceData:
+    ) -> xr.DataTree:
         """
         Predict data given input X.
 
@@ -2571,7 +2620,7 @@ class StateSpaceTimeSeries(PyMCModel):
 
         Returns
         -------
-        az.InferenceData
+        xr.DataTree
             Posterior predictive samples with y_hat and mu.
         """
         if not out_of_sample:
@@ -2604,20 +2653,21 @@ class StateSpaceTimeSeries(PyMCModel):
 
             # Extract the forecasted observed data and add treated_units dimension
             y_hat = forecast_copy["forecast_observed"].isel(observed_state=0)
-            y_hat_with_units = y_hat.expand_dims({"treated_units": ["unit_0"]})
+            y_hat_with_units = y_hat.expand_dims(
+                {"treated_units": self._treated_units}
+            ).transpose("chain", "draw", "obs_ind", "treated_units")
 
-            # Wrap in InferenceData for consistency
-            result = az.InferenceData(
-                posterior_predictive=xr.Dataset(
-                    {"y_hat": y_hat_with_units, "mu": y_hat_with_units}
-                )
+            result = xr.DataTree.from_dict(
+                {
+                    "posterior_predictive": xr.Dataset(
+                        {"y_hat": y_hat_with_units, "mu": y_hat_with_units}
+                    )
+                }
             )
 
             # Assign coordinates from input X for proper alignment
             if isinstance(X, xr.DataArray) and "obs_ind" in X.coords:
-                result["posterior_predictive"] = result[
-                    "posterior_predictive"
-                ].assign_coords(obs_ind=X.obs_ind)
+                _assign_group_coords(result, "posterior_predictive", obs_ind=X.obs_ind)
 
             return result
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -68,6 +68,7 @@ def _call_seasonality_component_apply(
     """Call seasonality components across tensor and xtensor variants."""
     return _call_time_component_apply(seasonality_component, dayofperiod)
 
+
 def _extend_datatree_left(idata: xr.DataTree, other: xr.DataTree) -> xr.DataTree:
     """Add DataTree groups without replacing groups already in ``idata``."""
     for group, node in other.children.items():
@@ -76,14 +77,10 @@ def _extend_datatree_left(idata: xr.DataTree, other: xr.DataTree) -> xr.DataTree
     return idata
 
 
-def _assign_group_coords(
-    idata: xr.DataTree, group: str, **coords: Any
-) -> xr.DataTree:
+def _assign_group_coords(idata: xr.DataTree, group: str, **coords: Any) -> xr.DataTree:
     """Assign coordinates to a DataTree group through its Dataset."""
     idata[group] = idata[group].to_dataset().assign_coords(**coords)
     return idata
-
-
 
 
 class PyMCModel(pm.Model):

--- a/causalpy/tests/test_datatree_contracts.py
+++ b/causalpy/tests/test_datatree_contracts.py
@@ -1,0 +1,45 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""DataTree / ArviZ migration contract tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+
+def test_cold_import_causalpy_without_arviz_migration_warning() -> None:
+    """``import causalpy`` in a fresh process must not raise ``arviz.MigrationWarning``.
+
+    ``conftest`` already imports CausalPy in-process, so this check has to run in a
+    cold subprocess. The subprocess imports ArviZ, installs a category-specific
+    warnings-as-errors filter, then imports CausalPy.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            (
+                "import warnings\n"
+                "import arviz\n"
+                "warnings.filterwarnings("
+                "'error', category=arviz.MigrationWarning)\n"
+                "import causalpy\n"
+            ),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/causalpy/tests/test_instrumental_variable.py
+++ b/causalpy/tests/test_instrumental_variable.py
@@ -18,6 +18,7 @@ Tests for the InstrumentalVariable experiment class.
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 
 import causalpy as cp
 from causalpy.custom_exceptions import DataException
@@ -479,7 +480,7 @@ def test_iv_get_plot_data_not_implemented(iv_data, sample_kwargs):
 
 
 def test_iv_sample_predictive_distribution(iv_data, sample_kwargs):
-    """Test that predictive distribution can be sampled."""
+    """PyMC PPC sampler mutates the fitted DataTree with posterior_predictive."""
     result = cp.InstrumentalVariable(
         instruments_data=iv_data["instruments_data"],
         data=iv_data["data"],
@@ -490,8 +491,68 @@ def test_iv_sample_predictive_distribution(iv_data, sample_kwargs):
         ),
     )
 
+    assert isinstance(result.idata, xr.DataTree)
+    assert "posterior_predictive" not in result.idata
+    posterior_before_ppc = result.idata["posterior"].to_dataset().copy()
+
     result.model.sample_predictive_distribution(ppc_sampler="pymc")
-    assert hasattr(result.idata, "posterior_predictive")
+
+    assert isinstance(result.idata, xr.DataTree)
+    assert "posterior_predictive" in result.idata
+    assert "prior_predictive" in result.idata
+    xr.testing.assert_identical(
+        result.idata["posterior"].to_dataset(), posterior_before_ppc
+    )
+
+
+def test_iv_default_jax_ppc_mutates_existing_datatree(
+    iv_data, sample_kwargs, monkeypatch
+):
+    """Default JAX PPC sampler mutates an existing DataTree in place.
+
+    JAX itself is optional in the test env; the DataTree mutation contract is
+    exercised by stubbing ``pm.sample_posterior_predictive`` while asserting the
+    default call uses ``compile_kwargs={"mode": "JAX"}`` and
+    ``extend_inferencedata=True``.
+    """
+    import pymc as pm
+
+    result = cp.InstrumentalVariable(
+        instruments_data=iv_data["instruments_data"],
+        data=iv_data["data"],
+        instruments_formula=iv_data["instruments_formula"],
+        formula=iv_data["formula"],
+        model=cp.pymc_models.InstrumentalVariableRegression(
+            sample_kwargs=sample_kwargs
+        ),
+    )
+
+    assert isinstance(result.idata, xr.DataTree)
+    assert "posterior_predictive" not in result.idata
+    original_idata = result.idata
+
+    def fake_sample_posterior_predictive(idata, *args, **kwargs):
+        assert kwargs.get("extend_inferencedata") is True
+        assert kwargs.get("compile_kwargs") == {"mode": "JAX"}
+        # Mimic in-place mutation from extend_inferencedata=True
+        idata["posterior_predictive"] = xr.Dataset(
+            {
+                "likelihood": (
+                    ("chain", "draw", "likelihood_dim_0"),
+                    np.zeros((1, 1, 1)),
+                )
+            }
+        )
+        return idata
+
+    monkeypatch.setattr(
+        pm, "sample_posterior_predictive", fake_sample_posterior_predictive
+    )
+    result.model.sample_predictive_distribution()  # default ppc_sampler="jax"
+
+    assert result.idata is original_idata
+    assert isinstance(result.idata, xr.DataTree)
+    assert "posterior_predictive" in result.idata
 
 
 # =============================================================================

--- a/causalpy/tests/test_integration_its_new_timeseries.py
+++ b/causalpy/tests/test_integration_its_new_timeseries.py
@@ -11,10 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from matplotlib import pyplot as plt
 
 import causalpy as cp
@@ -59,7 +59,7 @@ def test_its_with_bsts_model():
 
     # Basic checks
     assert isinstance(result, cp.InterruptedTimeSeries)
-    assert isinstance(result.idata, az.InferenceData)
+    assert isinstance(result.idata, xr.DataTree)
 
     # Plot and plot data
     fig, ax = result.plot()
@@ -125,7 +125,7 @@ def test_its_with_state_space_model():
     )
 
     assert isinstance(result, cp.InterruptedTimeSeries)
-    assert isinstance(result.idata, az.InferenceData)
+    assert isinstance(result.idata, xr.DataTree)
 
     # In-sample predictions should be available
     fig, ax = result.plot()
@@ -166,7 +166,21 @@ def test_state_space_predict_and_score():
     # Split into train/test
     train_dates = dates[:50]
     test_dates = dates[50:]
-    y_train = y[:50]
+    y_train = xr.DataArray(
+        y[:50, np.newaxis],
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": train_dates, "treated_units": ["unit_0"]},
+    )
+    X_train = xr.DataArray(
+        np.zeros((len(train_dates), 0)),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": train_dates, "coeffs": []},
+    )
+    X_test = xr.DataArray(
+        np.zeros((len(test_dates), 0)),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": test_dates, "coeffs": []},
+    )
 
     sample_kwargs = {
         "chains": 1,
@@ -183,26 +197,32 @@ def test_state_space_predict_and_score():
         mode="PyMC",
     )
 
-    # Fit the model
-    coords_train = {"datetime_index": train_dates}
-    model.fit(X=None, y=y_train, coords=coords_train)
+    # Fit the model.
+    model.fit(X=X_train, y=y_train)
 
-    # Test in-sample prediction (out_of_sample=False)
-    pred_in_sample = model.predict(X=None, coords=coords_train, out_of_sample=False)
-    assert pred_in_sample is not None
-    assert "posterior_predictive" in pred_in_sample or "y_hat" in pred_in_sample
+    # Test in-sample prediction.
+    pred_in_sample = model.predict(X=X_train, out_of_sample=False)
+    assert isinstance(pred_in_sample, xr.DataTree)
+    assert "posterior_predictive" in pred_in_sample
+    in_sample_pp = pred_in_sample["posterior_predictive"].to_dataset()
+    assert {"y_hat", "mu"} <= set(in_sample_pp.data_vars)
+    np.testing.assert_array_equal(
+        in_sample_pp.coords["obs_ind"].values, X_train.coords["obs_ind"].values
+    )
 
-    # Test out-of-sample prediction (out_of_sample=True)
-    coords_test = {"datetime_index": test_dates}
-    pred_out_of_sample = model.predict(X=None, coords=coords_test, out_of_sample=True)
-    assert pred_out_of_sample is not None
-    # StateSpaceTimeSeries.predict returns xr.Dataset for out_of_sample
-    assert "y_hat" in pred_out_of_sample or "forecast_observed" in pred_out_of_sample
+    # Test out-of-sample prediction with the target datetime coordinates.
+    pred_out_of_sample = model.predict(X=X_test, out_of_sample=True)
+    assert isinstance(pred_out_of_sample, xr.DataTree)
+    assert "posterior_predictive" in pred_out_of_sample
+    posterior_predictive = pred_out_of_sample["posterior_predictive"].to_dataset()
+    assert "y_hat" in posterior_predictive
+    np.testing.assert_array_equal(
+        posterior_predictive.coords["obs_ind"].values, X_test.coords["obs_ind"].values
+    )
 
-    # Test score method
-    score = model.score(X=None, y=y_train, coords=coords_train)
+    score = model.score(X=X_train, y=y_train)
     assert isinstance(score, pd.Series)
-    assert "r2" in score
+    assert "unit_0_r2" in score
 
 
 @pytest.mark.integration

--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -14,7 +14,6 @@
 
 import contextlib
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import pymc as pm

--- a/causalpy/tests/test_integration_pymc_examples.py
+++ b/causalpy/tests/test_integration_pymc_examples.py
@@ -1001,7 +1001,7 @@ def test_inverse_prop(mock_pymc_sample):
         weighting_scheme="robust",
         model=cp.pymc_models.PropensityScore(sample_kwargs=sample_kwargs),
     )
-    assert isinstance(result.idata, az.InferenceData)
+    assert isinstance(result.idata, xr.DataTree)
     ps = result.idata.posterior["p"].mean(dim=("chain", "draw"))
     w1, w2, _, _ = result.make_doubly_robust_adjustment(ps)
     assert isinstance(w1, pd.Series)
@@ -1043,7 +1043,9 @@ def test_inverse_prop(mock_pymc_sample):
         normal_outcome=True,
         spline_component=False,
     )
-    assert isinstance(idata_normal, az.InferenceData)
+    assert isinstance(idata_normal, xr.DataTree)
+    assert "prior_predictive" in idata_normal
+    assert "posterior" in idata_normal
     assert isinstance(model_normal, pm.Model)
     assert "beta_" in idata_normal.posterior
     assert "beta_ps" in idata_normal.posterior
@@ -1138,7 +1140,7 @@ def test_bayesian_structural_time_series():
         y=y_da,
         coords=coords_with_x.copy(),  # Pass a copy
     )
-    assert isinstance(model_with_x.idata, az.InferenceData)
+    assert isinstance(model_with_x.idata, xr.DataTree)
     assert "posterior" in model_with_x.idata
     assert "beta" in model_with_x.idata.posterior
     # PyMC Marketing components might use different internal names, e.g. fourier_beta, delta
@@ -1157,7 +1159,7 @@ def test_bayesian_structural_time_series():
         X=X_da,
         coords=coords_with_x,  # Original coords_with_x is fine here
     )
-    assert isinstance(predictions_with_x, az.InferenceData)
+    assert isinstance(predictions_with_x, xr.DataTree)
     score_with_x = model_with_x.score(
         X=X_da,
         y=y_da,
@@ -1195,7 +1197,7 @@ def test_bayesian_structural_time_series():
         y=y_da_no_x,
         coords=coords_no_x.copy(),  # Pass a copy
     )
-    assert isinstance(model_no_x.idata, az.InferenceData)
+    assert isinstance(model_no_x.idata, xr.DataTree)
     assert "posterior" in model_no_x.idata
     assert "beta" not in model_no_x.idata.posterior
     assert "fourier_beta" in model_no_x.idata.posterior
@@ -1206,7 +1208,7 @@ def test_bayesian_structural_time_series():
         X=X_da_no_x,
         coords=coords_no_x,  # Original coords_no_x is fine
     )
-    assert isinstance(predictions_no_x, az.InferenceData)
+    assert isinstance(predictions_no_x, xr.DataTree)
     score_no_x = model_no_x.score(
         X=X_da_no_x,
         y=y_da_no_x,
@@ -1234,13 +1236,13 @@ def test_bayesian_structural_time_series():
         y=y_da_no_x,
         coords=coords_empty_x.copy(),  # Pass a copy
     )
-    assert isinstance(model_empty_x.idata, az.InferenceData)
+    assert isinstance(model_empty_x.idata, xr.DataTree)
 
     predictions_empty_x = model_empty_x.predict(
         X=X_da_no_x,
         coords=coords_empty_x,  # Original coords_empty_x is fine
     )
-    assert isinstance(predictions_empty_x, az.InferenceData)
+    assert isinstance(predictions_empty_x, xr.DataTree)
     score_empty_x = model_empty_x.score(
         X=X_da_no_x,
         y=y_da_no_x,
@@ -1416,7 +1418,7 @@ def test_state_space_time_series():
     )
 
     # Verify inference data structure
-    assert isinstance(idata, az.InferenceData)
+    assert isinstance(idata, xr.DataTree)
     assert "posterior" in idata
     assert "posterior_predictive" in idata
 
@@ -1434,6 +1436,8 @@ def test_state_space_time_series():
     # Check for expected posterior predictive variables
     assert "y_hat" in idata.posterior_predictive
     assert "mu" in idata.posterior_predictive
+    assert "obs_ind" in idata["posterior_predictive"]["y_hat"].dims
+    assert "time" not in idata["posterior_predictive"]["y_hat"].dims
 
     # --- Test Case 2: In-sample prediction --- #
     # Create dummy X for in-sample prediction (state-space doesn't use it but API requires it for consistency)
@@ -1446,7 +1450,7 @@ def test_state_space_time_series():
         X=dummy_X_insample,
         out_of_sample=False,
     )
-    assert isinstance(predictions_in_sample, az.InferenceData)
+    assert isinstance(predictions_in_sample, xr.DataTree)
     assert "posterior_predictive" in predictions_in_sample
     assert "y_hat" in predictions_in_sample.posterior_predictive
     assert "mu" in predictions_in_sample.posterior_predictive
@@ -1464,22 +1468,17 @@ def test_state_space_time_series():
         X=future_X,
         out_of_sample=True,
     )
-    # Note: predict now returns InferenceData, not Dataset!
-    # But let's check what the test expects.
-    # The previous code expected xr.Dataset:
-    # assert isinstance(predictions_out_sample, xr.Dataset)
-    # I updated predict() to return az.InferenceData.
-    # So I should update this assertion too.
+    # Predictions are returned as a DataTree with a posterior_predictive group.
 
-    assert isinstance(predictions_out_sample, az.InferenceData)
-    assert "y_hat" in predictions_out_sample.posterior_predictive
-    assert "mu" in predictions_out_sample.posterior_predictive
-
-    # Verify forecast has correct dimensions
-    # y_hat is in posterior_predictive group
-    assert predictions_out_sample.posterior_predictive["y_hat"].shape[-1] == len(
-        future_dates
+    assert isinstance(predictions_out_sample, xr.DataTree)
+    posterior_predictive = predictions_out_sample["posterior_predictive"]
+    assert "y_hat" in posterior_predictive
+    assert "mu" in posterior_predictive
+    np.testing.assert_array_equal(
+        posterior_predictive["obs_ind"].values, future_X["obs_ind"].values
     )
+
+    assert posterior_predictive["y_hat"].sizes["obs_ind"] == len(future_dates)
 
     # --- Test Case 4: Model scoring --- #
     # Create dummy X for score (state-space doesn't use it but API requires it)

--- a/causalpy/tests/test_maketables_plugin.py
+++ b/causalpy/tests/test_maketables_plugin.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Tests for optional maketables plugin hooks on experiment objects."""
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
@@ -520,8 +519,8 @@ def test_maketables_missing_pymc_coef_variable_raises(mock_pymc_sample):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    posterior = result.model.idata["posterior"].to_dataset().rename(
-        {"beta": "beta_missing"}
+    posterior = (
+        result.model.idata["posterior"].to_dataset().rename({"beta": "beta_missing"})
     )
     result.model.idata = xr.DataTree.from_dict({"posterior": posterior})
 
@@ -544,8 +543,8 @@ def test_maketables_incompatible_pymc_label_dim_raises(mock_pymc_sample):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    posterior = result.model.idata["posterior"].to_dataset().rename(
-        {"coeffs": "bad_coeff_dim"}
+    posterior = (
+        result.model.idata["posterior"].to_dataset().rename({"coeffs": "bad_coeff_dim"})
     )
     result.model.idata = xr.DataTree.from_dict({"posterior": posterior})
 

--- a/causalpy/tests/test_maketables_plugin.py
+++ b/causalpy/tests/test_maketables_plugin.py
@@ -17,6 +17,7 @@ import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
@@ -516,8 +517,10 @@ def test_maketables_missing_pymc_coef_variable_raises(mock_pymc_sample):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    posterior = result.model.idata.posterior.rename({"beta": "beta_missing"})
-    result.model.idata = az.InferenceData(posterior=posterior)
+    posterior = result.model.idata["posterior"].to_dataset().rename(
+        {"beta": "beta_missing"}
+    )
+    result.model.idata = xr.DataTree.from_dict({"posterior": posterior})
 
     with pytest.raises(
         ValueError,
@@ -538,8 +541,10 @@ def test_maketables_incompatible_pymc_label_dim_raises(mock_pymc_sample):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    posterior = result.model.idata.posterior.rename({"coeffs": "bad_coeff_dim"})
-    result.model.idata = az.InferenceData(posterior=posterior)
+    posterior = result.model.idata["posterior"].to_dataset().rename(
+        {"coeffs": "bad_coeff_dim"}
+    )
+    result.model.idata = xr.DataTree.from_dict({"posterior": posterior})
 
     with pytest.raises(
         ValueError,

--- a/causalpy/tests/test_prediction_contract.py
+++ b/causalpy/tests/test_prediction_contract.py
@@ -102,7 +102,7 @@ def test_linear_regression_mu_matches_outcome_scale_impact(rng, mock_pymc_sample
     pred = model.predict(X, coords)
 
     impact = model.calculate_impact(y, pred)
-    mu = pred.posterior_predictive["mu"]
+    mu = pred["posterior_predictive"]["mu"]
     expected = (y - mu).transpose(..., "obs_ind")
 
     xr.testing.assert_allclose(impact, expected)
@@ -126,7 +126,7 @@ def test_poisson_log_link_mu_is_expected_count(rng, mock_pymc_sample):
     model.fit(X, y, coords)
     pred = model.predict(X, coords)
 
-    mu = pred.posterior_predictive["mu"]
+    mu = pred["posterior_predictive"]["mu"]
     assert float(mu.min()) >= 0.0
     impact = model.calculate_impact(y, pred)
     assert impact.dims[-1] == "obs_ind"
@@ -152,7 +152,7 @@ def test_bernoulli_logit_mu_is_probability(rng, mock_pymc_sample):
     model.fit(X, y, coords)
     pred = model.predict(X, coords)
 
-    mu = pred.posterior_predictive["mu"]
+    mu = pred["posterior_predictive"]["mu"]
     assert float(mu.min()) >= 0.0
     assert float(mu.max()) <= 1.0
     impact = model.calculate_impact(y, pred)
@@ -201,7 +201,64 @@ def test_calculate_impact_uses_mu_not_y_hat(rng, mock_pymc_sample):
     pred = model.predict(X, coords)
 
     impact_from_mu = model.calculate_impact(y, pred)
-    noise_inclusive = y - pred.posterior_predictive["y_hat"]
+    noise_inclusive = y - pred["posterior_predictive"]["y_hat"]
 
     with pytest.raises(AssertionError):
         xr.testing.assert_allclose(impact_from_mu, noise_inclusive)
+
+
+def test_predictive_and_counterfactual_datatree_item_access(rng, mock_pymc_sample):
+    """Impact uses ``pred["posterior_predictive"]["mu"]`` with outcome ``obs_ind`` alignment.
+
+    Predictive and counterfactual ``predict()`` results are DataTrees; callers and
+    ``calculate_impact`` must reach ``mu`` via item access and subtract that exact
+    array after aligning ``obs_ind`` to the observed outcome.
+    """
+    n_obs = 10
+    obs_ind = np.arange(100, 100 + n_obs)
+    X = xr.DataArray(
+        np.column_stack([np.ones(n_obs), rng.normal(size=n_obs)]),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": obs_ind, "coeffs": ["Intercept", "x1"]},
+    )
+    y = xr.DataArray(
+        (
+            X.data @ np.array([[0.25, 0.75]]).T + rng.normal(scale=0.3, size=(n_obs, 1))
+        ).astype(float),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": obs_ind, "treated_units": ["unit_0"]},
+    )
+    coords = {
+        "obs_ind": obs_ind,
+        "coeffs": ["Intercept", "x1"],
+        "treated_units": ["unit_0"],
+    }
+
+    model = LinearRegression(sample_kwargs={**sample_kwargs, "random_seed": 17})
+    model.fit(X, y, coords)
+
+    pred = model.predict(X, coords)
+    assert isinstance(pred, xr.DataTree)
+    mu = pred["posterior_predictive"]["mu"]
+    np.testing.assert_array_equal(
+        mu.coords["obs_ind"].values, X.coords["obs_ind"].values
+    )
+    impact = model.calculate_impact(y, pred)
+    mu_aligned = mu.assign_coords(obs_ind=y["obs_ind"])
+    xr.testing.assert_allclose(impact, (y - mu_aligned).transpose(..., "obs_ind"))
+    np.testing.assert_array_equal(impact["obs_ind"].values, y["obs_ind"].values)
+
+    # Counterfactual-style predict on a modified design matrix (same obs_ind).
+    X_cf = X.copy(deep=True)
+    X_cf.loc[:, "x1"] = 0.0
+    cf_pred = model.predict(X_cf, coords)
+    assert isinstance(cf_pred, xr.DataTree)
+    cf_mu = cf_pred["posterior_predictive"]["mu"]
+    np.testing.assert_array_equal(
+        cf_mu.coords["obs_ind"].values, X_cf.coords["obs_ind"].values
+    )
+    cf_impact = model.calculate_impact(y, cf_pred)
+    cf_mu_aligned = cf_mu.assign_coords(obs_ind=y["obs_ind"])
+    xr.testing.assert_allclose(cf_impact, (y - cf_mu_aligned).transpose(..., "obs_ind"))
+    np.testing.assert_array_equal(cf_impact["obs_ind"].values, y["obs_ind"].values)
+    assert not np.allclose(mu.values, cf_mu.values)

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -388,6 +388,56 @@ def test_clone_returns_unfitted_copy_with_same_config():
     assert cloned.idata is None
 
 
+def test_fit_produces_datatree_with_posterior():
+    """fit() wraps the thinned posterior subsample as a DataTree."""
+    model = make_forecast_model()
+    posterior = xr.Dataset(
+        {
+            "beta": (("chain", "draw", "coeffs"), np.ones((1, 2, 1))),
+            "sigma": (("chain", "draw"), np.ones((1, 2))),
+        },
+        coords={"coeffs": ["x"]},
+    )
+
+    class FakeForecaster:
+        def fit(self, *args, **kwargs):
+            return None
+
+        def draw_posterior(self, n, random_seed=None):
+            assert n == model.num_samples
+            return posterior
+
+    model.forecaster = FakeForecaster()
+    X, y = _design_arrays()
+    idata = model.fit(X, y)
+
+    assert isinstance(idata, xr.DataTree)
+    assert "posterior" in idata
+    assert model.idata is idata
+    assert set(idata["posterior"].to_dataset().data_vars) == {"beta", "sigma"}
+
+
+def test_to_inference_data_yields_datatree_posterior_predictive():
+    """_to_inference_data returns a DataTree with a posterior_predictive group."""
+    model = make_forecast_model()
+    model._treated_units = ["unit_0"]
+    obs_ind = pd.date_range("2020-01-01", periods=3, freq="D").to_numpy()
+    mu = xr.DataArray(np.ones((1, 2, 3)), dims=("chain", "draw", "obs_ind"))
+    y_hat = mu.copy()
+
+    out = model._to_inference_data(mu, y_hat, obs_ind)
+
+    assert isinstance(out, xr.DataTree)
+    assert "posterior_predictive" in out
+    pp = out["posterior_predictive"]
+    assert "mu" in pp and "y_hat" in pp
+    assert pp["mu"].dims == ("chain", "draw", "obs_ind", "treated_units")
+    np.testing.assert_array_equal(
+        pp["mu"].coords["obs_ind"].values.astype("datetime64[ns]"),
+        obs_ind.astype("datetime64[ns]"),
+    )
+
+
 @pytest.mark.integration
 def test_fit_idata_exposes_full_fit_result(forecast_result):
     """fit_idata is the full NUTS result; idata the thinned draw-coherent

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -26,6 +26,7 @@ from causalpy.pymc_models import (
     SoftmaxWeightedSumFitter,
     SyntheticDifferenceInDifferencesWeightFitter,
     WeightedSumFitter,
+    _extend_datatree_left,
     _softmax_simplex_weights,
 )
 
@@ -122,10 +123,10 @@ class TestPyMCModel:
 
         Generates normal data, fits the model, makes predictions, scores the model
         then:
-        1. checks that model.idata is az.InferenceData type
+        1. checks that model.idata is an xr.DataTree
         2. checks that beta, sigma, mu, and y_hat can be extract from idata
         3. checks score is a pandas series of the correct shape
-        4. checks that predictions are az.InferenceData type
+        4. checks that predictions are xr.DataTree
         """
         X = rng.normal(loc=0, scale=1, size=(20, 2))
         y = rng.normal(loc=0, scale=1, size=(20, 1))  # Now 2D with single treated unit
@@ -161,7 +162,10 @@ class TestPyMCModel:
         model.fit(X, y, coords=base_coords)
         predictions = model.predict(X=X)
         score = model.score(X=X, y=y)
-        assert isinstance(model.idata, az.InferenceData)
+        assert isinstance(model.idata, xr.DataTree)
+        assert "posterior" in model.idata
+        assert "prior_predictive" in model.idata
+        assert "posterior_predictive" in model.idata
         assert az.extract(data=model.idata, var_names=["beta"]).shape == (
             1,
             2,
@@ -184,7 +188,40 @@ class TestPyMCModel:
         # Test that the score follows the new unified format
         assert "unit_0_r2" in score.index
         assert "unit_0_r2_std" in score.index
-        assert isinstance(predictions, az.InferenceData)
+        assert isinstance(predictions, xr.DataTree)
+
+
+
+    def test_predict_preserves_datetime_obs_ind(self, rng, mock_pymc_sample):
+        """Predict reattaches the caller's datetime coordinates to the DataTree."""
+        dates = pd.date_range("2024-01-01", periods=8, freq="D")
+        X = xr.DataArray(
+            rng.normal(size=(len(dates), 1)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": dates, "coeffs": ["x"]},
+        )
+        y = xr.DataArray(
+            rng.normal(size=(len(dates), 1)),
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": dates, "treated_units": ["unit_0"]},
+        )
+        model = MyToyModel(sample_kwargs={"chains": 1, "draws": 2})
+        model.fit(
+            X,
+            y,
+            coords={
+                "obs_ind": np.arange(len(dates)),
+                "coeffs": ["x"],
+                "treated_units": ["unit_0"],
+            },
+        )
+
+        prediction = model.predict(X)
+
+        np.testing.assert_array_equal(
+            prediction["posterior_predictive"].to_dataset().coords["obs_ind"].values,
+            X.coords["obs_ind"].values,
+        )
 
 
 class NonStandardDataModel(PyMCModel):
@@ -292,7 +329,34 @@ class TestDataSetterValidation:
         model = LinearRegression(sample_kwargs={"chains": 2, "draws": 2})
         model.fit(X, y, coords=coords)
         predictions = model.predict(X=X)
-        assert isinstance(predictions, az.InferenceData)
+        assert isinstance(predictions, xr.DataTree)
+
+    def test_standard_data_nodes_predict_without_coords(self, rng, mock_pymc_sample):
+        """Prediction retains fitted unit width when no coordinate mapping is supplied."""
+        X = xr.DataArray(
+            rng.normal(size=(10, 1)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": np.arange(10), "coeffs": ["x1"]},
+        )
+        y = xr.DataArray(
+            rng.normal(size=(10, 1)),
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": np.arange(10), "treated_units": ["unit_0"]},
+        )
+        model = LinearRegression(sample_kwargs={"chains": 2, "draws": 2})
+
+        model.fit(X, y)
+        np.testing.assert_array_equal(model.coords["obs_ind"], X.coords["obs_ind"])
+        np.testing.assert_array_equal(model.coords["coeffs"], X.coords["coeffs"])
+        np.testing.assert_array_equal(
+            model.coords["treated_units"], y.coords["treated_units"]
+        )
+        predictions = model.predict(X=X)
+        score = model.score(X=X, y=y)
+
+        assert isinstance(predictions, xr.DataTree)
+        assert predictions["posterior_predictive"]["mu"].sizes["treated_units"] == 1
+        assert "unit_0_r2" in score
 
 
 def test_idata_property(mock_pymc_sample, did_data):
@@ -305,7 +369,90 @@ def test_idata_property(mock_pymc_sample, did_data):
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
     assert hasattr(result, "idata")
-    assert isinstance(result.idata, az.InferenceData)
+    assert isinstance(result.idata, xr.DataTree)
+
+
+def test_prior_merge_adds_groups_without_overwriting_sample_groups():
+    """Post-sample prior merging preserves the sample tree's shared groups."""
+    sample_idata = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset({"beta": xr.DataArray([1.0], dims="draw")}),
+            "observed_data": xr.Dataset({"y_hat": xr.DataArray([2.0], dims="obs_ind")}),
+            "constant_data": xr.Dataset({"X": xr.DataArray([3.0], dims="obs_ind")}),
+        }
+    )
+    prior_idata = xr.DataTree.from_dict(
+        {
+            "prior": xr.Dataset({"beta": xr.DataArray([4.0], dims="draw")}),
+            "prior_predictive": xr.Dataset(
+                {"y_hat": xr.DataArray([5.0], dims="obs_ind")}
+            ),
+            "observed_data": xr.Dataset({"y_hat": xr.DataArray([6.0], dims="obs_ind")}),
+            "constant_data": xr.Dataset({"X": xr.DataArray([7.0], dims="obs_ind")}),
+        }
+    )
+    sample_observed = sample_idata["observed_data"].to_dataset().copy()
+    sample_constant = sample_idata["constant_data"].to_dataset().copy()
+    prior = prior_idata["prior"].to_dataset().copy()
+    prior_predictive = prior_idata["prior_predictive"].to_dataset().copy()
+
+    merged = _extend_datatree_left(sample_idata, prior_idata)
+
+    assert merged is sample_idata
+    assert {"posterior", "prior", "prior_predictive"} <= set(merged.children)
+    xr.testing.assert_identical(merged["observed_data"].to_dataset(), sample_observed)
+    xr.testing.assert_identical(merged["constant_data"].to_dataset(), sample_constant)
+    xr.testing.assert_identical(merged["prior"].to_dataset(), prior)
+    xr.testing.assert_identical(
+        merged["prior_predictive"].to_dataset(), prior_predictive
+    )
+
+
+
+
+def test_propensity_score_fit_returns_datatree_groups(mock_pymc_sample):
+    """Propensity fitting retains posterior, prior predictive, and PPC groups."""
+    X = np.ones((8, 1))
+    t = np.array([0, 1, 0, 1, 0, 1, 0, 1])
+    model = cp.pymc_models.PropensityScore(
+        sample_kwargs={"chains": 1, "draws": 2, "progressbar": False}
+    )
+
+    idata = model.fit(
+        X=X,
+        t=t,
+        coords={"obs_ind": np.arange(len(t)), "coeffs": ["intercept"]},
+    )
+
+    assert isinstance(idata, xr.DataTree)
+    assert {"posterior", "prior_predictive", "posterior_predictive"} <= set(
+        idata.children
+    )
+
+
+
+
+def test_propensity_fit_outcome_model_returns_datatree(mock_pymc_sample):
+    """The outcome-model posterior update retains prior predictive groups."""
+    X = np.ones((8, 1))
+    t = np.array([0, 1, 0, 1, 0, 1, 0, 1])
+    model = cp.pymc_models.PropensityScore(
+        sample_kwargs={"chains": 1, "draws": 2, "progressbar": False}
+    )
+    model.fit(
+        X=X,
+        t=t,
+        coords={"obs_ind": np.arange(len(t)), "coeffs": ["intercept"]},
+    )
+
+    idata, _ = model.fit_outcome_model(
+        X_outcome=pd.DataFrame({"intercept": np.ones(len(t))}),
+        y=pd.Series(np.linspace(0.0, 1.0, len(t))),
+        coords={"outcome_coeffs": ["intercept"]},
+    )
+
+    assert isinstance(idata, xr.DataTree)
+    assert {"prior_predictive", "posterior"} <= set(idata.children)
 
 
 seeds = [1234, 42, 123456789]
@@ -461,9 +608,9 @@ class TestWeightedSumFitterMultiUnit:
         result = wsf.fit(X, y, coords=coords)
 
         # Check that fitting was successful
-        assert isinstance(result, az.InferenceData)
-        assert "posterior" in result.groups()
-        assert "posterior_predictive" in result.groups()
+        assert isinstance(result, xr.DataTree)
+        assert "posterior" in result
+        assert "posterior_predictive" in result
 
     def test_multi_unit_predictions(self, synthetic_control_data):
         """Test that predictions work correctly with multiple treated units."""
@@ -476,8 +623,8 @@ class TestWeightedSumFitterMultiUnit:
         pred = wsf.predict(X)
 
         # Check prediction structure
-        assert isinstance(pred, az.InferenceData)
-        assert "posterior_predictive" in pred.groups()
+        assert isinstance(pred, xr.DataTree)
+        assert "posterior_predictive" in pred
 
         # Check shapes - should be (chains, draws, obs_ind, treated_units)
         mu_shape = pred["posterior_predictive"]["mu"].shape
@@ -542,7 +689,7 @@ class TestWeightedSumFitterMultiUnit:
         result = wsf.fit(X, y, coords=coords)
 
         # Check that fitting was successful
-        assert isinstance(result, az.InferenceData)
+        assert isinstance(result, xr.DataTree)
 
         # Test prediction
         pred = wsf.predict(X)
@@ -834,8 +981,8 @@ class TestSyntheticDifferenceInDifferencesWeightFitter:
         )
         result = model.fit(X, y, coords=coords)
 
-        assert isinstance(result, az.InferenceData)
-        assert "posterior" in result.groups()
+        assert isinstance(result, xr.DataTree)
+        assert "posterior" in result
         assert "omega" in result.posterior
         assert "lam" in result.posterior
 
@@ -874,9 +1021,9 @@ class TestSoftmaxWeightedSumFitterMultiUnit:
         wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
         result = wsf.fit(X, y, coords=coords)
 
-        assert isinstance(result, az.InferenceData)
-        assert "posterior" in result.groups()
-        assert "posterior_predictive" in result.groups()
+        assert isinstance(result, xr.DataTree)
+        assert "posterior" in result
+        assert "posterior_predictive" in result
 
     def test_multi_unit_predictions(self, synthetic_control_data):
         """Test that predictions work correctly with multiple treated units."""
@@ -886,8 +1033,8 @@ class TestSoftmaxWeightedSumFitterMultiUnit:
         wsf.fit(X, y, coords=coords)
 
         pred = wsf.predict(X)
-        assert isinstance(pred, az.InferenceData)
-        assert "posterior_predictive" in pred.groups()
+        assert isinstance(pred, xr.DataTree)
+        assert "posterior_predictive" in pred
 
     def test_coefficients_structure(self, synthetic_control_data):
         """Test that beta weights sum to 1 along coeffs dim (simplex constraint)."""
@@ -908,8 +1055,8 @@ class TestSoftmaxWeightedSumFitterMultiUnit:
         wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
         result = wsf.fit(X, y, coords=coords)
 
-        assert isinstance(result, az.InferenceData)
-        assert "posterior" in result.groups()
+        assert isinstance(result, xr.DataTree)
+        assert "posterior" in result
         assert "beta" in result.posterior
 
     def test_scoring(self, synthetic_control_data):

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -190,8 +190,6 @@ class TestPyMCModel:
         assert "unit_0_r2_std" in score.index
         assert isinstance(predictions, xr.DataTree)
 
-
-
     def test_predict_preserves_datetime_obs_ind(self, rng, mock_pymc_sample):
         """Predict reattaches the caller's datetime coordinates to the DataTree."""
         dates = pd.date_range("2024-01-01", periods=8, freq="D")
@@ -408,8 +406,6 @@ def test_prior_merge_adds_groups_without_overwriting_sample_groups():
     )
 
 
-
-
 def test_propensity_score_fit_returns_datatree_groups(mock_pymc_sample):
     """Propensity fitting retains posterior, prior predictive, and PPC groups."""
     X = np.ones((8, 1))
@@ -428,8 +424,6 @@ def test_propensity_score_fit_returns_datatree_groups(mock_pymc_sample):
     assert {"posterior", "prior_predictive", "posterior_predictive"} <= set(
         idata.children
     )
-
-
 
 
 def test_propensity_fit_outcome_model_returns_datatree(mock_pymc_sample):

--- a/causalpy/tests/test_sdid_helpers.py
+++ b/causalpy/tests/test_sdid_helpers.py
@@ -22,7 +22,6 @@ individual steps without paying the cost of a full MCMC run.
 from types import SimpleNamespace
 from typing import Any, Protocol
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import pytest
@@ -174,7 +173,7 @@ class TestExtractWeightPosteriors:
                 "omega0": (("chain", "draw"), omega0_true),
             }
         )
-        idata = az.InferenceData(posterior=posterior)
+        idata = xr.DataTree.from_dict({"posterior": posterior})
         stub = _make_experiment_stub(model=SimpleNamespace(idata=idata))
 
         omega, omega0, lam, n_ch, n_dr = stub._extract_weight_posteriors()
@@ -262,12 +261,20 @@ class TestBuildReportingObjects:
 
         stub._build_reporting_objects(sc_all, toy_panel.T_pre, n_chains, n_draws)
 
-        # pre_pred / post_pred are InferenceData with a 'mu' variable in
+        # pre_pred / post_pred are DataTrees with a 'mu' variable in
         # the posterior_predictive group.
-        assert isinstance(stub.pre_pred, az.InferenceData)
-        assert isinstance(stub.post_pred, az.InferenceData)
+        assert isinstance(stub.pre_pred, xr.DataTree)
+        assert isinstance(stub.post_pred, xr.DataTree)
         assert "mu" in stub.pre_pred.posterior_predictive
         assert "mu" in stub.post_pred.posterior_predictive
+        for prediction, index in (
+            (stub.pre_pred, toy_panel.data.index[: toy_panel.T_pre]),
+            (stub.post_pred, toy_panel.data.index[toy_panel.T_pre :]),
+        ):
+            mu = prediction["posterior_predictive"].to_dataset()["mu"]
+            assert mu.dims == ("chain", "draw", "obs_ind", "treated_units")
+            np.testing.assert_array_equal(mu.coords["obs_ind"].values, index.values)
+            assert mu.coords["treated_units"].values.tolist() == toy_panel.treated_units
 
         # pre_impact / post_impact are xr.DataArrays with the correct dims.
         for impact, expected_len in (

--- a/causalpy/tests/test_three_period_its.py
+++ b/causalpy/tests/test_three_period_its.py
@@ -146,11 +146,10 @@ def test_three_period_pymc_datetime_index(datetime_data, mock_pymc_sample):
     assert isinstance(result.data_post_intervention, pd.DataFrame)
 
     # Check PyMC-specific types
-    import arviz as az
     import xarray as xr
 
-    assert isinstance(result.intervention_pred, az.InferenceData)
-    assert isinstance(result.post_intervention_pred, az.InferenceData)
+    assert isinstance(result.intervention_pred, xr.DataTree)
+    assert isinstance(result.post_intervention_pred, xr.DataTree)
     # For PyMC models, post_impact is always xarray DataArray
     assert isinstance(result.intervention_impact, xr.DataArray)
     assert isinstance(result.post_intervention_impact, xr.DataArray)
@@ -189,11 +188,10 @@ def test_three_period_pymc_integer_index(integer_data, mock_pymc_sample):
     assert isinstance(result.data_post_intervention, pd.DataFrame)
 
     # Check PyMC-specific types
-    import arviz as az
     import xarray as xr
 
-    assert isinstance(result.intervention_pred, az.InferenceData)
-    assert isinstance(result.post_intervention_pred, az.InferenceData)
+    assert isinstance(result.intervention_pred, xr.DataTree)
+    assert isinstance(result.post_intervention_pred, xr.DataTree)
     # For PyMC models, post_impact is always xarray DataArray
     assert isinstance(result.intervention_impact, xr.DataArray)
     assert isinstance(result.post_intervention_impact, xr.DataArray)
@@ -832,19 +830,25 @@ def test_intervention_pred_is_slice_of_post_pred(datetime_data, mock_pymc_sample
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    # For PyMC models, check that intervention_pred is InferenceData
-    assert hasattr(result.intervention_pred, "posterior_predictive")
+    # For PyMC models, intervention_pred is a DataTree.
+    import xarray as xr
 
-    # Extract mu from both
+    assert isinstance(result.intervention_pred, xr.DataTree)
+
     intervention_mu = result.intervention_pred.posterior_predictive["mu"]
     post_mu = result.post_pred.posterior_predictive["mu"]
-
-    # Check that intervention_mu is a subset of post_mu
     intervention_coords = result.data_intervention.index
     post_mu_intervention = post_mu.sel(obs_ind=intervention_coords)
 
-    # They should have the same shape
     assert intervention_mu.shape == post_mu_intervention.shape
+    xr.testing.assert_allclose(intervention_mu, post_mu_intervention)
+
+    post_intervention_mu = result.post_intervention_pred.posterior_predictive["mu"]
+    post_intervention_coords = result.data_post_intervention.index
+    xr.testing.assert_allclose(
+        post_intervention_mu,
+        post_mu.sel(obs_ind=post_intervention_coords),
+    )
 
 
 # ==============================================================================

--- a/causalpy/tests/test_timeseries_model_coverage.py
+++ b/causalpy/tests/test_timeseries_model_coverage.py
@@ -436,7 +436,9 @@ class TestStateSpaceTimeSeriesCoverage:
             sample_kwargs={"draws": 10, "tune": 10, "progressbar": False}
         )
 
-        with pytest.raises(ValueError, match="supports exactly one treated unit, got 2"):
+        with pytest.raises(
+            ValueError, match="supports exactly one treated unit, got 2"
+        ):
             model.build_model(y=y_multi)
 
     def test_build_model_rejects_empty_treated_units(self, sample_data):
@@ -453,7 +455,9 @@ class TestStateSpaceTimeSeriesCoverage:
             sample_kwargs={"draws": 10, "tune": 10, "progressbar": False}
         )
 
-        with pytest.raises(ValueError, match="supports exactly one treated unit, got 0"):
+        with pytest.raises(
+            ValueError, match="supports exactly one treated unit, got 0"
+        ):
             model.build_model(y=y_empty)
 
     def test_build_model_requires_treated_units_dimension(self, sample_data):

--- a/causalpy/tests/test_timeseries_model_coverage.py
+++ b/causalpy/tests/test_timeseries_model_coverage.py
@@ -224,6 +224,71 @@ class TestBayesianBasisExpansionTimeSeriesCoverage:
             model.predict(X_empty)
 
 
+class TestBayesianBasisExpansionTimeSeriesDataTree:
+    """DataTree migration contracts for BayesianBasisExpansionTimeSeries.
+
+    Uses MockComponent so these tests do not depend on pymc-marketing default
+    components (which may be unavailable or incompatible in the pymc 6 env).
+    """
+
+    @pytest.fixture
+    def sample_data(self):
+        """Create sample time series data."""
+        dates = pd.date_range(start="2020-01-01", end="2020-03-01", freq="D")
+        n_obs = len(dates)
+        y_values = np.random.default_rng(0).normal(size=n_obs)
+
+        X_da = xr.DataArray(
+            np.zeros((n_obs, 0)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": dates, "coeffs": []},
+        )
+        y_da = xr.DataArray(
+            y_values.reshape(-1, 1),
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": dates, "treated_units": ["unit_0"]},
+        )
+        return X_da, y_da
+
+    def test_fit_returns_datatree_with_expected_groups(
+        self, sample_data, mock_pymc_sample
+    ):
+        """fit() returns a DataTree with posterior / prior / predictive groups."""
+        X_da, y_da = sample_data
+        model = cp.pymc_models.BayesianBasisExpansionTimeSeries(
+            trend_component=MockComponent(),
+            seasonality_component=MockComponent(),
+            sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+        )
+
+        idata = model.fit(X_da, y_da)
+
+        assert isinstance(idata, xr.DataTree)
+        assert "posterior" in idata
+        assert "prior_predictive" in idata
+        assert "posterior_predictive" in idata
+
+    def test_predict_preserves_datetime_obs_ind(self, sample_data, mock_pymc_sample):
+        """predict() keeps the exact datetime obs_ind coordinates from X."""
+        X_da, y_da = sample_data
+        model = cp.pymc_models.BayesianBasisExpansionTimeSeries(
+            trend_component=MockComponent(),
+            seasonality_component=MockComponent(),
+            sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+        )
+        model.fit(X_da, y_da)
+
+        pred = model.predict(X_da)
+
+        assert isinstance(pred, xr.DataTree)
+        assert "posterior_predictive" in pred
+        obs_ind = pred["posterior_predictive"]["mu"].coords["obs_ind"]
+        np.testing.assert_array_equal(
+            obs_ind.values.astype("datetime64[ns]"),
+            X_da.coords["obs_ind"].values.astype("datetime64[ns]"),
+        )
+
+
 class TestStateSpaceTimeSeriesCoverage:
     """Test uncovered branches in StateSpaceTimeSeries."""
 
@@ -232,7 +297,7 @@ class TestStateSpaceTimeSeriesCoverage:
         """Create sample time series data."""
         dates = pd.date_range(start="2020-01-01", end="2020-02-01", freq="D")
         n_obs = len(dates)
-        y_values = np.random.randn(n_obs) + 10
+        y_values = np.random.default_rng(0).normal(size=n_obs) + 10
 
         y_da = xr.DataArray(
             y_values.reshape(-1, 1),
@@ -357,6 +422,82 @@ class TestStateSpaceTimeSeriesCoverage:
         with pytest.raises(ValueError, match="y must have at least one observation"):
             model.build_model(y=y_bad)
 
+    def test_build_model_rejects_multiple_treated_units(self, sample_data):
+        """State-space models reject unsupported multi-unit outcomes."""
+        y_multi = xr.DataArray(
+            np.repeat(sample_data.values, 2, axis=1),
+            dims=["obs_ind", "treated_units"],
+            coords={
+                "obs_ind": sample_data.coords["obs_ind"],
+                "treated_units": ["first", "second"],
+            },
+        )
+        model = cp.pymc_models.StateSpaceTimeSeries(
+            sample_kwargs={"draws": 10, "tune": 10, "progressbar": False}
+        )
+
+        with pytest.raises(ValueError, match="supports exactly one treated unit, got 2"):
+            model.build_model(y=y_multi)
+
+    def test_build_model_rejects_empty_treated_units(self, sample_data):
+        """State-space models reject empty treated-unit dimensions clearly."""
+        y_empty = xr.DataArray(
+            np.empty((sample_data.sizes["obs_ind"], 0)),
+            dims=["obs_ind", "treated_units"],
+            coords={
+                "obs_ind": sample_data.coords["obs_ind"],
+                "treated_units": [],
+            },
+        )
+        model = cp.pymc_models.StateSpaceTimeSeries(
+            sample_kwargs={"draws": 10, "tune": 10, "progressbar": False}
+        )
+
+        with pytest.raises(ValueError, match="supports exactly one treated unit, got 0"):
+            model.build_model(y=y_empty)
+
+    def test_build_model_requires_treated_units_dimension(self, sample_data):
+        """State-space models reject 1D outcomes before score can fail."""
+        y_1d = xr.DataArray(
+            sample_data.values[:, 0],
+            dims=["obs_ind"],
+            coords={"obs_ind": sample_data.coords["obs_ind"]},
+        )
+        model = cp.pymc_models.StateSpaceTimeSeries(
+            sample_kwargs={"draws": 10, "tune": 10, "progressbar": False}
+        )
+
+        with pytest.raises(ValueError, match="requires a treated_units dimension"):
+            model.build_model(y=y_1d)
+
+    def test_fit_and_score_support_unlabeled_single_treated_unit(
+        self, sample_data, mock_pymc_sample
+    ):
+        """A singleton treated-unit dimension uses its xarray index label."""
+        y_unlabeled = xr.DataArray(
+            sample_data.values,
+            dims=["obs_ind", "treated_units"],
+            coords={"obs_ind": sample_data.coords["obs_ind"]},
+        )
+        X = xr.DataArray(
+            np.zeros((y_unlabeled.sizes["obs_ind"], 0)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": y_unlabeled.coords["obs_ind"], "coeffs": []},
+        )
+        model = cp.pymc_models.StateSpaceTimeSeries(
+            level_order=1,
+            seasonal_length=7,
+            sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+        )
+
+        prediction = model.fit(X=X, y=y_unlabeled)
+        score = model.score(X=X, y=y_unlabeled)
+
+        assert prediction["posterior_predictive"]["y_hat"].coords[
+            "treated_units"
+        ].values.tolist() == [0]
+        assert "unit_0_r2" in score
+
     def test_fit_y_none(self):
         """Test error when y is None in fit."""
         model = cp.pymc_models.StateSpaceTimeSeries(
@@ -368,6 +509,101 @@ class TestStateSpaceTimeSeriesCoverage:
             match="y must be provided for StateSpaceTimeSeries.fit",
         ):
             model.fit(y=None)
+
+    def test_fit_predict_datatree_uses_obs_ind_not_time(
+        self, sample_data, mock_pymc_sample
+    ):
+        """fit/predict return DataTree with y_hat/mu on obs_ind (not time).
+
+        Also checks OOS predict preserves the exact supplied datetime obs_ind.
+        """
+        y_da = sample_data.assign_coords(treated_units=["treated"])
+        dates = y_da.coords["obs_ind"].values
+        dummy_X = xr.DataArray(
+            np.zeros((len(dates), 0)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": dates, "coeffs": []},
+        )
+        model = cp.pymc_models.StateSpaceTimeSeries(
+            level_order=1,
+            seasonal_length=7,
+            sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+        )
+
+        idata = model.fit(X=dummy_X, y=y_da)
+        assert isinstance(idata, xr.DataTree)
+        assert "posterior_predictive" in idata
+        assert model.idata is idata
+        fitted_pp = model.idata["posterior_predictive"]
+        assert "y_hat" in fitted_pp and "mu" in fitted_pp
+        assert set(fitted_pp.to_dataset().data_vars) == {"y_hat", "mu"}
+        assert "obs_ind" in fitted_pp["y_hat"].dims
+        np.testing.assert_array_equal(
+            fitted_pp["y_hat"].coords["treated_units"].values,
+            y_da.coords["treated_units"].values,
+        )
+        assert fitted_pp["y_hat"].dims == (
+            "chain",
+            "draw",
+            "obs_ind",
+            "treated_units",
+        )
+        np.testing.assert_array_equal(
+            fitted_pp["y_hat"].coords["obs_ind"].values, dates
+        )
+
+        in_sample = model.predict(X=dummy_X, out_of_sample=False)
+        assert isinstance(in_sample, xr.DataTree)
+        in_pp = in_sample["posterior_predictive"]
+        assert "y_hat" in in_pp and "mu" in in_pp
+        assert set(in_pp.to_dataset().data_vars) == {"y_hat", "mu"}
+        assert "obs_ind" in in_pp["y_hat"].dims
+        assert "time" not in in_pp["y_hat"].dims
+        assert "obs_ind" in in_pp["mu"].dims
+        assert "time" not in in_pp["mu"].dims
+        np.testing.assert_array_equal(
+            in_pp["y_hat"].coords["treated_units"].values,
+            y_da.coords["treated_units"].values,
+        )
+        assert in_pp["y_hat"].dims == (
+            "chain",
+            "draw",
+            "obs_ind",
+            "treated_units",
+        )
+        np.testing.assert_array_equal(in_pp["y_hat"].coords["obs_ind"].values, dates)
+
+        oos_dates = pd.date_range(
+            start=pd.Timestamp(dates[-1]) + pd.Timedelta(days=1),
+            periods=5,
+            freq="D",
+        )
+        X_oos = xr.DataArray(
+            np.zeros((len(oos_dates), 0)),
+            dims=["obs_ind", "coeffs"],
+            coords={"obs_ind": oos_dates, "coeffs": []},
+        )
+        oos = model.predict(X=X_oos, out_of_sample=True)
+        assert isinstance(oos, xr.DataTree)
+        oos_pp = oos["posterior_predictive"]
+        assert "y_hat" in oos_pp and "mu" in oos_pp
+        assert set(oos_pp.to_dataset().data_vars) == {"y_hat", "mu"}
+        assert "obs_ind" in oos_pp["y_hat"].dims
+        assert "time" not in oos_pp["y_hat"].dims
+        np.testing.assert_array_equal(
+            oos_pp["y_hat"].coords["obs_ind"].values.astype("datetime64[ns]"),
+            oos_dates.values.astype("datetime64[ns]"),
+        )
+        np.testing.assert_array_equal(
+            oos_pp["y_hat"].coords["treated_units"].values,
+            y_da.coords["treated_units"].values,
+        )
+        assert oos_pp["y_hat"].dims == (
+            "chain",
+            "draw",
+            "obs_ind",
+            "treated_units",
+        )
 
     def test_predict_out_of_sample_x_none(self, sample_data):
         """Test error when X is None for out-of-sample predictions."""

--- a/causalpy/tests/test_variable_selection_priors.py
+++ b/causalpy/tests/test_variable_selection_priors.py
@@ -15,6 +15,7 @@
 import numpy as np
 import pymc as pm
 import pytest
+import xarray as xr
 
 from causalpy.variable_selection_priors import (
     HorseshoePrior,
@@ -109,6 +110,56 @@ def test_create_prior_normal(coords, sample_data):
 
         assert "beta" in model.named_vars
         assert beta.name == "beta"
+
+
+def test_inclusion_probabilities_supports_datatree_posterior():
+    """Inclusion summaries operate on ArviZ 1 DataArray extracts."""
+    idata = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset(
+                {
+                    "gamma_beta": (
+                        ("chain", "draw", "features"),
+                        np.array([[[1, 0], [1, 1]], [[0, 0], [1, 0]]]),
+                    )
+                }
+            )
+        }
+    )
+
+    summary = VariableSelectionPrior("spike_and_slab").get_inclusion_probabilities(
+        idata, "beta"
+    )
+
+    np.testing.assert_allclose(summary["prob"], [0.75, 0.25])
+    assert summary["selected"].tolist() == [True, False]
+    np.testing.assert_allclose(summary["gamma_mean"], [0.75, 0.25])
+
+
+def test_shrinkage_factors_supports_datatree_posterior():
+    """Horseshoe summaries broadcast DataArray posterior draws by sample."""
+    idata = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset(
+                {
+                    "tau_beta": (
+                        ("chain", "draw"),
+                        np.array([[2.0, 3.0], [4.0, 5.0]]),
+                    ),
+                    "lambda_tilde_beta": (
+                        ("chain", "draw", "features"),
+                        np.array([[[1.0, 2.0], [3.0, 4.0]], [[5.0, 6.0], [7.0, 8.0]]]),
+                    ),
+                }
+            )
+        }
+    )
+
+    summary = VariableSelectionPrior("horseshoe").get_shrinkage_factors(idata, "beta")
+
+    np.testing.assert_allclose(summary["shrinkage_factor"], [16.5, 20.0])
+    np.testing.assert_allclose(summary["lambda_tilde"], [4.0, 5.0])
+    np.testing.assert_allclose(summary["tau"], 3.5)
 
 
 def test_convenience_function_with_custom_hyperparams(coords):

--- a/causalpy/variable_selection_priors.py
+++ b/causalpy/variable_selection_priors.py
@@ -531,9 +531,7 @@ class VariableSelectionPrior:
             raise ValueError(f"Could not find '{lambda_tilde_name}' in posterior")
 
         tau = az.extract(idata, group="posterior", var_names=tau_name)
-        lambda_tilde = az.extract(
-            idata, group="posterior", var_names=lambda_tilde_name
-        )
+        lambda_tilde = az.extract(idata, group="posterior", var_names=lambda_tilde_name)
         shrinkage_factor = (tau * lambda_tilde).mean(dim="sample")
         lambda_tilde_mean = lambda_tilde.mean(dim="sample")
 

--- a/causalpy/variable_selection_priors.py
+++ b/causalpy/variable_selection_priors.py
@@ -438,8 +438,8 @@ class VariableSelectionPrior:
 
         Parameters
         ----------
-        idata : arviz.InferenceData
-            Fitted model inference data
+        idata : xarray.DataTree
+            Fitted model data tree
         param_name : str
             Name of the coefficient parameter (must match name in create_prior)
         threshold : float, default=0.5
@@ -476,25 +476,17 @@ class VariableSelectionPrior:
         import arviz as az
 
         # Extract gamma values
-        gamma = az.extract(idata.posterior[gamma_name])
+        gamma = az.extract(idata, group="posterior", var_names=gamma_name)
+        probabilities = (gamma > threshold).mean(dim="sample")
+        gamma_mean = gamma.mean(dim="sample")
 
-        # Compute inclusion probabilities
-        probabilities = (gamma > threshold).mean(dim="sample").to_array()
-        gamma_mean = gamma.mean(dim="sample").to_array()
-        selected = probabilities > threshold
-
-        summary = {
-            "probabilities": probabilities,
-            "selected": selected,
-            "gamma_mean": gamma_mean,
-        }
-        probs = summary["probabilities"].T
-        df = pd.DataFrame(index=list(range(len(probs))))
-
-        df["prob"] = probs
-        df["selected"] = summary["selected"].T
-        df["gamma_mean"] = summary["gamma_mean"].T
-        return df
+        return pd.DataFrame(
+            {
+                "prob": np.asarray(probabilities).reshape(-1),
+                "selected": np.asarray(probabilities > threshold).reshape(-1),
+                "gamma_mean": np.asarray(gamma_mean).reshape(-1),
+            }
+        )
 
     def get_shrinkage_factors(self, idata, param_name: str) -> pd.DataFrame:
         """
@@ -505,8 +497,8 @@ class VariableSelectionPrior:
 
         Parameters
         ----------
-        idata : arviz.InferenceData
-            Fitted model inference data
+        idata : xarray.DataTree
+            Fitted model data tree
         param_name : str
             Name of the coefficient parameter
 
@@ -538,27 +530,20 @@ class VariableSelectionPrior:
         if lambda_tilde_name not in idata.posterior:
             raise ValueError(f"Could not find '{lambda_tilde_name}' in posterior")
 
-        # Extract components
-        tau = az.extract(idata.posterior[tau_name]).to_array()
-        lambda_tilde = az.extract(idata.posterior[lambda_tilde_name]).to_array()
-
-        shrinkage_factor = np.array(
-            [tau[0, i] * lambda_tilde[0, :, :] for i in range(len(tau))]
+        tau = az.extract(idata, group="posterior", var_names=tau_name)
+        lambda_tilde = az.extract(
+            idata, group="posterior", var_names=lambda_tilde_name
         )
-        shrinkage_factor = shrinkage_factor.mean(axis=2)
+        shrinkage_factor = (tau * lambda_tilde).mean(dim="sample")
+        lambda_tilde_mean = lambda_tilde.mean(dim="sample")
 
-        summary = {
-            "shrinkage_factors": shrinkage_factor,
-            "tau": tau.mean(),
-            "lambda_tilde": lambda_tilde.mean(dim=("sample")),
-        }
-        probs = summary["shrinkage_factors"].T
-        df = pd.DataFrame(index=list(range(len(probs))))
-        df["shrinkage_factor"] = probs
-
-        df["lambda_tilde"] = summary["lambda_tilde"].T
-        df["tau"] = np.mean(tau).item()
-        return df
+        return pd.DataFrame(
+            {
+                "shrinkage_factor": np.asarray(shrinkage_factor).reshape(-1),
+                "lambda_tilde": np.asarray(lambda_tilde_mean).reshape(-1),
+                "tau": float(tau.mean()),
+            }
+        )
 
 
 def create_variable_selection_prior(


### PR DESCRIPTION
## Summary
- Port PyMC 6/ArviZ 1 inference-result handling to xarray DataTree.
- Preserve predictive, coordinate, counterfactual, and StateSpace contracts.
- Add focused regression coverage for DataTree group operations and warning-free imports.

Parent: #1038

## Verification
- Focused PyMC/DataTree migration gates passed in `mamba_temp_env_issue_1042`.

Closes #1042