### PR TITLE
Verify pymc-forecast adapter on PyMC 6

### DIFF
--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -67,6 +67,7 @@ draw-coherent posterior subsample used for prediction; the *full* fit result
 
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import Any
 
 import arviz as az
@@ -275,9 +276,15 @@ class PyMCForecastModel:
         # one posterior subsample, shared by every predictive call: draw i of
         # the pre-period fit and draw i of the counterfactual come from the
         # same parameter draw
-        self._posterior = self.forecaster.draw_posterior(
-            self.num_samples, random_seed=self.random_seed
+        posterior_context = (
+            self.forecaster.model
+            if isinstance(self.forecaster, self._pf.Forecaster)
+            else nullcontext()
         )
+        with posterior_context:
+            self._posterior = self.forecaster.draw_posterior(
+                self.num_samples, random_seed=self.random_seed
+            )
         self.idata = xr.DataTree.from_dict({"posterior": self._posterior})
         return self.idata
 

--- a/causalpy/pymc_forecast_models.py
+++ b/causalpy/pymc_forecast_models.py
@@ -88,7 +88,7 @@ def _import_pymc_forecast():
         raise ImportError(
             "PyMCForecastModel requires the optional dependency 'pymc-forecast'. "
             "Install it with `pip install causalpy[forecast]` or "
-            "`pip install 'pymc-forecast[extras]>=0.2'`."
+            "`pip install 'pymc-forecast[extras]>=0.2,<0.3'`."
         ) from err
     return pymc_forecast
 

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -66,6 +66,13 @@ sample_kwargs = {
     "chains": 2,
 }
 
+fast_sample_kwargs = {
+    "draws": 100,
+    "tune": 100,
+    "chains": 2,
+    "progressbar": False,
+}
+
 TRUE_EFFECT = 2.0
 
 
@@ -116,6 +123,16 @@ def make_forecast_model():
         linear_model,
         forecaster_kwargs=dict(sample_kwargs),
         num_samples=200,
+        random_seed=42,
+    )
+
+
+def make_fast_forecast_model():
+    """Small HMC schedule for forecast-placebo control-flow tests."""
+    return PyMCForecastModel(
+        linear_model,
+        forecaster_kwargs=dict(fast_sample_kwargs),
+        num_samples=50,
         random_seed=42,
     )
 
@@ -370,6 +387,19 @@ def test_print_coefficients_before_fit_raises():
         make_forecast_model().print_coefficients([])
 
 
+def test_print_coefficients_without_scalar_parameters(capsys):
+    """Time-varying forecasting latents do not require scalar parameters."""
+    model = make_forecast_model()
+    posterior = xr.Dataset({"latent": (("chain", "draw", "time"), np.ones((1, 2, 3)))})
+    model.idata = xr.DataTree.from_dict({"posterior": posterior})
+
+    model.print_coefficients([])
+
+    assert capsys.readouterr().out == (
+        "Model parameters:\n  (no scalar parameters in posterior)\n"
+    )
+
+
 @pytest.mark.integration
 def test_three_period_design(its_data):
     """treatment_end_time splitting works on the forecast backend's output."""
@@ -509,7 +539,7 @@ class TestPlaceboInTime:
         from causalpy.checks.base import clone_model
 
         df, _ = its_data
-        base_model = forecast_result.model
+        base_model = make_fast_forecast_model()
 
         def factory(data, treatment_time):
             return cp.InterruptedTimeSeries(
@@ -522,12 +552,7 @@ class TestPlaceboInTime:
         check = cp.checks.PlaceboInTime(
             n_folds=2,
             experiment_factory=factory,
-            sample_kwargs={
-                "draws": 100,
-                "tune": 100,
-                "chains": 2,
-                "progressbar": False,
-            },
+            sample_kwargs=dict(fast_sample_kwargs),
             random_seed=42,
         )
         result = check.run(forecast_result)
@@ -543,7 +568,7 @@ class TestPlaceboInTime:
     ):
         """The PipelineContext factory path preserves the forecast backend."""
         df, treatment_time = its_data
