### PR TITLE
Port plotting for ArviZ 1.x

### DIFF
--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -23,7 +23,6 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Any, Literal
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -375,7 +374,7 @@ class BaseExperiment(ABC):
         ...     legend_kwargs={"loc": "upper left", "bbox_to_anchor": (1.04, 1)},
         ... )
         """
-        with plt.style.context(az.style.library["arviz-darkgrid"]):
+        with plt.style.context("arviz-darkgrid"):
             if self._model_backend.is_bayesian:
                 fig, ax = self._bayesian_plot(**draw_kwargs)
             elif self._model_backend.is_ols:

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -525,9 +525,9 @@ class PanelRegression(BaseExperiment):
         ----------
         hdi_prob : float
             Probability mass of the highest density interval drawn around
-            each posterior coefficient via :func:`arviz.plot_forest`. Must
-            be in ``(0, 1]``. Ignored for OLS models. Defaults to
-            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
+            each posterior coefficient. Must be in ``(0, 1]``. Ignored for
+            OLS models. Defaults to :data:`~causalpy.constants.HDI_PROB`
+            (currently 0.94).
         show : bool
             Whether to automatically display the plot. Defaults to ``True``.
         legend_kwargs : dict, optional
@@ -559,9 +559,8 @@ class PanelRegression(BaseExperiment):
         ----------
         hdi_prob : float, optional
             Probability mass of the highest density interval drawn around each
-            posterior coefficient via :func:`arviz.plot_forest`. Must be in
-            ``(0, 1]``. Defaults to :data:`~causalpy.constants.HDI_PROB`
-            (currently 0.94).
+            posterior coefficient. Must be in ``(0, 1]``. Defaults to
+            :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
 
         Returns
         -------
@@ -987,6 +986,7 @@ class PanelRegression(BaseExperiment):
                     sorted_time_vals,
                     unit_mu.mean(dim=["chain", "draw"]).values,
                     "s--",
+                    color="C1",
                     label="Fitted",
                     alpha=0.7,
                 )
@@ -997,7 +997,10 @@ class PanelRegression(BaseExperiment):
                     ax,
                     ci_prob=hdi_prob,
                     ci_kind="hdi",
-                    plot_hdi_kwargs={"fill_kwargs": {"alpha": 0.2}},
+                    plot_hdi_kwargs={
+                        "color": "C1",
+                        "fill_kwargs": {"alpha": 0.2},
+                    },
                 )
             else:
                 # OLS: get fitted values for this unit

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -16,7 +16,6 @@
 import re
 from typing import Any, Literal
 
-import arviz as az
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -25,10 +24,12 @@ from patsy import ModelDesc
 from scipy import stats
 from sklearn.base import RegressorMixin
 
+from causalpy._arviz_compat import hdi_bound_arrays
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.plot_utils import _plot_interval_band
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
 from causalpy.utils import round_num
@@ -598,18 +599,34 @@ class PanelRegression(BaseExperiment):
             raise ValueError("hdi_prob must be between 0 and 1")
 
         coeff_names = var_names if var_names is not None else self._get_non_fe_labels()
+        if not coeff_names:
+            raise ValueError("var_names must contain at least one coefficient")
 
         if self._model_backend.is_bayesian:
-            # Bayesian: use az.plot_forest directly
-            axes = az.plot_forest(
-                self.model.idata,
-                var_names=["beta"],
-                coords={"coeffs": coeff_names},
-                combined=True,
-                hdi_prob=hdi_prob,
+            coefficients = self.model.idata.posterior["beta"].sel(coeffs=coeff_names)  # type: ignore[union-attr]
+            if "treated_units" in coefficients.dims:
+                if coefficients.sizes["treated_units"] != 1:
+                    raise ValueError(
+                        "Bayesian coefficient plotting requires one treated unit"
+                    )
+                coefficients = coefficients.squeeze("treated_units", drop=True)
+            means = np.asarray(
+                coefficients.mean(dim=["chain", "draw"]).values,
+                dtype=float,
             )
-            ax = axes.ravel()[0]
-            fig = ax.figure
+            lower, upper = hdi_bound_arrays(
+                coefficients,
+                prob=hdi_prob,
+                dim=["chain", "draw"],
+            )
+            y_pos = np.arange(len(coeff_names))
+            fig, ax = plt.subplots(figsize=(10, max(4, len(coeff_names) * 0.5)))
+            ax.hlines(y_pos, lower, upper, color="C0")
+            ax.plot(means, y_pos, "o", color="C0")
+            ax.set_yticks(y_pos)
+            ax.set_yticklabels(coeff_names)
+            ax.axvline(x=0, color="black", linestyle="--", linewidth=0.8)
+            ax.set_xlabel("Coefficient Value")
             ax.set_title(f"Model Coefficients with {hdi_prob:.0%} HDI")
         else:
             # OLS: point estimates
@@ -720,6 +737,11 @@ class PanelRegression(BaseExperiment):
         -------
         tuple[plt.Figure, plt.Axes]
             Figure and axes objects
+
+        Raises
+        ------
+        ValueError
+            If ``var_names`` is empty or ``hdi_prob`` is outside ``(0, 1)``.
         """
         return self._plot_coefficients_internal(var_names=var_names, hdi_prob=hdi_prob)
 
@@ -876,6 +898,9 @@ class PanelRegression(BaseExperiment):
             else:
                 interval_source = mu
 
+        if units is None and n_sample <= 0:
+            raise ValueError("n_sample must be positive when units is not provided")
+
         # Select units to plot
         all_units = self.data[self.unit_fe_variable].unique()
 
@@ -903,6 +928,9 @@ class PanelRegression(BaseExperiment):
                     self.outcome_variable_name
                 ].var()
                 selected_units = unit_var.nlargest(n_sample).index.tolist()
+
+        if len(selected_units) == 0:
+            raise ValueError("plot_trajectories() requires at least one unit")
 
         # Create only the subplots we need
         n_units_plot = len(selected_units)
@@ -963,14 +991,13 @@ class PanelRegression(BaseExperiment):
                     alpha=0.7,
                 )
 
