### PR TITLE
Plots in experiment docstrings: configurable editorial theme + DiD (#391)

### DIFF
--- a/causalpy/__init__.py
+++ b/causalpy/__init__.py
@@ -14,10 +14,12 @@
 """CausalPy: causal inference for quasi-experiments in Python."""
 
 import causalpy.checks as checks  # noqa: E402
+import causalpy.plot_styles as plot_styles
 import causalpy.pymc_forecast_models as pymc_forecast_models
 import causalpy.pymc_models as pymc_models
 import causalpy.skl_models as skl_models
 import causalpy.variable_selection_priors as variable_selection_priors
+from causalpy.plot_styles import plot_style, set_plot_style
 from causalpy.skl_models import create_causalpy_compatible_class
 from causalpy.transforms import ramp, step
 from causalpy.version import __version__
@@ -64,6 +66,8 @@ __all__ = [
     "PipelineResult",
     "PanelRegression",
     "plot_correlations",
+    "plot_style",
+    "plot_styles",
     "PrePostNEGD",
     "pymc_forecast_models",
     "pymc_models",
@@ -72,6 +76,7 @@ __all__ = [
     "RegressionKink",
     "SensitivityAnalysis",
     "SensitivitySummary",
+    "set_plot_style",
     "skl_models",
     "StaggeredDifferenceInDifferences",
     "step",

--- a/causalpy/experiments/base.py
+++ b/causalpy/experiments/base.py
@@ -32,6 +32,12 @@ from sklearn.base import RegressorMixin
 
 from causalpy.experiments.model_adapter import ModelAdapter, make_model_adapter
 from causalpy.maketables_adapters import get_maketables_adapter
+from causalpy.plot_styles import (
+    active_theme,
+    apply_title_font,
+    bake_cycle_colors,
+    style_context,
+)
 from causalpy.pymc_forecast_models import PyMCForecastModel
 from causalpy.pymc_models import PyMCModel
 from causalpy.reporting import EffectSummary
@@ -317,8 +323,9 @@ class BaseExperiment(ABC):
         `#886 <https://github.com/pymc-labs/CausalPy/issues/886>`_) and
         forwards the call here. This helper:
 
-        1. Applies the ``arviz-darkgrid`` style for the duration of the
-           draw call.
+        1. Applies the active plotting theme's style for the duration of the
+           draw call (see :mod:`causalpy.plot_styles`; the default theme is
+           ``arviz-darkgrid``), then applies the theme's title font, if any.
         2. Calls the subclass's backend-agnostic :meth:`_plot`.
         3. Mutates the resulting legend(s) in place when *legend_kwargs*
            is supplied, preserving custom handles built by the subclass.
@@ -374,8 +381,17 @@ class BaseExperiment(ABC):
         ...     legend_kwargs={"loc": "upper left", "bbox_to_anchor": (1.04, 1)},
         ... )
         """
-        with plt.style.context(az.style.library["arviz-darkgrid"]):
+        theme = active_theme()
+        with plt.style.context(style_context(theme)):
             fig, ax = self._plot(**draw_kwargs)
+            # Freeze deferred "CN" cycle colours while the themed cycle is still
+            # active; otherwise a figure drawn later (docs, notebooks) would
+            # re-resolve them against the default cycle. Skipped for the default
+            # theme to keep its output byte-for-byte unchanged.
+            if theme.rcparams is not None:
+                bake_cycle_colors(fig)
+        if theme.title_font is not None:
+            apply_title_font(fig, theme.title_font)
 
         # Apply legend customization if requested.  We mutate the existing
         # Legend object in place so that custom handles — especially the

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -31,6 +31,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.plot_styles import active_colors
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     has_posterior_draws,
@@ -88,22 +89,38 @@ class DifferenceInDifferences(BaseExperiment):
 
     Examples
     --------
-    >>> import causalpy as cp
-    >>> df = cp.load_data("did")
-    >>> seed = 42
-    >>> result = cp.DifferenceInDifferences(
-    ...     df,
-    ...     formula="y ~ 1 + group*post_treatment",
-    ...     time_variable_name="t",
-    ...     group_variable_name="group",
-    ...     model=cp.pymc_models.LinearRegression(
-    ...         sample_kwargs={
-    ...             "target_accept": 0.95,
-    ...             "random_seed": seed,
-    ...             "progressbar": False,
-    ...         }
-    ...     ),
-    ... )
+    The figure below is rendered with CausalPy's editorial plot theme
+    (``cp.plot_style("editorial")``); omit the ``with`` block to use the default
+    style. Sampling is kept small and seeded so the documentation build stays
+    fast and reproducible.
+
+    .. plot::
+        :context: close-figs
+        :include-source: True
+        :format: doctest
+
+        >>> import causalpy as cp
+        >>> import matplotlib.pyplot as plt
+        >>> df = cp.load_data("did")
+        >>> result = cp.DifferenceInDifferences(
+        ...     df,
+        ...     formula="y ~ 1 + group*post_treatment",
+        ...     time_variable_name="t",
+        ...     group_variable_name="group",
+        ...     model=cp.pymc_models.LinearRegression(
+        ...         sample_kwargs={
+        ...             "draws": 500,
+        ...             "tune": 500,
+        ...             "chains": 2,
+        ...             "cores": 1,
+        ...             "random_seed": 42,
+        ...             "progressbar": False,
+        ...         }
+        ...     ),
+        ... )
+        >>> with cp.plot_style("editorial"):
+        ...     fig, ax = result.plot()
+        >>> plt.show()
     """
 
     supports_ols = True
@@ -611,13 +628,14 @@ class DifferenceInDifferences(BaseExperiment):
         else:
             arrow_x = 1.05
             arrow_style = "<->"
+        impact_color = active_colors().impact
         ax.annotate(
             "",
             xy=(arrow_x, y_pred_counterfactual_scalar),
             xycoords="data",
             xytext=(arrow_x, y_pred_treatment_scalar),
             textcoords="data",
-            arrowprops={"arrowstyle": arrow_style, "color": "green", "lw": 3},
+            arrowprops={"arrowstyle": arrow_style, "color": impact_color, "lw": 3},
         )
         ax.annotate(
             "causal\nimpact",
@@ -628,7 +646,7 @@ class DifferenceInDifferences(BaseExperiment):
             xycoords="data",
             xytext=(5, 0),
             textcoords="offset points",
-            color="green",
+            color=impact_color,
             va="center",
         )
 

--- a/causalpy/plot_styles.py
+++ b/causalpy/plot_styles.py
@@ -1,0 +1,401 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Configurable plot themes for CausalPy experiment figures.
+
+Historically :meth:`~causalpy.experiments.base.BaseExperiment._render_plot`
+hard-coded the ``arviz-darkgrid`` matplotlib style. This module turns that into
+a small, opt-in registry so the same experiment ``plot()`` methods can render in
+different visual themes without any per-plot changes.
+
+The default theme is unchanged (``arviz-darkgrid``), so existing figures,
+notebooks, and user code look exactly as before. An ``editorial`` theme provides
+a light, publication-oriented (NYT/FT-inspired) look used by the rendered plots
+in the API docstrings.
+
+A theme bundles three things:
+
+* **rcParams** applied for the duration of the draw call (background, spines,
+  grid, colour cycle, tick styling, ...).
+* **Semantic colours** (:class:`PlotColors`) for the few marks that are *not*
+  driven by the matplotlib colour cycle — the difference-in-differences causal
+  impact arrow and the zero/treatment reference rules. These let those accents
+  follow the active theme instead of being hard-coded.
+* An optional **title font** stack applied to axis titles after drawing, so a
+  theme can use a serif headline over sans-serif data labels.
+
+The public surface is intentionally tiny: :func:`plot_style` (a context manager),
+:func:`set_plot_style` (a global switch), and the registry helpers. Naming is
+kept theme-centric so the registry can later map to declarative
+:mod:`plotnine` themes (see issue #988) without changing callers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+from dataclasses import dataclass
+
+import arviz as az
+import matplotlib as mpl
+import matplotlib.colors as mcolors
+from cycler import cycler
+from matplotlib.lines import Line2D
+
+# -- Editorial palette (PyMC brand) ------------------------------------------
+# Colours anchor on the official PyMC brand palette so figures read as native to
+# the PyMC ecosystem. Source: https://github.com/pymc-devs/brand (the brand repo
+# ships these as swatch PNGs, e.g. ``colorswatch_12698a_green.png`` for the teal
+# and ``colorswatch_504a4e_black.png`` for the charcoal). The near-white ground
+# is an editorial choice (PyMC's own ground is white ``#ffffff``); everything
+# else is brand teal + charcoal. Exposed as module constants so tests and
+# downstream code can reference the exact values.
+PYMC_TEAL = "#12698a"  #: PyMC primary brand colour (logo teal / petrol blue).
+PYMC_CHARCOAL = "#504a4e"  #: PyMC brand dark (logo wordmark charcoal).
+
+EDITORIAL_BG = "#faf9f7"  #: Near-white warm background (editorial ground).
+EDITORIAL_INK = PYMC_CHARCOAL  #: Text, observed points, reference rules, accents.
+EDITORIAL_MUTED = "#7d7377"  #: Muted charcoal tint for labels and reference rules.
+EDITORIAL_SPINE = "#9a9296"  #: Colour of the single (bottom) axis spine.
+EDITORIAL_GRID = "#dcd6ca"  #: Subtle horizontal gridline colour.
+
+#: Ordered qualitative colour cycle mapped onto the ``C0``/``C1``/``C2`` roles
+#: the experiment ``_plot`` methods use (``C0`` = control / pre-period, ``C1`` =
+#: treated / counterfactual). Led by the two PyMC brand colours, followed by
+#: teal/charcoal-family tints for any additional series.
+EDITORIAL_CYCLE = [
+    PYMC_TEAL,  # C0 PyMC teal
+    PYMC_CHARCOAL,  # C1 PyMC charcoal
+    "#5aa0b8",  # C2 light teal
+    "#8a8388",  # C3 warm grey
+    "#0e4e68",  # C4 deep teal
+    "#b7c9d1",  # C5 pale teal-grey
+]
+
+# NOTE on the font choice (issue #391). The editorial theme sets a *serif title
+# over sans-serif data labels* — the NYT/FT headline convention. We deliberately
+# use only serif faces that ship *with matplotlib* (STIX Two Text, STIXGeneral,
+# DejaVu Serif) rather than a more distinctive system or web font. The docstring
+# plots are rendered on Read the Docs, which installs via pip (not the conda
+# env), so any face that is not bundled with matplotlib — e.g. Charter, Georgia,
+# Ubuntu, or the NYT-analog "Libre Franklin" — would silently fall back to the
+# default and render differently on RTD than it does locally. Shipping a
+# distinctive sans (Libre Franklin is OFL-licensed) as a bundled repo asset
+# registered through matplotlib.font_manager is a possible future upgrade; it is
+# intentionally left out here to keep this change dependency-free and its output
+# reproducible across environments.
+#: Serif title font stack; first available wins, ``DejaVu Serif`` is the floor.
+EDITORIAL_TITLE_FONT: tuple[str, ...] = ("STIX Two Text", "STIXGeneral", "DejaVu Serif")
+
+EDITORIAL_RCPARAMS: dict[str, object] = {
+    "figure.facecolor": EDITORIAL_BG,
+    "axes.facecolor": EDITORIAL_BG,
+    "savefig.facecolor": EDITORIAL_BG,
+    "savefig.edgecolor": EDITORIAL_BG,
+    "font.family": "sans-serif",
+    "text.color": EDITORIAL_INK,
+    "axes.edgecolor": EDITORIAL_SPINE,
+    "axes.linewidth": 1.1,
+    "axes.grid": True,
+    "axes.grid.axis": "y",
+    "axes.axisbelow": True,
+    "grid.color": EDITORIAL_GRID,
+    "grid.linewidth": 0.9,
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "axes.spines.left": False,
+    "axes.spines.bottom": True,
+    "axes.titlelocation": "left",
+    "axes.titlesize": 14,
+    "axes.titleweight": "bold",
+    "axes.titlepad": 10,
+    "axes.titlecolor": EDITORIAL_INK,
+    "axes.labelcolor": EDITORIAL_MUTED,
+    "axes.labelsize": 11,
+    "xtick.color": EDITORIAL_MUTED,
+    "ytick.color": EDITORIAL_MUTED,
+    "xtick.labelcolor": EDITORIAL_MUTED,
+    "ytick.labelcolor": EDITORIAL_MUTED,
+    "xtick.labelsize": 10,
+    "ytick.labelsize": 10,
+    "xtick.major.size": 0,
+    "ytick.major.size": 0,
+    "xtick.major.pad": 7,
+    "ytick.major.pad": 7,
+    "legend.frameon": False,
+    "legend.fontsize": 10,
+    "lines.linewidth": 2.0,
+    "axes.prop_cycle": cycler(color=EDITORIAL_CYCLE),
+}
+
+
+@dataclass(frozen=True)
+class PlotColors:
+    """Theme-driven colours for marks that are not on the matplotlib colour cycle.
+
+    Attributes
+    ----------
+    impact : str
+        Colour for emphasis marks such as the difference-in-differences causal
+        impact arrow.
+    reference : str
+        Colour for reference rules such as the zero line on impact panels and
+        the treatment-time marker.
+    """
+
+    impact: str
+    reference: str
+
+
+@dataclass(frozen=True)
+class PlotTheme:
+    """A named plotting theme.
+
+    Attributes
+    ----------
+    name : str
+        Registry key, e.g. ``"editorial"``.
+    rcparams : dict or None
+        Matplotlib rcParams applied while drawing. ``None`` means "use the
+        matplotlib/ArviZ style named ``name``" (how the default
+        ``arviz-darkgrid`` theme defers to :data:`arviz.style.library`).
+    colors : PlotColors
+        Semantic accent colours (see :class:`PlotColors`).
+    title_font : tuple of str or None
+        Font family stack applied to axis titles after drawing, or ``None`` to
+        leave titles in the rcParams font.
+    """
+
+    name: str
+    rcparams: dict[str, object] | None
+    colors: PlotColors
+    title_font: tuple[str, ...] | None
+
+
+_THEMES: dict[str, PlotTheme] = {
+    # Default: byte-for-byte the previous behaviour (green arrow, black rules,
+    # arviz-darkgrid style, rcParams title font).
+    "arviz-darkgrid": PlotTheme(
+        name="arviz-darkgrid",
+        rcparams=None,
+        colors=PlotColors(impact="green", reference="k"),
+        title_font=None,
+    ),
+    "editorial": PlotTheme(
+        name="editorial",
+        rcparams=EDITORIAL_RCPARAMS,
+        colors=PlotColors(impact=EDITORIAL_INK, reference=EDITORIAL_MUTED),
+        title_font=EDITORIAL_TITLE_FONT,
+    ),
+}
+
+#: Name of the active theme. Defaults to ``"arviz-darkgrid"`` to preserve the
+#: historical look for all existing callers.
+_ACTIVE: str = "arviz-darkgrid"
+
+
+def available_styles() -> list[str]:
+    """Return the names of the registered themes."""
+    return list(_THEMES)
+
+
+def get_theme(name: str) -> PlotTheme:
+    """Return the :class:`PlotTheme` registered under ``name``.
+
+    Parameters
+    ----------
+    name : str
+        A registered theme name (see :func:`available_styles`).
+
+    Raises
+    ------
+    ValueError
+        If ``name`` is not a registered theme.
+    """
+    try:
+        return _THEMES[name]
+    except KeyError:
+        raise ValueError(
+            f"Unknown plot style {name!r}. Available: {available_styles()}."
+        ) from None
+
+
+def active_theme() -> PlotTheme:
+    """Return the currently active :class:`PlotTheme`."""
+    return _THEMES[_ACTIVE]
+
+
+def active_colors() -> PlotColors:
+    """Return the active theme's semantic accent colours.
+
+    Experiment ``_plot`` methods call this for marks that are not driven by the
+    matplotlib colour cycle, so those accents follow the active theme.
+    """
+    return active_theme().colors
+
+
+def style_context(theme: PlotTheme | None = None) -> list:
+    """Build the argument for :func:`matplotlib.pyplot.style.context`.
+
+    Parameters
+    ----------
+    theme : PlotTheme, optional
+        Theme to render. Defaults to the :func:`active_theme`.
+
+    Returns
+    -------
+    list
+        A style spec list suitable for ``plt.style.context(...)``. Custom
+        rcParams themes are composed on top of the matplotlib defaults so the
+        result is independent of any ambient global style; the default
+        ``arviz-darkgrid`` theme defers to :data:`arviz.style.library` exactly
+        as before.
+    """
+    theme = theme or active_theme()
+    if theme.rcparams is None:
+        return [az.style.library[theme.name]]
+    return ["default", theme.rcparams]
+
+
+def apply_title_font(fig: mpl.figure.Figure, fonts: Sequence[str]) -> None:
+    """Apply a font family stack to every axis title (and suptitle) on ``fig``.
+
+    Lets a theme use a serif headline over sans-serif data labels without each
+    ``_plot`` method having to opt in.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure whose titles to restyle.
+    fonts : sequence of str
+        Font family stack (first available wins).
+    """
+    family = list(fonts)
+    for ax in fig.axes:
+        title = ax.title
+        if title is not None and title.get_text():
+            title.set_fontfamily(family)
+    suptitle = getattr(fig, "_suptitle", None)
+    if suptitle is not None and suptitle.get_text():
+        suptitle.set_fontfamily(family)
+
+
+_CN_RE = re.compile(r"^C\d+$")
+
+
+def _is_cycle_ref(color: object) -> bool:
+    """True for a matplotlib cycle reference string like ``"C0"``/``"C1"``."""
+    return isinstance(color, str) and bool(_CN_RE.match(color))
+
+
+def bake_cycle_colors(fig: mpl.figure.Figure) -> None:
+    """Freeze deferred ``"CN"`` cycle colours to concrete RGBA on ``fig``.
+
+    matplotlib resolves ``"C0"``/``"C1"``/... against
+    ``rcParams["axes.prop_cycle"]`` **lazily, at draw time**, for
+    :class:`~matplotlib.lines.Line2D`. A figure built inside a temporary style
+    context but *drawn later* by the caller — the API-docstring ``.. plot::``
+    directive, a notebook cell, or a bare ``fig.savefig`` — would otherwise
+    re-resolve those references against whatever cycle is active at draw time
+    (usually the matplotlib default), silently discarding the theme's colours.
+
+    Calling this **inside** the theme's style context resolves each reference
+    against the active (themed) cycle and writes the concrete colour back onto
+    the artist, so the returned figure keeps the theme's colours wherever it is
+    later drawn. Only lines need this: fill/band collections resolve their
+    colours eagerly at creation, so they already carry concrete RGBA.
+
+    Parameters
+    ----------
+    fig : matplotlib.figure.Figure
+        Figure whose artists to freeze. Mutated in place.
+    """
+    for line in fig.findobj(Line2D):
+        for getter, setter in (
+            ("get_color", "set_color"),
+            ("get_markerfacecolor", "set_markerfacecolor"),
+            ("get_markeredgecolor", "set_markeredgecolor"),
+        ):
+            color = getattr(line, getter)()
+            if _is_cycle_ref(color):
+                getattr(line, setter)(mcolors.to_rgba(color))
+
+
+def set_plot_style(name: str) -> str:
+    """Set the active plot theme globally and return the previous theme name.
+
+    Parameters
+    ----------
+    name : str
+        A registered theme name (see :func:`available_styles`).
+
+    Returns
+    -------
+    str
+        The name of the theme that was active before this call, so it can be
+        restored.
+
+    Examples
+    --------
+    >>> import causalpy as cp
+    >>> previous = cp.set_plot_style("editorial")
+    >>> _ = cp.set_plot_style(previous)  # restore
+    """
+    global _ACTIVE
+    get_theme(name)  # validate
+    previous, _ACTIVE = _ACTIVE, name
+    return previous
+
+
+@contextmanager
+def plot_style(name: str) -> Iterator[PlotTheme]:
+    """Temporarily activate a plot theme.
+
+    Parameters
+    ----------
+    name : str
+        A registered theme name (see :func:`available_styles`).
+
+    Yields
+    ------
+    PlotTheme
+        The activated theme.
+
+    Examples
+    --------
+    >>> import causalpy as cp
+    >>> df = cp.load_data("did")
+    >>> result = cp.DifferenceInDifferences(
+    ...     df,
+    ...     formula="y ~ 1 + group*post_treatment",
+    ...     time_variable_name="t",
+    ...     group_variable_name="group",
+    ...     model=cp.pymc_models.LinearRegression(
+    ...         sample_kwargs={
+    ...             "draws": 500,
+    ...             "tune": 500,
+    ...             "chains": 2,
+    ...             "random_seed": 42,
+    ...             "progressbar": False,
+    ...         }
+    ...     ),
+    ... )
+    >>> with cp.plot_style("editorial"):
+    ...     fig, ax = result.plot()
+    """
+    previous = set_plot_style(name)
+    try:
+        yield active_theme()
+    finally:
+        set_plot_style(previous)

--- a/causalpy/tests/test_plot_styles.py
+++ b/causalpy/tests/test_plot_styles.py
@@ -1,0 +1,211 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the configurable plot themes in :mod:`causalpy.plot_styles`."""
+
+import matplotlib.colors as mcolors
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from matplotlib.lines import Line2D
+
+import causalpy as cp
+import causalpy.plot_styles as ps
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+@pytest.fixture(autouse=True)
+def _restore_active_style():
+    """Prevent the module-global active style from leaking across tests."""
+    previous = ps.active_theme().name
+    yield
+    ps.set_plot_style(previous)
+
+
+def _close(a, b, atol=0.01):
+    return np.allclose(mcolors.to_rgba(a), mcolors.to_rgba(b), atol=atol)
+
+
+# -- Registry / default-preservation ----------------------------------------
+def test_default_theme_is_arviz_darkgrid_and_unchanged():
+    """The default must stay arviz-darkgrid with the original accent colours."""
+    theme = ps.active_theme()
+    assert theme.name == "arviz-darkgrid"
+    # rcparams is None => defer to arviz's style library (historical behaviour)
+    assert theme.rcparams is None
+    assert theme.title_font is None
+    assert theme.colors == ps.PlotColors(impact="green", reference="k")
+
+
+def test_available_styles_includes_editorial():
+    assert "arviz-darkgrid" in ps.available_styles()
+    assert "editorial" in ps.available_styles()
+
+
+def test_get_theme_unknown_raises():
+    with pytest.raises(ValueError, match="Unknown plot style"):
+        ps.get_theme("does-not-exist")
+
+
+def test_editorial_theme_uses_pymc_brand_palette():
+    theme = ps.get_theme("editorial")
+    cycle = theme.rcparams["axes.prop_cycle"].by_key()["color"]
+    assert cycle[0] == ps.PYMC_TEAL
+    assert cycle[1] == ps.PYMC_CHARCOAL
+    # ink-role accents are the PyMC charcoal
+    assert theme.colors.impact == ps.PYMC_CHARCOAL
+    assert theme.title_font[0] == "STIX Two Text"
+    assert theme.rcparams["figure.facecolor"] == ps.EDITORIAL_BG
+
+
+# -- Switching the active style ----------------------------------------------
+def test_set_plot_style_switches_and_returns_previous():
+    previous = ps.set_plot_style("editorial")
+    assert previous == "arviz-darkgrid"
+    assert ps.active_theme().name == "editorial"
+    assert ps.active_colors().impact == ps.PYMC_CHARCOAL
+
+
+def test_set_plot_style_unknown_raises_without_changing_state():
+    with pytest.raises(ValueError):
+        ps.set_plot_style("nope")
+    assert ps.active_theme().name == "arviz-darkgrid"
+
+
+def test_plot_style_context_manager_activates_and_restores():
+    assert ps.active_theme().name == "arviz-darkgrid"
+    with ps.plot_style("editorial") as theme:
+        assert theme.name == "editorial"
+        assert ps.active_theme().name == "editorial"
+    assert ps.active_theme().name == "arviz-darkgrid"
+
+
+def test_plot_style_context_restores_on_exception():
+    with pytest.raises(RuntimeError), ps.plot_style("editorial"):
+        assert ps.active_theme().name == "editorial"
+        raise RuntimeError("boom")
+    assert ps.active_theme().name == "arviz-darkgrid"
+
+
+# -- style_context (what plt.style.context receives) -------------------------
+def test_style_context_default_defers_to_arviz_library():
+    spec = ps.style_context(ps.get_theme("arviz-darkgrid"))
+    import arviz as az
+
+    assert spec == [az.style.library["arviz-darkgrid"]]
+
+
+def test_style_context_editorial_composes_on_matplotlib_default():
+    spec = ps.style_context(ps.get_theme("editorial"))
+    assert spec[0] == "default"
+    assert isinstance(spec[1], dict)
+    assert "axes.prop_cycle" in spec[1]
+    with plt.style.context(spec):
+        cycle = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+        assert cycle[0] == ps.PYMC_TEAL
+
+
+# -- apply_title_font --------------------------------------------------------
+def test_apply_title_font_sets_family():
+    fig, ax = plt.subplots()
+    ax.set_title("hello")
+    ps.apply_title_font(fig, ("STIX Two Text", "DejaVu Serif"))
+    assert "STIX Two Text" in ax.title.get_fontfamily()
+    plt.close(fig)
+
+
+def test_apply_title_font_sets_suptitle():
+    fig = plt.figure()
+    fig.suptitle("super")
+    ps.apply_title_font(fig, ("STIX Two Text", "DejaVu Serif"))
+    assert "STIX Two Text" in fig._suptitle.get_fontfamily()
+    plt.close(fig)
+
+
+def test_apply_title_font_skips_empty_titles():
+    fig, ax = plt.subplots()  # no title set
+    ps.apply_title_font(fig, ("DejaVu Serif",))  # must not raise
+    plt.close(fig)
+
+
+# -- bake_cycle_colors -------------------------------------------------------
+def test_is_cycle_ref():
+    assert ps._is_cycle_ref("C0")
+    assert ps._is_cycle_ref("C12")
+    assert not ps._is_cycle_ref("#123456")
+    assert not ps._is_cycle_ref("red")
+    assert not ps._is_cycle_ref((0.1, 0.2, 0.3, 1.0))
+
+
+def test_bake_cycle_colors_freezes_line_colors():
+    with plt.style.context(ps.style_context(ps.get_theme("editorial"))):
+        fig, ax = plt.subplots()
+        (line,) = ax.plot([0, 1], [0, 1], color="C1")
+        # lazily stored as the string "C1" until drawn
+        assert line.get_color() == "C1"
+        ps.bake_cycle_colors(fig)
+        baked = line.get_color()
+    # frozen to a concrete RGBA that survives leaving the style context
+    assert baked != "C1"
+    assert _close(baked, ps.PYMC_CHARCOAL)  # C1 in the editorial cycle
+    plt.close(fig)
+
+
+def test_bake_cycle_colors_leaves_explicit_colors_untouched():
+    fig, ax = plt.subplots()
+    (line,) = ax.plot([0, 1], [0, 1], color="#123456")
+    ps.bake_cycle_colors(fig)
+    assert _close(line.get_color(), "#123456")
+    plt.close(fig)
+
+
+# -- Integration with a real experiment plot() -------------------------------
+@pytest.mark.integration
+def test_editorial_theme_applies_to_experiment_plot(mock_pymc_sample, did_data):
+    """Editorial theme reaches a real figure: near-white ground + baked colours."""
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    with cp.plot_style("editorial"):
+        fig, ax = result.plot(show=False)
+
+    # background is the editorial near-white
+    assert _close(fig.get_facecolor(), ps.EDITORIAL_BG)
+    # no Line2D retains an unresolved "CN" reference (bake ran)
+    line_colors = [ln.get_color() for ln in fig.findobj(Line2D)]
+    assert not any(ps._is_cycle_ref(c) for c in line_colors)
+    # the PyMC brand teal made it onto the figure
+    assert any(_close(c, ps.PYMC_TEAL) for c in line_colors if not ps._is_cycle_ref(c))
+    # the context manager restored the default afterwards
+    assert ps.active_theme().name == "arviz-darkgrid"
+    plt.close(fig)
+
+
+@pytest.mark.integration
+def test_default_theme_plot_not_editorial(mock_pymc_sample, did_data):
+    """Under the default theme the figure must NOT pick up the editorial ground."""
+    result = cp.DifferenceInDifferences(
+        did_data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    fig, ax = result.plot(show=False)
+    assert not _close(fig.get_facecolor(), ps.EDITORIAL_BG)
+    plt.close(fig)


### PR DESCRIPTION
## What this does (and doesn't) update

Addresses #391 (rendered plots in experiment-class API docstrings). Rather than change all ~10 experiments at once, this PR establishes the **pattern end-to-end on `DifferenceInDifferences`** and opens it for discussion before rollout since the issue's original plan was blocked on the #381 refactor, which has since landed.

It turned out that "just add `.. plot::`" has a wrinkle worth solving properly, so this PR also adds a small, opt-in **plot theme system** used by the rendered example.

## Summary of changes

- **New `causalpy/plot_styles.py`** — a tiny theme registry (`PlotTheme` / `PlotColors`) with `plot_style(...)` (context manager), `set_plot_style(...)`, `style_context(...)`, `apply_title_font(...)` and `bake_cycle_colors(...)`. The default theme stays **`arviz-darkgrid`** and is untouched.
- **`editorial` theme** — a light, publication-oriented look anchored on the **official PyMC brand palette** (teal `#12698a` + charcoal `#504a4e`, from [pymc-devs/brand](https://github.com/pymc-devs/brand)): near-white ground, y-grid only, no top/right/left spines, left-aligned **serif titles**, direct-labelled accents.
- **`base._render_plot`** now resolves the *active* theme, applies its title font, and freezes cycle colours (see "Design notes"). Gated to non-default themes, so **`arviz-darkgrid` output is byte-for-byte identical**.
- **`DifferenceInDifferences`** — the causal-impact accent follows the theme (was a hard-coded `green`), and the `Examples` block becomes a `.. plot::` directive that is **both a valid doctest and a rendered figure**, using a small seeded sample.
- Exports `plot_style`, `set_plot_style`, `plot_styles`; adds `causalpy/tests/test_plot_styles.py`.

Usage stays trivial and the default is unchanged:

```python
result = cp.DifferenceInDifferences(df, ...)
with cp.plot_style("editorial"):
    fig, ax = result.plot()
```

## Examples

### Before
 Basic defaults, not my favorite
<img width="950" height="639" alt="causalpy-391-DiD-BEFORE-arviz-darkgrid" src="https://github.com/user-attachments/assets/3ac0a414-885c-441c-8e48-5bada6fd4b46" />


### After
With theming 
<img width="780" height="602" alt="causalpy-391-DiD-AFTER-editorial-pymc" src="https://github.com/user-attachments/assets/4cba9407-c224-4753-ba49-39555371eb71" />


### The theme generalizes to other estimates

An ITS example

<img width="914" height="925" alt="causalpy-391-ITS-editorial-pymc" src="https://github.com/user-attachments/assets/a26c0e46-278a-449c-8ce7-b0ea5e852e14" />



## Design notes (the interesting bits)

- **Serif titles use only matplotlib-bundled fonts** (`STIX Two Text` → `STIXGeneral` → `DejaVu Serif`). Full disclosure, I'm a bit of a font nerd, so I was sorely tempted to ship something like Libre Franklin (the free Franklin-Gothic analog that NYT-style charts lean on) — but a non-bundled face would render differently on Read the Docs, which installs via pip rather than the conda env, so I kept it dependency-free and reproducible. Bundling an OFL font is a nice future upgrade if there's appetite for it.
- **Colour "baking".** matplotlib resolves `"C0"`/`"C1"` cycle refs *lazily, at draw time* for lines. Because `.plot()` returns a figure that's drawn later (the `.. plot::` directive, notebooks, a bare `savefig`), those refs would otherwise re-resolve against the default cycle and silently drop the theme. `bake_cycle_colors` freezes them to concrete RGBA inside the theme context. Fill/band collections resolve eagerly, so only lines need it.
- **`conf.py` is untouched** — `matplotlib.sphinxext.plot_directive` is already enabled, and `autodoc_mock_imports` doesn't block directive execution (the mock is scoped to autodoc's own imports).

## Testing / docs

- `make test-patch-cov`: **1250 passed, 5 skipped**; patch coverage **~98–100%** on the changed lines (new module fully covered).
- `prek` clean (ruff, ruff-format, numpydoc, mypy). Default plot output verified byte-identical.
- `make html` builds cleanly and renders the figure on the DiD API page, with **zero new warnings**.

## Questions for maintainers (happy to adjust)

1. Is the editorial + PyMC-brand direction what you want for the docstring plots, or should they match the notebook gallery's current style?
2. The rendered plots sample a small seeded model per `.. plot::` at build time (~30–60s each). OK for RTD, or would you prefer the OLS/`sklearn` variants (instant, deterministic, but no posterior bands)?
3. How should this relate to the planned plotnine migration (#988) and the PyMC-6 plotting port (#1043)? The named-theme API is meant to map cleanly onto `plotnine.theme()` later.
4. If the direction is agreed: rollout is to theme the remaining experiments' hard-coded accents (`k`/`green`/etc.) and add `.. plot::` to the other ~9 docstrings.