-        configured_model = make_forecast_model()
+        configured_model = make_fast_forecast_model()
         context = cp.PipelineContext(data=df)
         context.experiment = forecast_result
         context.experiment_config = {
@@ -555,12 +580,7 @@ class TestPlaceboInTime:
 
         check = cp.checks.PlaceboInTime(
             n_folds=1,
-            sample_kwargs={
-                "draws": 100,
-                "tune": 100,
-                "chains": 2,
-                "progressbar": False,
-            },
+            sample_kwargs=dict(fast_sample_kwargs),
             random_seed=42,
         )
         result = check.run(forecast_result, context)

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -202,6 +202,16 @@ class TestRoundTripAgainstPyMCBackend:
         plot_df = forecast_result.get_plot_data_bayesian()
         assert {"prediction", "impact"}.issubset(plot_df.columns)
 
+    def test_summaries_and_plot_data_without_plotting(self, forecast_result, capsys):
+        """Forecast summary and plot-data contracts remain observable when
+        generic plotting is unavailable."""
+        forecast_result.summary()
+        assert "Model parameters:" in capsys.readouterr().out
+        summary = forecast_result.effect_summary()
+        assert len(summary.text) > 0
+        plot_df = forecast_result.get_plot_data_bayesian()
+        assert {"prediction", "impact"}.issubset(plot_df.columns)
+
     def test_experiment_reports_bayesian_backend(self, forecast_result):
         assert forecast_result._model_backend.is_bayesian
         assert forecast_result._model_backend.kind == "pymc-forecast"
@@ -373,6 +383,24 @@ def test_statespace_models_rejected():
         PyMCForecastModel(linear_model, forecaster=pymc_forecast.StatespaceForecaster)
 
 
+def test_statespace_model_instances_rejected():
+    """The StatespaceModel branch cannot silently use noisy predictions."""
+
+    class UnsupportedStatespaceModel(pymc_forecast.StatespaceModel):
+        def statespace(self, data, covariates):
+            raise AssertionError(
+                "The rejection guard must run before model construction."
+            )
+
+        def priors(self, ss_mod, data, covariates):
+            raise AssertionError(
+                "The rejection guard must run before model construction."
+            )
+
+    with pytest.raises(NotImplementedError, match="pymc-forecast/issues/50"):
+        PyMCForecastModel(UnsupportedStatespaceModel())
+
+
 def test_clone_returns_unfitted_copy_with_same_config():
     """clone_model dispatches to _clone; the copy is unfitted but identically
     configured, so sensitivity checks can refit the same model spec."""
@@ -498,6 +526,28 @@ class TestPlaceboInTime:
             assert fold_model is not base_model
             assert fold_model.idata is not None
 
+    def test_placebo_context_factory_clones_forecast_model(
+        self, its_data, forecast_result
+    ):
+        """The PipelineContext factory path preserves the forecast backend."""
+        df, treatment_time = its_data
+        context = cp.PipelineContext(data=df)
+        context.experiment = forecast_result
+        context.experiment_config = {
+            "method": cp.InterruptedTimeSeries,
+            "treatment_time": treatment_time,
+            "formula": "y ~ 1 + t",
+            "model": make_forecast_model(),
+        }
+
+        result = cp.checks.PlaceboInTime(n_folds=1, random_seed=42).run(
+            forecast_result, context
+        )
+        assert len(result.metadata["fold_results"]) == 1
+        assert isinstance(
+            result.metadata["fold_results"][0].experiment.model, PyMCForecastModel
+        )
+
 
 def test_pymc_forecast_02_prediction_schema_contract():
     """The optional extra's pinned 0.2 schema matches adapter consumption."""
@@ -523,8 +573,9 @@ def test_pymc_forecast_02_prediction_schema_contract():
 def test_missing_forecast_extra_has_actionable_install_error(monkeypatch):
     """The optional dependency boundary fails only at forecast-model creation."""
     monkeypatch.setitem(sys.modules, "pymc_forecast", None)
-    with pytest.raises(ImportError, match=r"pip install causalpy\[forecast\]"):
+    with pytest.raises(ImportError, match=r"pip install causalpy\[forecast\]") as error:
         _import_pymc_forecast()
+    assert "pymc-forecast[extras]>=0.2,<0.3" in str(error.value)
 
 
 def test_default_forecaster_is_hmc(forecast_result):

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -14,6 +14,9 @@
 """Tests for the pymc-forecast model-provider adapter behind
 InterruptedTimeSeries (issue #1013)."""
 
+import sys
+from importlib.metadata import version
+
 import matplotlib
 
 matplotlib.use("Agg")
@@ -30,7 +33,7 @@ from causalpy.experiments.model_adapter import (
     PyMCForecastAdapter,
     make_model_adapter,
 )
-from causalpy.pymc_forecast_models import PyMCForecastModel
+from causalpy.pymc_forecast_models import PyMCForecastModel, _import_pymc_forecast
 
 pymc_forecast = pytest.importorskip("pymc_forecast")
 
@@ -444,6 +447,7 @@ def test_fit_idata_exposes_full_fit_result(forecast_result):
     posterior used for prediction."""
     model = forecast_result.model
     full = model.fit_idata
+    assert isinstance(full, xr.DataTree)
     assert hasattr(full, "sample_stats")
     assert full.posterior.sizes["draw"] == sample_kwargs["draws"]
     thinned = forecast_result.idata
@@ -493,3 +497,100 @@ class TestPlaceboInTime:
             assert isinstance(fold_model, PyMCForecastModel)
             assert fold_model is not base_model
             assert fold_model.idata is not None
+
+
+def test_pymc_forecast_02_prediction_schema_contract():
+    """The optional extra's pinned 0.2 schema matches adapter consumption."""
+    assert version("pymc-forecast").startswith("0.2.")
+    assert {
+        "OBS_VAR": pymc_forecast.OBS_VAR,
+        "MU_VAR": pymc_forecast.MU_VAR,
+        "FORECAST_VAR": pymc_forecast.FORECAST_VAR,
+        "MU_FORECAST_VAR": pymc_forecast.MU_FORECAST_VAR,
+        "TIME_DIM": pymc_forecast.TIME_DIM,
+        "FUTURE_DIM": pymc_forecast.FUTURE_DIM,
+    } == {
+        "OBS_VAR": "obs",
+        "MU_VAR": "mu",
+        "FORECAST_VAR": "forecast",
+        "MU_FORECAST_VAR": "mu_future",
+        "TIME_DIM": "time",
+        "FUTURE_DIM": "time_future",
+    }
+    assert callable(pymc_forecast.prediction_samples)
+
+
+def test_missing_forecast_extra_has_actionable_install_error(monkeypatch):
+    """The optional dependency boundary fails only at forecast-model creation."""
+    monkeypatch.setitem(sys.modules, "pymc_forecast", None)
+    with pytest.raises(ImportError, match=r"pip install causalpy\[forecast\]"):
+        _import_pymc_forecast()
+
+
+def test_default_forecaster_is_hmc(forecast_result):
+    """The default backend executes the documented HMC forecaster."""
+    assert isinstance(forecast_result.model.forecaster, pymc_forecast.HMCForecaster)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    ("forecaster", "forecaster_kwargs"),
+    [
+        pytest.param(
+            pymc_forecast.Forecaster,
+            {"num_steps": 1_000, "progressbar": False},
+            id="advi",
+        ),
+        pytest.param(
+            pymc_forecast.PathfinderForecaster,
+            {
+                "pathfinder_kwargs": {
+                    "num_paths": 1,
+                    "num_draws": 50,
+                    "num_draws_per_path": 50,
+                    "num_elbo_draws": 5,
+                    "parallel": False,
+                },
+                "progressbar": False,
+            },
+            id="pathfinder",
+        ),
+    ],
+)
+def test_approximate_forecasters_fit_and_predict_datatrees(
+    its_data, forecaster, forecaster_kwargs
+):
+    """ADVI and Pathfinder fit, sample, predict, and forecast through the
+    adapter's DataTree protocol without making an accuracy claim."""
+    df, treatment_time = its_data
+    num_samples = 10
+    result = cp.InterruptedTimeSeries(
+        df,
+        treatment_time,
+        formula="y ~ 1 + t",
+        model=PyMCForecastModel(
+            linear_model,
+            forecaster=forecaster,
+            forecaster_kwargs=forecaster_kwargs,
+            num_samples=num_samples,
+            random_seed=42,
+        ),
+    )
+
+    model = result.model
+    assert isinstance(model.forecaster, forecaster)
+    assert model.forecaster.is_fitted
+    assert isinstance(model.idata, xr.DataTree)
+    assert model.idata.posterior.sizes["draw"] == num_samples
+    assert list(result.score.index) == ["unit_0_r2", "unit_0_r2_std"]
+    for pred, expected_index in (
+        (result.pre_pred, result.datapre.index),
+        (result.post_pred, result.datapost.index),
+    ):
+        assert isinstance(pred, xr.DataTree)
+        pp = pred.posterior_predictive
+        assert set(pp.data_vars) == {"mu", "y_hat"}
+        assert pp.mu.dims == ("chain", "draw", "obs_ind", "treated_units")
+        pd.testing.assert_index_equal(
+            pd.Index(pp.obs_ind.values), expected_index, check_names=False
+        )

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -400,6 +400,24 @@ def test_print_coefficients_without_scalar_parameters(capsys):
     )
 
 