-                # Plot HDI using az.plot_hdi
-                az.plot_hdi(
+                _plot_interval_band(
                     sorted_time_vals,
                     unit_interval,
-                    hdi_prob=hdi_prob,
-                    ax=ax,
-                    smooth=False,
-                    fill_kwargs={"alpha": 0.2},
+                    ax,
+                    ci_prob=hdi_prob,
+                    ci_kind="hdi",
+                    plot_hdi_kwargs={"fill_kwargs": {"alpha": 0.2}},
                 )
             else:
                 # OLS: get fitted values for this unit

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -16,7 +16,6 @@
 import warnings
 from typing import Any, Literal
 
-import arviz as az
 import numpy as np
 import pandas as pd
 import seaborn as sns
@@ -30,7 +29,11 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
-from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
+from causalpy.plot_utils import (
+    _PosteriorPlotStyle,
+    plot_posterior_over_x,
+    plot_scalar_posterior,
+)
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary, _effect_summary_did
 from causalpy.utils import _is_variable_dummy_coded, round_num
@@ -398,12 +401,12 @@ class PrePostNEGD(BaseExperiment):
         )
 
         # Plot estimated caual impact / treatment effect
-        az.plot_posterior(
+        plot_scalar_posterior(
             self.causal_impact,
-            ref_val=0,
             ax=ax[1],
+            ci_prob=ci_prob,
+            ref_val=0,
             round_to=round_to,
-            hdi_prob=ci_prob,
         )
         ax[1].set(title="Estimated treatment effect")
         return fig, ax

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -70,8 +70,8 @@ def plot_posterior_over_x(
     ax : plt.Axes
         Matplotlib axes object.
     plot_hdi_kwargs : dict, optional
-        Keyword arguments for line, band, heatmap, or sample styling (passed through
-        to matplotlib / ArviZ helpers depending on ``kind`` and ``ci_kind``).
+        Keyword arguments for local Matplotlib line, band, heatmap, or sample
+        styling. Ribbon bands accept nested ``fill_kwargs``.
     ci_prob : float, optional
         Credible interval width when ``kind="ribbon"``. Defaults to
         :data:`~causalpy.constants.HDI_PROB` (currently 0.94). Ignored for
@@ -165,6 +165,13 @@ def _plot_interval_band(
         )
     else:
         lower, upper = _equal_tailed_interval(Y, ci_prob)
+        preserved_dims = list(lower.dims)
+        if len(preserved_dims) != 1:
+            msg = (
+                "Vector ETI bounds require exactly one preserved dimension; "
+                f"got {preserved_dims!r}"
+            )
+            raise ValueError(msg)
 
     lower_vals = np.asarray(lower, dtype=float).ravel()
     upper_vals = np.asarray(upper, dtype=float).ravel()
@@ -210,13 +217,6 @@ def _plot_ribbon(
     line_kwargs = plot_hdi_kwargs.copy()
     line_kwargs.pop("fill_kwargs", None)
 
-    (h_line,) = ax.plot(
-        x,
-        Y.mean(dim=["chain", "draw"]),
-        ls="-",
-        **line_kwargs,
-        label=label,
-    )
     h_patch = _plot_interval_band(
         x,
         Y,
@@ -224,6 +224,13 @@ def _plot_ribbon(
         ci_prob=ci_prob,
         ci_kind=ci_kind,
         plot_hdi_kwargs=plot_hdi_kwargs,
+    )
+    (h_line,) = ax.plot(
+        x,
+        Y.mean(dim=["chain", "draw"]),
+        ls="-",
+        **line_kwargs,
+        label=label,
     )
     return h_line, h_patch
 
@@ -262,16 +269,21 @@ def plot_scalar_posterior(
     ValueError
         If the posterior is non-scalar after squeezing or has no finite draws.
     """
-    posterior = draws.squeeze(drop=True)
+    if {"chain", "draw"} - set(draws.dims):
+        msg = "Scalar posterior plotting requires both chain and draw dimensions."
+        raise ValueError(msg)
+    squeeze_dims = [
+        dim
+        for dim in draws.dims
+        if dim not in {"chain", "draw"} and draws.sizes[dim] == 1
+    ]
+    posterior = draws.squeeze(dim=squeeze_dims, drop=True) if squeeze_dims else draws
     non_sample_dims = [dim for dim in posterior.dims if dim not in {"chain", "draw"}]
     if non_sample_dims:
         msg = (
             "Scalar posterior plotting requires only chain and draw dimensions after "
             f"squeezing singleton dimensions; got {non_sample_dims!r}."
         )
-        raise ValueError(msg)
-    if {"chain", "draw"} - set(posterior.dims):
-        msg = "Scalar posterior plotting requires both chain and draw dimensions."
         raise ValueError(msg)
 
     flat = np.asarray(

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -18,7 +18,6 @@ Plotting utility functions.
 import warnings
 from typing import Any, Literal, TypedDict
 
-import arviz as az
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,8 +27,9 @@ from matplotlib.collections import PolyCollection
 from matplotlib.lines import Line2D
 from pandas.api.extensions import ExtensionArray
 
-from causalpy._arviz_compat import hdi
+from causalpy._arviz_compat import hdi, hdi_bound_arrays, hdi_bounds
 from causalpy.constants import HDI_PROB
+from causalpy.utils import round_num
 
 
 class _PosteriorPlotStyle(TypedDict):
@@ -147,6 +147,53 @@ def _equal_tailed_interval(
     return lower, upper
 
 
+def _plot_interval_band(
+    x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
+    Y: xr.DataArray,
+    ax: plt.Axes,
+    *,
+    ci_prob: float,
+    ci_kind: Literal["hdi", "eti"],
+    plot_hdi_kwargs: dict[str, Any],
+) -> PolyCollection:
+    """Draw a posterior interval band without drawing a summary line."""
+    if ci_kind == "hdi":
+        lower, upper = hdi_bound_arrays(
+            Y,
+            prob=ci_prob,
+            dim=["chain", "draw"],
+        )
+    else:
+        lower, upper = _equal_tailed_interval(Y, ci_prob)
+
+    lower_vals = np.asarray(lower, dtype=float).ravel()
+    upper_vals = np.asarray(upper, dtype=float).ravel()
+    n_x = len(np.asarray(x))
+    if lower_vals.size != n_x or upper_vals.size != n_x:
+        msg = (
+            f"{ci_kind.upper()} ribbon: length mismatch between x and interval bounds "
+            f"(x={n_x}, lower={lower_vals.size}, upper={upper_vals.size})."
+        )
+        raise ValueError(msg)
+
+    fill_kwargs = plot_hdi_kwargs.get("fill_kwargs", {})
+    line_color = plot_hdi_kwargs.get("color", "C0")
+    fill_color = fill_kwargs.get("color", line_color)
+    fill_alpha = fill_kwargs.get("alpha", 0.3)
+    return ax.fill_between(
+        x,
+        lower_vals,
+        upper_vals,
+        color=fill_color,
+        alpha=fill_alpha,
+        **{
+            key: value
+            for key, value in fill_kwargs.items()
+            if key not in ["color", "alpha"]
+        },
+    )
+
+
 def _plot_ribbon(
     x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
     Y: xr.DataArray,
@@ -160,12 +207,9 @@ def _plot_ribbon(
     if plot_hdi_kwargs is None:
         plot_hdi_kwargs = {}
 
-    # Separate fill_kwargs for az.plot_hdi, as ax.plot doesn't accept them
     line_kwargs = plot_hdi_kwargs.copy()
-    if "fill_kwargs" in line_kwargs:
-        del line_kwargs["fill_kwargs"]
+    line_kwargs.pop("fill_kwargs", None)
 
-    # Plot mean line
     (h_line,) = ax.plot(
         x,
         Y.mean(dim=["chain", "draw"]),
@@ -173,63 +217,98 @@ def _plot_ribbon(
         **line_kwargs,
         label=label,
     )
+    h_patch = _plot_interval_band(
+        x,
+        Y,
+        ax,
+        ci_prob=ci_prob,
+        ci_kind=ci_kind,
+        plot_hdi_kwargs=plot_hdi_kwargs,
+    )
+    return h_line, h_patch
 
-    # Plot interval ribbon
-    if ci_kind == "hdi":
-        # Use ArviZ's plot_hdi for HDI
-        ax_hdi = az.plot_hdi(
-            x,
-            Y,
-            hdi_prob=ci_prob,
-            ax=ax,
-            smooth=False,
-            **plot_hdi_kwargs,
+
+def plot_scalar_posterior(
+    draws: xr.DataArray,
+    *,
+    ax: plt.Axes,
+    ci_prob: float = HDI_PROB,
+    ref_val: float | None = 0,
+    round_to: int | None = None,
+) -> plt.Axes:
+    """Draw a scalar posterior density, explicit HDI, and optional reference value.
+
+    Parameters
+    ----------
+    draws : xr.DataArray
+        Scalar posterior draws with ``chain`` and ``draw`` dimensions. Singleton
+        non-sample dimensions are squeezed before plotting.
+    ax : plt.Axes
+        Matplotlib axes to draw on.
+    ci_prob : float, default=HDI_PROB
+        Probability mass of the explicit highest density interval.
+    ref_val : float, optional
+        Reference value shown as a vertical dashed line. Defaults to 0.
+    round_to : int, optional
+        Minimum significant figures used in the summary annotation.
+
+    Returns
+    -------
+    plt.Axes
+        The axes supplied by the caller after drawing.
+
+    Raises
+    ------
+    ValueError
+        If the posterior is non-scalar after squeezing or has no finite draws.
+    """
+    posterior = draws.squeeze(drop=True)
+    non_sample_dims = [dim for dim in posterior.dims if dim not in {"chain", "draw"}]
+    if non_sample_dims:
+        msg = (
+            "Scalar posterior plotting requires only chain and draw dimensions after "
+            f"squeezing singleton dimensions; got {non_sample_dims!r}."
         )
-    else:  # ci_kind == "eti"
-        lower, upper = _equal_tailed_interval(Y, ci_prob)
-        lower_vals = np.asarray(lower.values, dtype=float).ravel()
-        upper_vals = np.asarray(upper.values, dtype=float).ravel()
-        n_x = len(np.asarray(x))
-        if lower_vals.size != n_x or upper_vals.size != n_x:
-            msg = (
-                "ETI ribbon: length mismatch between x and interval bounds "
-                f"(x={n_x}, lower={lower_vals.size}, upper={upper_vals.size})."
-            )
-            raise ValueError(msg)
+        raise ValueError(msg)
+    if {"chain", "draw"} - set(posterior.dims):
+        msg = "Scalar posterior plotting requires both chain and draw dimensions."
+        raise ValueError(msg)
 
-        # Extract fill_kwargs if provided
-        fill_kwargs = plot_hdi_kwargs.get("fill_kwargs", {})
-        line_color = plot_hdi_kwargs.get("color", "C0")
-        fill_color = fill_kwargs.get("color", line_color)
-        fill_alpha = fill_kwargs.get("alpha", 0.3)
+    flat = np.asarray(
+        posterior.stack(sample=("chain", "draw")).values,
+        dtype=float,
+    ).ravel()
+    finite_draws = flat[np.isfinite(flat)]
+    if finite_draws.size == 0:
+        msg = "Scalar posterior plotting requires at least one finite posterior draw."
+        raise ValueError(msg)
 
-        ax.fill_between(
-            x,
-            lower_vals,
-            upper_vals,
-            color=fill_color,
-            alpha=fill_alpha,
-            **{k: v for k, v in fill_kwargs.items() if k not in ["color", "alpha"]},
-        )
-        ax_hdi = ax
-
-    # Return handle to patch. We get a list of the children of the axis. Filter for just
-    # the PolyCollection objects. Take the last one.
-    if ci_kind == "hdi":
-        h_patch = list(
-            filter(lambda x: isinstance(x, PolyCollection), ax_hdi.get_children())
-        )[-1]
-    else:  # ci_kind == "eti"
-        # For ETI, we used fill_between which creates a PolyCollection
-        # Get the last PolyCollection from the axes
-        h_patch = (
-            list(
-                filter(lambda x: isinstance(x, PolyCollection), ax_hdi.get_children())
-            )[-1]
-            if any(isinstance(x, PolyCollection) for x in ax_hdi.get_children())
-            else None
-        )
-    return (h_line, h_patch)
+    lower, upper = hdi_bounds(finite_draws, prob=ci_prob)
+    mean = float(finite_draws.mean())
+    ax.hist(finite_draws, bins="auto", density=True, color="C0", alpha=0.5)
+    ax.plot(
+        [lower, upper],
+        [0, 0],
+        color="C0",
+        linewidth=4,
+        solid_capstyle="butt",
+        label=f"{ci_prob:.0%} HDI",
+    )
+    if ref_val is not None:
+        ax.axvline(ref_val, color="black", linestyle="--", label="Reference value")
+    ax.text(
+        0.98,
+        0.98,
+        (
+            f"Mean: {round_num(mean, round_to)}\n"
+            f"{ci_prob:.0%} HDI "
+            f"[{round_num(lower, round_to)}, {round_num(upper, round_to)}]"
+        ),
+        transform=ax.transAxes,
+        horizontalalignment="right",
+        verticalalignment="top",
+    )
+    return ax
 
 
 def _x_as_numeric_mesh(

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -147,16 +147,14 @@ def _equal_tailed_interval(
     return lower, upper
 
 
-def _plot_interval_band(
+def _interval_bound_values(
     x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
     Y: xr.DataArray,
-    ax: plt.Axes,
     *,
     ci_prob: float,
     ci_kind: Literal["hdi", "eti"],
-    plot_hdi_kwargs: dict[str, Any],
-) -> PolyCollection:
-    """Draw a posterior interval band without drawing a summary line."""
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return validated posterior interval bounds aligned one-to-one with ``x``."""
     if ci_kind == "hdi":
         lower, upper = hdi_bound_arrays(
             Y,
@@ -182,6 +180,29 @@ def _plot_interval_band(
             f"(x={n_x}, lower={lower_vals.size}, upper={upper_vals.size})."
         )
         raise ValueError(msg)
+    return lower_vals, upper_vals
+
+
+def _plot_interval_band(
+    x: pd.DatetimeIndex | np.ndarray | pd.Index | pd.Series | ExtensionArray,
+    Y: xr.DataArray,
+    ax: plt.Axes,
+    *,
+    ci_prob: float,
+    ci_kind: Literal["hdi", "eti"],
+    plot_hdi_kwargs: dict[str, Any],
+    interval_bounds: tuple[np.ndarray, np.ndarray] | None = None,
+) -> PolyCollection:
+    """Draw a validated posterior interval band without a summary line."""
+    if interval_bounds is None:
+        lower_vals, upper_vals = _interval_bound_values(
+            x,
+            Y,
+            ci_prob=ci_prob,
+            ci_kind=ci_kind,
+        )
+    else:
+        lower_vals, upper_vals = interval_bounds
 
     fill_kwargs = plot_hdi_kwargs.get("fill_kwargs", {})
     line_color = plot_hdi_kwargs.get("color", "C0")
@@ -217,6 +238,12 @@ def _plot_ribbon(
     line_kwargs = plot_hdi_kwargs.copy()
     line_kwargs.pop("fill_kwargs", None)
 
+    interval_bounds = _interval_bound_values(
+        x,
+        Y,
+        ci_prob=ci_prob,
+        ci_kind=ci_kind,
+    )
     (h_line,) = ax.plot(
         x,
         Y.mean(dim=["chain", "draw"]),
@@ -232,6 +259,7 @@ def _plot_ribbon(
         ci_prob=ci_prob,
         ci_kind=ci_kind,
         plot_hdi_kwargs=band_kwargs,
+        interval_bounds=interval_bounds,
     )
     return h_line, h_patch
 

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -217,20 +217,21 @@ def _plot_ribbon(
     line_kwargs = plot_hdi_kwargs.copy()
     line_kwargs.pop("fill_kwargs", None)
 
-    h_patch = _plot_interval_band(
-        x,
-        Y,
-        ax,
-        ci_prob=ci_prob,
-        ci_kind=ci_kind,
-        plot_hdi_kwargs=plot_hdi_kwargs,
-    )
     (h_line,) = ax.plot(
         x,
         Y.mean(dim=["chain", "draw"]),
         ls="-",
         **line_kwargs,
         label=label,
+    )
+    band_kwargs = {**plot_hdi_kwargs, "color": h_line.get_color()}
+    h_patch = _plot_interval_band(
+        x,
+        Y,
+        ax,
+        ci_prob=ci_prob,
+        ci_kind=ci_kind,
+        plot_hdi_kwargs=band_kwargs,
     )
     return h_line, h_patch
 

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -345,7 +345,7 @@ _RKINK_TARGETS: list[_SpyTarget] = [
 ]
 _PREPOST_TARGETS: list[_SpyTarget] = [
     ("causalpy.experiments.prepostnegd.plot_posterior_over_x", "ci_prob"),
-    ("causalpy.experiments.prepostnegd.az.plot_posterior", "hdi_prob"),
+    ("causalpy.experiments.prepostnegd.plot_scalar_posterior", "ci_prob"),
 ]
 _PIECEWISE_TARGETS: list[_SpyTarget] = [
     ("causalpy.experiments.piecewise_its.plot_posterior_over_x", "ci_prob"),

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -49,18 +49,17 @@ sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
 # Each entry maps a "spy target" (dotted import path of the callable used by
 # the experiment's plot path) to the kwarg name that ``hdi_prob`` flows into.
-# ``plot_posterior_over_x`` targets use ``"ci_prob"`` (the canonical name); other callables
-# such as ``az.plot_posterior`` and ``az.plot_forest`` use ``"hdi_prob"``.
+# ``plot_posterior_over_x`` and local plotting helpers receive ``"ci_prob"``;
+# coefficient HDI helpers receive their explicit ``"prob"`` argument.
 _SpyTarget = tuple[str, str]
 
 
 def _resolve_dotted(dotted: str) -> Any:
-    """Resolve a dotted path that may include attribute access through an alias.
+    """Resolve a dotted import path through a module attribute.
 
-    For example, ``causalpy.experiments.prepostnegd.az.plot_posterior`` is not
-    importable as a module path because ``az`` is an alias inside the module,
-    not a real submodule. We import the longest valid module prefix and then
-    walk the remaining attributes.
+    The local plotting helpers are imported into their experiment modules, so
+    test spies target that stable call-site attribute rather than a private
+    implementation module.
     """
     parts = dotted.split(".")
     for i in range(len(parts), 0, -1):
@@ -423,7 +422,7 @@ def test_rkink_plot_default_ci_prob(mock_pymc_sample, fitted_rkink):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_prepost_plot_threads_ci_prob(mock_pymc_sample, fitted_prepost, ci_prob):
-    """PrePostNEGD ``plot(ci_prob=...)`` reaches ``plot_posterior_over_x`` and ``az.plot_posterior``."""
+    """PrePostNEGD ``plot(ci_prob=...)`` reaches both local posterior helpers."""
     _check_threading(fitted_prepost, _PREPOST_TARGETS, ci_prob)
 
 
@@ -449,17 +448,13 @@ def test_piecewise_plot_default_ci_prob(mock_pymc_sample, fitted_piecewise):
 @pytest.mark.integration
 @pytest.mark.parametrize("ci_prob", _PARAMS)
 def test_panel_plot_threads_ci_prob(mock_pymc_sample, fitted_panel, ci_prob):
-    """PanelRegression ``plot(hdi_prob=...)`` reaches ``az.plot_forest``.
-
-    PanelRegression has not yet been migrated to ``ci_prob`` (it does not
-    support ETI/spaghetti/histogram), so we call ``plot(hdi_prob=...)`` here.
-    """
+    """PanelRegression ``plot(hdi_prob=...)`` reaches its local HDI helper."""
     _check_threading(fitted_panel, _PANEL_TARGETS, ci_prob, plot_kwarg="hdi_prob")
 
 
 @pytest.mark.integration
 def test_panel_plot_default_ci_prob(mock_pymc_sample, fitted_panel):
-    """PanelRegression default ``plot()`` forwards ``HDI_PROB`` to ``az.plot_forest``."""
+    """PanelRegression default ``plot()`` forwards ``HDI_PROB`` to its HDI helper."""
     _check_default(fitted_panel, _PANEL_TARGETS)
 
 

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -351,7 +351,7 @@ _PIECEWISE_TARGETS: list[_SpyTarget] = [
     ("causalpy.experiments.piecewise_its.plot_posterior_over_x", "ci_prob"),
 ]
 _PANEL_TARGETS: list[_SpyTarget] = [
-    ("causalpy.experiments.panel_regression.az.plot_forest", "hdi_prob"),
+    ("causalpy.experiments.panel_regression.hdi_bound_arrays", "prob"),
 ]
 
 

--- a/causalpy/tests/test_integration_its_new_timeseries.py
+++ b/causalpy/tests/test_integration_its_new_timeseries.py
@@ -61,8 +61,11 @@ def test_its_with_bsts_model():
     assert isinstance(result, cp.InterruptedTimeSeries)
     assert isinstance(result.idata, xr.DataTree)
 
-    # Plot rendering is covered by the plotting migration tests. Keep this
-    # integration focused on the BSTS result and its downstream data contract.
+    # Plot and plot data
+    fig, ax = result.plot()
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, np.ndarray)
+
     plot_data = result.get_plot_data()
     assert isinstance(plot_data, pd.DataFrame)
     expected_columns = {

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from matplotlib.collections import PolyCollection
+from matplotlib.colors import to_rgba
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
@@ -893,6 +894,13 @@ def test_panel_bayesian_coefficient_forest_preserves_axes_and_hdi_bounds(
             np.sort(segment[:, 0]),
             [expected_lower, expected_upper],
         )
+    marker_line = next(line for line in ax.lines if line.get_marker() == "o")
+    np.testing.assert_allclose(
+        marker_line.get_xdata(),
+        coefficients.mean(dim=["chain", "draw"]).values,
+    )
+    np.testing.assert_allclose(marker_line.get_ydata(), np.arange(len(coeff_names)))
+
     plt.close(fig)
 
 
@@ -913,10 +921,12 @@ def test_panel_plot_coefficients_rejects_empty_selection(small_panel_data):
 
 @pytest.mark.integration
 @pytest.mark.parametrize("hdi_prob", [0.5, 0.94])
+@pytest.mark.parametrize("interval_type", ["mean", "predictive"])
 def test_panel_trajectory_hdi_band_preserves_fitted_line_and_legend(
     mock_pymc_sample,
     small_panel_data,
     hdi_prob,
+    interval_type,
 ):
     """Trajectory bands use the selected interval without duplicating Fitted."""
     result = cp.PanelRegression(
@@ -928,7 +938,11 @@ def test_panel_trajectory_hdi_band_preserves_fitted_line_and_legend(
         model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
     )
 
-    fig, axes = result.plot_trajectories(units=["unit_0"], hdi_prob=hdi_prob)
+    fig, axes = result.plot_trajectories(
+        units=["unit_0"],
+        hdi_prob=hdi_prob,
+        interval_type=interval_type,
+    )
 
     assert isinstance(axes, np.ndarray)
     ax = axes[0]
@@ -948,8 +962,15 @@ def test_panel_trajectory_hdi_band_preserves_fitted_line_and_legend(
         fitted_lines[0].get_ydata(),
         unit_mu.mean(dim=["chain", "draw"]).values,
     )
+    interval_source = (
+        unit_mu
+        if interval_type == "mean"
+        else result.model.idata.posterior_predictive["y_hat"]
+        .isel(obs_ind=sorted_indices.tolist())
+        .squeeze("treated_units", drop=True)
+    )
     lower, upper = hdi_bound_arrays(
-        unit_mu,
+        interval_source,
         prob=hdi_prob,
         dim=["chain", "draw"],
     )
@@ -961,6 +982,10 @@ def test_panel_trajectory_hdi_band_preserves_fitted_line_and_legend(
     vertices = band.get_paths()[0].vertices[:, 1]
     for bound in np.concatenate([lower, upper]):
         assert np.isclose(vertices, bound).any()
+    np.testing.assert_allclose(
+        band.get_facecolor()[0],
+        to_rgba(fitted_lines[0].get_color(), alpha=0.2),
+    )
     plt.close(fig)
 
 

--- a/causalpy/tests/test_panel_regression.py
+++ b/causalpy/tests/test_panel_regression.py
@@ -19,9 +19,11 @@ import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 import pytest
+from matplotlib.collections import PolyCollection
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
+from causalpy._arviz_compat import hdi_bound_arrays
 
 # Minimal sample kwargs for fast tests
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
@@ -846,3 +848,135 @@ def test_plot_unit_effects_no_fe_labels(small_panel_data):
 
     with pytest.raises(ValueError, match="No unit fixed effects found"):
         result.plot_unit_effects()
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", [0.5, 0.94])
+def test_panel_bayesian_coefficient_forest_preserves_axes_and_hdi_bounds(
+    mock_pymc_sample,
+    small_panel_data,
+    hdi_prob,
+):
+    """Bayesian coefficient plotting stays on one Axes with explicit HDI bounds."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    coeff_names = ["treatment", "x1"]
+
+    fig, ax = result.plot_coefficients(var_names=coeff_names, hdi_prob=hdi_prob)
+
+    assert isinstance(fig, plt.Figure)
+    assert isinstance(ax, plt.Axes)
+    assert [tick.get_text() for tick in ax.get_yticklabels()] == coeff_names
+    assert f"{hdi_prob:.0%} HDI" in ax.get_title()
+
+    coefficients = result.model.idata.posterior["beta"].sel(coeffs=coeff_names)
+    coefficients = coefficients.squeeze("treated_units", drop=True)
+    lower, upper = hdi_bound_arrays(
+        coefficients,
+        prob=hdi_prob,
+        dim=["chain", "draw"],
+    )
+    error_segments = ax.collections[0].get_segments()
+    for segment, expected_lower, expected_upper in zip(
+        error_segments,
+        lower,
+        upper,
+        strict=True,
+    ):
+        np.testing.assert_allclose(
+            np.sort(segment[:, 0]),
+            [expected_lower, expected_upper],
+        )
+    plt.close(fig)
+
+
+def test_panel_plot_coefficients_rejects_empty_selection(small_panel_data):
+    """An empty requested coefficient list raises instead of creating a blank plot."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=LinearRegression(),
+    )
+
+    with pytest.raises(ValueError, match="at least one coefficient"):
+        result.plot_coefficients(var_names=[])
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("hdi_prob", [0.5, 0.94])
+def test_panel_trajectory_hdi_band_preserves_fitted_line_and_legend(
+    mock_pymc_sample,
+    small_panel_data,
+    hdi_prob,
+):
+    """Trajectory bands use the selected interval without duplicating Fitted."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+
+    fig, axes = result.plot_trajectories(units=["unit_0"], hdi_prob=hdi_prob)
+
+    assert isinstance(axes, np.ndarray)
+    ax = axes[0]
+    fitted_lines = [line for line in ax.lines if line.get_label() == "Fitted"]
+    assert len(fitted_lines) == 1
+    assert [text.get_text() for text in ax.get_legend().get_texts()] == [
+        "Actual",
+        "Fitted",
+    ]
+
+    unit_indices = np.where(result.data["unit"] == "unit_0")[0]
+    sort_order = np.argsort(result.data.loc[result.data["unit"] == "unit_0", "time"])
+    sorted_indices = unit_indices[sort_order]
+    unit_mu = result.model.idata.posterior["mu"].isel(obs_ind=sorted_indices.tolist())
+    unit_mu = unit_mu.squeeze("treated_units", drop=True)
+    np.testing.assert_allclose(
+        fitted_lines[0].get_ydata(),
+        unit_mu.mean(dim=["chain", "draw"]).values,
+    )
+    lower, upper = hdi_bound_arrays(
+        unit_mu,
+        prob=hdi_prob,
+        dim=["chain", "draw"],
+    )
+    band = next(
+        collection
+        for collection in ax.collections
+        if isinstance(collection, PolyCollection)
+    )
+    vertices = band.get_paths()[0].vertices[:, 1]
+    for bound in np.concatenate([lower, upper]):
+        assert np.isclose(vertices, bound).any()
+    plt.close(fig)
+
+
+@pytest.mark.parametrize("select", ["random", "extreme", "high_variance"])
+def test_panel_plot_trajectories_rejects_empty_selection(small_panel_data, select):
+    """Every selection strategy rejects a non-positive sample size before plotting."""
+    result = cp.PanelRegression(
+        data=small_panel_data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=LinearRegression(),
+    )
+
+    with pytest.raises(ValueError, match="n_sample must be positive"):
+        result.plot_trajectories(n_sample=0, select=select)
+    with pytest.raises(ValueError, match="at least one unit"):
+        result.plot_trajectories(units=[])

--- a/causalpy/tests/test_plot_utils.py
+++ b/causalpy/tests/test_plot_utils.py
@@ -457,6 +457,10 @@ def test_plot_posterior_over_x_default_behavior(synthetic_posterior_data):
     # Check return types
     assert isinstance(h_line, plt.Line2D), "Should return Line2D for mean line"
     assert h_patch is not None, "Should return PolyCollection for HDI ribbon"
+    np.testing.assert_allclose(
+        h_patch.get_facecolor()[0],
+        to_rgba(h_line.get_color(), alpha=0.3),
+    )
 
     plt.close(fig)
 
@@ -744,9 +748,16 @@ def test_plot_posterior_over_x_hdi_band_handles_singleton_and_empty_x():
     )
     _, empty_patch = plot_posterior_over_x(empty_x, empty, ax=axes[1])
 
-    assert len(singleton_line.get_xdata()) == 1
-    assert isinstance(singleton_patch, PolyCollection)
+    lower, upper = hdi_bound_arrays(
+        singleton,
+        prob=0.94,
+        dim=["chain", "draw"],
+    )
+    singleton_vertices = singleton_patch.get_paths()[0].vertices[:, 1]
+    for bound in np.concatenate([lower, upper]):
+        assert np.isclose(singleton_vertices, bound).any()
     assert isinstance(empty_patch, PolyCollection)
+    assert sum(len(path.vertices) for path in empty_patch.get_paths()) == 0
     plt.close(fig)
 
 
@@ -815,4 +826,66 @@ def test_plot_scalar_posterior_rejects_nonscalar_and_nonfinite_draws():
         plot_scalar_posterior(nonfinite, ax=axes[1])
     assert not axes[0].patches
     assert not axes[1].patches
+    plt.close(fig)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("ci_kind", ["hdi", "eti"])
+def test_plot_posterior_over_x_ribbon_rejects_x_length_mismatch(ci_kind):
+    """Both interval kinds reject bounds that cannot align one-to-one with x."""
+    x = np.arange(3)
+    draws = xr.DataArray(
+        np.arange(12, dtype=float).reshape(2, 3, 2),
+        dims=["chain", "draw", "obs_ind"],
+    )
+    fig, ax = plt.subplots()
+
+    with pytest.raises(ValueError, match="length mismatch"):
+        plot_posterior_over_x(x, draws, ax=ax, ci_kind=ci_kind)
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_posterior_over_x_eti_rejects_multiple_preserved_dimensions():
+    """ETI ribbons reject extra dimensions instead of flattening them into x."""
+    x = np.arange(4)
+    draws = xr.DataArray(
+        np.arange(24, dtype=float).reshape(2, 3, 2, 2),
+        dims=["chain", "draw", "obs_ind", "extra"],
+    )
+    fig, ax = plt.subplots()
+
+    with pytest.raises(ValueError, match="exactly one preserved dimension"):
+        plot_posterior_over_x(x, draws, ax=ax, ci_kind="eti")
+    plt.close(fig)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("shape", [(1, 4), (4, 1)])
+def test_plot_scalar_posterior_preserves_singleton_sample_dimensions(shape):
+    """A single chain or draw remains a valid scalar posterior."""
+    values = np.arange(np.prod(shape), dtype=float).reshape(shape)
+    draws = xr.DataArray(values, dims=["chain", "draw"])
+    expected_lower, expected_upper = hdi_bounds(values.ravel(), prob=0.94)
+    fig, ax = plt.subplots()
+
+    plot_scalar_posterior(draws, ax=ax)
+
+    hdi_line = next(line for line in ax.lines if line.get_label() == "94% HDI")
+    np.testing.assert_allclose(hdi_line.get_xdata(), [expected_lower, expected_upper])
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_scalar_posterior_omits_reference_line_when_requested():
+    """An explicit None reference value suppresses the vertical reference artist."""
+    draws = xr.DataArray(
+        np.arange(6, dtype=float).reshape(2, 3),
+        dims=["chain", "draw"],
+    )
+    fig, ax = plt.subplots()
+
+    plot_scalar_posterior(draws, ax=ax, ref_val=None)
+
+    assert all(line.get_label() != "Reference value" for line in ax.lines)
     plt.close(fig)

--- a/causalpy/tests/test_plot_utils.py
+++ b/causalpy/tests/test_plot_utils.py
@@ -21,8 +21,15 @@ import pandas as pd
 import pytest
 import xarray as xr
 from matplotlib.collections import PolyCollection
+from matplotlib.colors import to_rgba
 
-from causalpy.plot_utils import get_hdi_to_df, plot_posterior_over_x
+from causalpy._arviz_compat import hdi_bound_arrays, hdi_bounds
+from causalpy.plot_utils import (
+    get_hdi_to_df,
+    plot_posterior_over_x,
+    plot_scalar_posterior,
+)
+from causalpy.utils import round_num
 
 
 @pytest.mark.integration
@@ -674,4 +681,138 @@ def test_plot_posterior_over_x_warns_num_samples_ignored_for_non_spaghetti(
     fig, ax = plt.subplots()
     with pytest.warns(UserWarning, match="num_samples.*ignored"):
         plot_posterior_over_x(x, Y, ax=ax, kind="ribbon", num_samples=100)
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_posterior_over_x_hdi_band_matches_explicit_bounds(
+    synthetic_posterior_data,
+):
+    """The HDI ribbon contains the explicit compatibility bounds at every x value."""
+    x, Y = synthetic_posterior_data
+    fig, ax = plt.subplots()
+
+    _, patch = plot_posterior_over_x(x, Y, ax=ax, ci_prob=0.89)
+
+    lower, upper = hdi_bound_arrays(Y, prob=0.89, dim=["chain", "draw"])
+    vertices = patch.get_paths()[0].vertices[:, 1]
+    for bound in np.concatenate([lower, upper]):
+        assert np.isclose(vertices, bound).any()
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_posterior_over_x_hdi_band_honors_fill_kwargs(synthetic_posterior_data):
+    """The local HDI ribbon preserves color and alpha styling."""
+    x, Y = synthetic_posterior_data
+    fig, ax = plt.subplots()
+
+    _, patch = plot_posterior_over_x(
+        x,
+        Y,
+        ax=ax,
+        plot_hdi_kwargs={
+            "color": "C2",
+            "fill_kwargs": {"color": "C2", "alpha": 0.4},
+        },
+    )
+
+    assert patch.get_alpha() == pytest.approx(0.4)
+    np.testing.assert_allclose(patch.get_facecolor()[0], to_rgba("C2", alpha=0.4))
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_posterior_over_x_hdi_band_handles_singleton_and_empty_x():
+    """Local HDI bands retain valid artists for singleton and empty x dimensions."""
+    singleton_x = pd.DatetimeIndex(["2020-01-01"])
+    singleton = xr.DataArray(
+        np.arange(6, dtype=float).reshape(2, 3, 1),
+        dims=["chain", "draw", "obs_ind"],
+    )
+    empty_x = pd.DatetimeIndex([])
+    empty = xr.DataArray(
+        np.empty((2, 3, 0)),
+        dims=["chain", "draw", "obs_ind"],
+    )
+
+    fig, axes = plt.subplots(1, 2)
+    singleton_line, singleton_patch = plot_posterior_over_x(
+        singleton_x,
+        singleton,
+        ax=axes[0],
+    )
+    _, empty_patch = plot_posterior_over_x(empty_x, empty, ax=axes[1])
+
+    assert len(singleton_line.get_xdata()) == 1
+    assert isinstance(singleton_patch, PolyCollection)
+    assert isinstance(empty_patch, PolyCollection)
+    plt.close(fig)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("ci_prob", [0.5, 0.94])
+def test_plot_scalar_posterior_uses_finite_draws_for_hdi_and_annotation(ci_prob):
+    """Scalar posterior density ignores partial NaN/Inf draws for every statistic."""
+    values = np.array(
+        [
+            [1.0, np.nan, 2.0, np.inf],
+            [3.0, -np.inf, 4.0, 5.0],
+        ]
+    )
+    draws = xr.DataArray(
+        values[:, :, None],
+        dims=["chain", "draw", "treated_units"],
+    )
+    finite_draws = values[np.isfinite(values)]
+    expected_lower, expected_upper = hdi_bounds(finite_draws, prob=ci_prob)
+    expected_mean = float(finite_draws.mean())
+    fig, ax = plt.subplots()
+
+    returned_ax = plot_scalar_posterior(
+        draws,
+        ax=ax,
+        ci_prob=ci_prob,
+        round_to=4,
+    )
+
+    hdi_line = next(
+        line for line in ax.lines if line.get_label() == f"{ci_prob:.0%} HDI"
+    )
+    np.testing.assert_allclose(
+        hdi_line.get_xdata(),
+        [expected_lower, expected_upper],
+    )
+    assert returned_ax is ax
+    assert any(
+        line.get_label() == "Reference value" and np.allclose(line.get_xdata(), [0, 0])
+        for line in ax.lines
+    )
+    annotation = ax.texts[0].get_text()
+    assert round_num(expected_mean, 4) in annotation
+    assert f"{ci_prob:.0%} HDI" in annotation
+    assert "nan" not in annotation.lower()
+    assert "inf" not in annotation.lower()
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_plot_scalar_posterior_rejects_nonscalar_and_nonfinite_draws():
+    """Scalar density fails clearly before it can render invalid posterior inputs."""
+    nonscalar = xr.DataArray(
+        np.ones((2, 3, 2)),
+        dims=["chain", "draw", "coeffs"],
+    )
+    nonfinite = xr.DataArray(
+        np.full((2, 3), np.nan),
+        dims=["chain", "draw"],
+    )
+    fig, axes = plt.subplots(1, 2)
+
+    with pytest.raises(ValueError, match="only chain and draw"):
+        plot_scalar_posterior(nonscalar, ax=axes[0])
+    with pytest.raises(ValueError, match="at least one finite"):
+        plot_scalar_posterior(nonfinite, ax=axes[1])
+    assert not axes[0].patches
+    assert not axes[1].patches
     plt.close(fig)

--- a/causalpy/tests/test_plot_utils.py
+++ b/causalpy/tests/test_plot_utils.py
@@ -466,6 +466,24 @@ def test_plot_posterior_over_x_default_behavior(synthetic_posterior_data):
 
 
 @pytest.mark.integration
+def test_plot_posterior_over_x_default_ribbon_matches_line_color_after_prior_artist(
+    synthetic_posterior_data,
+):
+    """Default bands use the same colour as their line after the axes cycle advances."""
+    x, Y = synthetic_posterior_data
+    fig, ax = plt.subplots()
+    ax.plot(x, np.zeros(len(x)))
+
+    h_line, h_patch = plot_posterior_over_x(x, Y, ax=ax)
+
+    np.testing.assert_allclose(
+        h_patch.get_facecolor()[0],
+        to_rgba(h_line.get_color(), alpha=0.3),
+    )
+    plt.close(fig)
+
+
+@pytest.mark.integration
 def test_plot_posterior_over_x_backward_compatibility_hdi_prob(
     synthetic_posterior_data,
 ):


### PR DESCRIPTION
## Summary

Port CausalPy plotting away from ArviZ APIs removed in 1.x while preserving public axes, interval, color, legend, and `show` contracts.

Closes #1043
Parent: #1038

## Changes

- Use the registered `arviz-darkgrid` Matplotlib style in the shared plot dispatcher.
- Replace removed `az.plot_hdi`, `az.plot_posterior`, and `az.plot_forest` calls with local Matplotlib interval, scalar-density, and panel coefficient helpers.
- Preserve the default 0.94 interval, explicit HDI/ETI threading, legacy `hdi_prob` behavior, line/ribbon color alignment, axes shapes, legends, and validation-before-rendering behavior.
- Add focused edge coverage for malformed dimensions, lengths, nonfinite/scalar posterior draws, empty selections, advanced palette cycles, and panel trajectories.
- Restore the real ITS/BSTS `result.plot()` integration assertion temporarily removed by #1045 now that the shared plotting port is present.

## Testing

- No-exclusion plotting/SDID/BSTS gate — 187 passed, zero skips or deselections.
- `mamba run -n mamba_temp_env_issue_1043 prek run --all-files` — passed, including mypy.
- `mamba run -n mamba_temp_env_issue_1043 make html` — passed with 16 existing warnings.
- `DIFF_COVER_COMPARE_BRANCH=a90d336f3e4bc4a38a4dc7dd42c09858560f5143 make test-patch-cov` — 1,335 passed, 5 expected skips, 97.43% total coverage, and 98% exact-base patch coverage.
- Production search finds no remaining `az.style.library`, `az.plot_hdi`, `az.plot_posterior`, or `az.plot_forest` references.
- `make doctest` was also run: 30 passed and 13 skipped, but seven pre-existing PyMC examples still expect the old `InferenceData` repr instead of `xarray.DataTree`; PyMC 6.0.1 on Python 3.14 also triggered an Accelerate multiprocessing segfault. These failures are outside the plotting diff and are not part of the required PR gate.

## Final integration

- PR #1074/#1072 is merged into `pymc6_and_pymcmarketing1_migration` at `a90d336f3e4bc4a38a4dc7dd42c09858560f5143`.
- This branch merged that transition head normally at `eee20ac4006b38b4aa4c3400bdde316c7ba4b86f`; no rebase or force push was used.
- Final tested head: `b8d2abe72baf2bf79df4caebb7325fc7d715eff6`.

## Checklist

- [x] Removed ArviZ plotting APIs replaced
- [x] Default 0.94 and explicit interval contracts preserved
- [x] SDID plotting covered without exclusion
- [x] Durable real BSTS plotting coverage restored
- [x] Full suite and exact-base patch coverage green
- [x] All-files quality hooks and local HTML green
- [x] Read the Docs and all applicable remote checks green on final head