+def test_print_coefficients_skips_non_scalar_parameters(capsys):
+    """Only scalar posterior variables are reported as model parameters."""
+    model = make_forecast_model()
+    posterior = xr.Dataset(
+        {
+            "sigma": (("chain", "draw"), np.ones((1, 2))),
+            "latent": (("chain", "draw", "time"), np.ones((1, 2, 3))),
+        }
+    )
+    model.idata = xr.DataTree.from_dict({"posterior": posterior})
+
+    model.print_coefficients([])
+
+    output = capsys.readouterr().out
+    assert "sigma" in output
+    assert "latent" not in output
+
+
 @pytest.mark.integration
 def test_three_period_design(its_data):
     """treatment_end_time splitting works on the forecast backend's output."""
@@ -408,7 +426,7 @@ def test_three_period_design(its_data):
         df,
         treatment_time,
         formula="y ~ 1 + t",
-        model=make_forecast_model(),
+        model=make_fast_forecast_model(),
         treatment_end_time=df.index[85],
     )
     assert result.intervention_pred.posterior_predictive["mu"].sizes["obs_ind"] == 15
@@ -509,6 +527,23 @@ def test_to_inference_data_yields_datatree_posterior_predictive():
         pp["mu"].coords["obs_ind"].values.astype("datetime64[ns]"),
         obs_ind.astype("datetime64[ns]"),
     )
+
+
+def test_to_inference_data_renames_series_dimension():
+    """Upstream multi-series predictions retain their unit coordinate."""
+    model = make_forecast_model()
+    obs_ind = pd.date_range("2020-01-01", periods=3, freq="D").to_numpy()
+    samples = xr.DataArray(
+        np.ones((1, 2, 3, 2)),
+        dims=("chain", "draw", "obs_ind", "series"),
+        coords={"series": ["unit_a", "unit_b"]},
+    )
+
+    out = model._to_inference_data(samples, samples.copy(), obs_ind)
+
+    pp = out["posterior_predictive"]
+    assert pp["mu"].dims == ("chain", "draw", "obs_ind", "treated_units")
+    assert list(pp["mu"].treated_units.values) == ["unit_a", "unit_b"]
 
 
 @pytest.mark.integration

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -295,8 +295,8 @@ def test_covariate_free_future_index_path(its_data):
         formula="y ~ 0",
         model=PyMCForecastModel(
             LocalLevel(),
-            forecaster_kwargs=dict(sample_kwargs),
-            num_samples=200,
+            forecaster_kwargs=dict(fast_sample_kwargs),
+            num_samples=50,
             random_seed=42,
         ),
     )
@@ -405,16 +405,17 @@ def test_print_coefficients_skips_non_scalar_parameters(capsys):
     model = make_forecast_model()
     posterior = xr.Dataset(
         {
-            "sigma": (("chain", "draw"), np.ones((1, 2))),
+            "sigma": (("chain", "draw"), np.full((1, 2), 1.23456)),
             "latent": (("chain", "draw", "time"), np.ones((1, 2, 3))),
         }
     )
     model.idata = xr.DataTree.from_dict({"posterior": posterior})
 
-    model.print_coefficients([])
+    model.print_coefficients([], round_to=3)
 
     output = capsys.readouterr().out
     assert "sigma" in output
+    assert "1.23" in output
     assert "latent" not in output
 
 
@@ -657,6 +658,13 @@ def test_missing_forecast_extra_has_actionable_install_error(monkeypatch):
 def test_default_forecaster_is_hmc(forecast_result):
     """The default backend executes the documented HMC forecaster."""
     assert isinstance(forecast_result.model.forecaster, pymc_forecast.HMCForecaster)
+
+
+def test_default_forecaster_configuration_is_empty():
+    """An omitted forecaster configuration constructs a usable HMC backend."""
+    model = PyMCForecastModel(linear_model)
+    assert isinstance(model.forecaster, pymc_forecast.HMCForecaster)
+    assert model.forecaster_kwargs == {}
 
 
 @pytest.mark.integration

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -202,9 +202,16 @@ class TestRoundTripAgainstPyMCBackend:
         plot_df = forecast_result.get_plot_data_bayesian()
         assert {"prediction", "impact"}.issubset(plot_df.columns)
 
-    def test_summaries_and_plot_data_without_plotting(self, forecast_result, capsys):
+    def test_summaries_and_plot_data_without_plotting(
+        self, forecast_result, capsys, monkeypatch
+    ):
         """Forecast summary and plot-data contracts remain observable when
         generic plotting is unavailable."""
+
+        def fail_if_plot_called(*args, **kwargs):
+            raise AssertionError("summary helpers must not call plot()")
+
+        monkeypatch.setattr(forecast_result, "plot", fail_if_plot_called)
         forecast_result.summary()
         assert "Model parameters:" in capsys.readouterr().out
         summary = forecast_result.effect_summary()
@@ -356,6 +363,11 @@ def test_unfit_adapter_has_no_idata_or_coefficients():
         _ = adapter.idata
     with pytest.raises(NotImplementedError, match="design-matrix coefficients"):
         adapter.coefficients()
+
+
+def test_print_coefficients_before_fit_raises():
+    with pytest.raises(RuntimeError, match="has not been fit"):
+        make_forecast_model().print_coefficients([])
 
 
 @pytest.mark.integration
@@ -531,22 +543,31 @@ class TestPlaceboInTime:
     ):
         """The PipelineContext factory path preserves the forecast backend."""
         df, treatment_time = its_data
+        configured_model = make_forecast_model()
         context = cp.PipelineContext(data=df)
         context.experiment = forecast_result
         context.experiment_config = {
             "method": cp.InterruptedTimeSeries,
             "treatment_time": treatment_time,
             "formula": "y ~ 1 + t",
-            "model": make_forecast_model(),
+            "model": configured_model,
         }
 
-        result = cp.checks.PlaceboInTime(n_folds=1, random_seed=42).run(
-            forecast_result, context
+        check = cp.checks.PlaceboInTime(
+            n_folds=1,
+            sample_kwargs={
+                "draws": 100,
+                "tune": 100,
+                "chains": 2,
+                "progressbar": False,
+            },
+            random_seed=42,
         )
-        assert len(result.metadata["fold_results"]) == 1
-        assert isinstance(
-            result.metadata["fold_results"][0].experiment.model, PyMCForecastModel
-        )
+        result = check.run(forecast_result, context)
+        fold_model = result.metadata["fold_results"][0].experiment.model
+        assert isinstance(fold_model, PyMCForecastModel)
+        assert fold_model is not configured_model
+        assert fold_model.idata is not None
 
 
 def test_pymc_forecast_02_prediction_schema_contract():

--- a/causalpy/tests/test_pymc_forecast_adapter.py
+++ b/causalpy/tests/test_pymc_forecast_adapter.py
@@ -582,6 +582,11 @@ def test_approximate_forecasters_fit_and_predict_datatrees(
     assert model.forecaster.is_fitted
     assert isinstance(model.idata, xr.DataTree)
     assert model.idata.posterior.sizes["draw"] == num_samples
+    if forecaster is pymc_forecast.Forecaster:
+        with pytest.raises(AttributeError, match="does not retain a full DataTree"):
+            _ = model.fit_idata
+    else:
+        assert isinstance(model.fit_idata, xr.DataTree)
     assert list(result.score.index) == ["unit_0_r2", "unit_0_r2_std"]
     for pred, expected_index in (
         (result.pre_pred, result.datapre.index),


### PR DESCRIPTION
## Summary
- verify pymc-forecast 0.2 adapter constants and optional-extra failure/install contract on PyMC 6/DataTree
- exercise HMC, ADVI, and Pathfinder through real fit, posterior, in-sample, and out-of-sample forecast paths
- cover prediction normalization, Statespace rejection, scalar parameter rendering, and explicit/PipelineContext PlaceboInTime clone/refit paths
- preserve the PyMC model context while converting ADVI results to DataTree

## Final satellite validation

This satellite PR uses the maintainer-approved narrow final gate because the resource-heavy repository suite was already repeated during transition integration. The complete Python 3.12/3.14/full matrix remains reserved for the final transition PR to `main`.

Validated from head `960c02aaab2a5ee81026431acc1d392466fbea41` against transition base `b530b9b75327aa3bbdbc4ec625189dc8e66fda9f`:

- exact ADVI/DataTree regression nodes with `--no-cov`: 2 passed, 0 failed
- complete `causalpy/tests/test_pymc_forecast_adapter.py` with `--no-cov`: 34 passed, 0 skipped, 0 deselected, 0 xfailed
- `prek run --all-files`: all hooks passed and produced no tracked changes
- targeted adapter coverage: 34 passed; `causalpy/pymc_forecast_models.py` and the adapter test module both reached 100%
- `diff-cover coverage.xml --compare-branch=b530b9b75327aa3bbdbc4ec625189dc8e66fda9f --fail-under=96`: 100% diff coverage, 102 changed lines, 0 missing

The only runtime warning was the expected bounded-step ADVI convergence warning used by the fast regression test.

Closes #1046
Parent: #1038
