### PR TITLE
Preserve SDID mapping inputs during fit

### DIFF
--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -227,6 +227,10 @@ class PyMCModelAdapter(ModelAdapter):
         coords : dict, optional
             Coordinate metadata for the PyMC model.
         """
+        if isinstance(X, dict) and isinstance(y, dict):
+            return self._model.fit_mapping(X=X, y=y, coords=coords)
+        if isinstance(X, dict) or isinstance(y, dict):
+            raise TypeError("X and y must either both be mappings or both be arrays")
         return self._model.fit(X=X, y=y, coords=coords)
 
     def predict(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -15,7 +15,7 @@
 
 import inspect
 import warnings
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 import arviz as az
 import numpy as np
@@ -338,17 +338,22 @@ class PyMCModel(pm.Model):
             )
 
     def fit(
-        self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None = None
+        self,
+        X: xr.DataArray | dict[str, xr.DataArray],
+        y: xr.DataArray | dict[str, xr.DataArray],
+        coords: dict[str, Any] | None = None,
     ) -> xr.DataTree:
         """Draw samples from posterior, prior predictive, and posterior
         predictive distributions.
 
         Parameters
         ----------
-        X : xr.DataArray
-            Input features as an xarray DataArray.
-        y : xr.DataArray
-            Target variable as an xarray DataArray.
+        X : xarray.DataArray or dict of str to xarray.DataArray
+            Input features. Specialized models may consume a dictionary of
+            labeled input arrays.
+        y : xarray.DataArray or dict of str to xarray.DataArray
+            Target values. Specialized models may consume a dictionary of
+            labeled target arrays.
         coords : dict, optional
             Dictionary with coordinate names for named dimensions.
             Defaults to None.
@@ -360,9 +365,28 @@ class PyMCModel(pm.Model):
         """
 
         coords = {} if coords is None else coords.copy()
-        for data in (X, y):
-            for dimension in data.dims:
-                coords.setdefault(dimension, data.get_index(dimension))
+        if isinstance(X, xr.DataArray) and isinstance(y, xr.DataArray):
+            for data in (X, y):
+                for dimension in data.dims:
+                    coords.setdefault(dimension, data.get_index(dimension))
+            self._n_treated_units = y.sizes.get("treated_units", 1)
+        elif (
+            isinstance(X, dict)
+            and isinstance(y, dict)
+            and X
+            and y
+            and all(
+                isinstance(key, str) and isinstance(value, xr.DataArray)
+                for data in (X, y)
+                for key, value in data.items()
+            )
+        ):
+            self._n_treated_units = 1
+        else:
+            raise TypeError(
+                "X and y must both be xarray.DataArray objects or non-empty "
+                "dictionaries mapping strings to xarray.DataArray objects"
+            )
 
         # Ensure random_seed is used in sample_prior_predictive() and
         # sample_posterior_predictive() if provided in sample_kwargs.
@@ -372,8 +396,7 @@ class PyMCModel(pm.Model):
         # Data-driven priors are computed first, then user-specified priors override them
         self.priors = {**self.priors_from_data(X, y), **self.priors}
 
-        self._n_treated_units = y.sizes.get("treated_units", 1)
-        self.build_model(X, y, coords)
+        self.build_model(cast(xr.DataArray, X), cast(xr.DataArray, y), coords)
         with self:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is None:

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -15,7 +15,7 @@
 
 import inspect
 import warnings
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 import arviz as az
 import numpy as np
@@ -339,8 +339,8 @@ class PyMCModel(pm.Model):
 
     def fit(
         self,
-        X: xr.DataArray | dict[str, xr.DataArray],
-        y: xr.DataArray | dict[str, xr.DataArray],
+        X: xr.DataArray,
+        y: xr.DataArray,
         coords: dict[str, Any] | None = None,
     ) -> xr.DataTree:
         """Draw samples from posterior, prior predictive, and posterior
@@ -348,12 +348,10 @@ class PyMCModel(pm.Model):
 
         Parameters
         ----------
-        X : xarray.DataArray or dict of str to xarray.DataArray
-            Input features. Specialized models may consume a dictionary of
-            labeled input arrays.
-        y : xarray.DataArray or dict of str to xarray.DataArray
-            Target values. Specialized models may consume a dictionary of
-            labeled target arrays.
+        X : xarray.DataArray
+            Input features as a labeled array.
+        y : xarray.DataArray
+            Target values as a labeled array.
         coords : dict, optional
             Dictionary with coordinate names for named dimensions.
             Defaults to None.
@@ -364,30 +362,45 @@ class PyMCModel(pm.Model):
             DataTree containing the samples.
         """
 
-        coords = {} if coords is None else coords.copy()
-        if isinstance(X, xr.DataArray) and isinstance(y, xr.DataArray):
-            for data in (X, y):
-                for dimension in data.dims:
-                    coords.setdefault(dimension, data.get_index(dimension))
-            self._n_treated_units = y.sizes.get("treated_units", 1)
-        elif (
-            isinstance(X, dict)
-            and isinstance(y, dict)
-            and X
-            and y
-            and all(
-                isinstance(key, str) and isinstance(value, xr.DataArray)
-                for data in (X, y)
-                for key, value in data.items()
-            )
-        ):
-            self._n_treated_units = 1
-        else:
+        if not isinstance(X, xr.DataArray) or not isinstance(y, xr.DataArray):
             raise TypeError(
-                "X and y must both be xarray.DataArray objects or non-empty "
-                "dictionaries mapping strings to xarray.DataArray objects"
+                "X and y must both be xarray.DataArray objects; specialized "
+                "mapping inputs must be fitted through PyMCModelAdapter"
             )
 
+        coords = {} if coords is None else coords.copy()
+        for data in (X, y):
+            for dimension in data.dims:
+                coords.setdefault(dimension, data.get_index(dimension))
+        self._n_treated_units = y.sizes.get("treated_units", 1)
+        return self._fit_with_validated_data(X, y, coords)
+
+    def fit_mapping(
+        self,
+        X: dict[str, xr.DataArray],
+        y: dict[str, xr.DataArray],
+        coords: dict[str, Any] | None = None,
+    ) -> xr.DataTree:
+        """Fit a specialized model that accepts mapping-valued inputs.
+
+        Parameters
+        ----------
+        X : dict of str to xarray.DataArray
+            Labeled predictor arrays for specialized model components.
+        y : dict of str to xarray.DataArray
+            Labeled target arrays for specialized model components.
+        coords : dict, optional
+            Coordinate metadata for the model.
+        """
+        raise TypeError(f"{type(self).__name__} does not support mapping-valued inputs")
+
+    def _fit_with_validated_data(
+        self,
+        X: Any,
+        y: Any,
+        coords: dict[str, Any],
+    ) -> xr.DataTree:
+        """Build and sample a model after its public fit boundary validates inputs."""
         # Ensure random_seed is used in sample_prior_predictive() and
         # sample_posterior_predictive() if provided in sample_kwargs.
         random_seed = self.sample_kwargs.get("random_seed", None)
@@ -396,7 +409,7 @@ class PyMCModel(pm.Model):
         # Data-driven priors are computed first, then user-specified priors override them
         self.priors = {**self.priors_from_data(X, y), **self.priors}
 
-        self.build_model(cast(xr.DataArray, X), cast(xr.DataArray, y), coords)
+        self.build_model(X, y, coords)
         with self:
             self.idata = pm.sample(**self.sample_kwargs)
             if self.idata is None:
@@ -1089,6 +1102,67 @@ class SyntheticDifferenceInDifferencesWeightFitter(PyMCModel):
     """  # noqa: W605
 
     default_priors: dict[str, Prior] = {}
+
+    def fit(
+        self,
+        X: xr.DataArray | dict[str, xr.DataArray],
+        y: xr.DataArray | dict[str, xr.DataArray],
+        coords: dict[str, Any] | None = None,
+    ) -> xr.DataTree:
+        """Fit SDID mappings while retaining the ordinary model fit contract.
+
+        Parameters
+        ----------
+        X : xarray.DataArray or dict of str to xarray.DataArray
+            Predictor data for an ordinary fit or the SDID weight modules.
+        y : xarray.DataArray or dict of str to xarray.DataArray
+            Target data for an ordinary fit or the SDID weight modules.
+        coords : dict, optional
+            Coordinate metadata for the model.
+        """
+        if isinstance(X, dict) and isinstance(y, dict):
+            return self.fit_mapping(X, y, coords)
+        if isinstance(X, dict) or isinstance(y, dict):
+            raise TypeError("X and y must either both be mappings or both be arrays")
+        return super().fit(X, y, coords)
+
+    def fit_mapping(
+        self,
+        X: dict[str, xr.DataArray],
+        y: dict[str, xr.DataArray],
+        coords: dict[str, Any] | None = None,
+    ) -> xr.DataTree:
+        """Fit the unit- and time-weight modules from labeled mapping inputs.
+
+        Parameters
+        ----------
+        X : dict of str to xarray.DataArray
+            Unit- and time-weight design matrices.
+        y : dict of str to xarray.DataArray
+            Unit- and time-weight target arrays.
+        coords : dict, optional
+            Coordinate metadata shared by the two modules.
+        """
+        if (
+            not X
+            or not y
+            or not all(
+                isinstance(key, str) and isinstance(value, xr.DataArray)
+                for data in (X, y)
+                for key, value in data.items()
+            )
+        ):
+            raise TypeError(
+                "X and y must be non-empty dictionaries mapping strings to "
+                "xarray.DataArray objects"
+            )
+
+        self._n_treated_units = 1
+        return self._fit_with_validated_data(
+            X,
+            y,
+            {} if coords is None else coords.copy(),
+        )
 
     def priors_from_data(self, X, y) -> dict[str, Any]:
         """

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -1103,12 +1103,24 @@ class TestSoftmaxWeightedSumFitterMultiUnit:
         for i, _unit in enumerate(treated_units):
             assert f"unit_{i}_r2" in scores.index
 
-    def test_build_model_raises_without_coeffs_coord(self, synthetic_control_data):
-        """Test that build_model raises ValueError when coords lacks 'coeffs'."""
-        X, y, _coords, _control_units, _treated_units = synthetic_control_data
+    def test_fit_infers_coords_from_labeled_arrays(self, synthetic_control_data):
+        """Fit infers model coordinates from labeled DataArray inputs."""
+        X, y, _coords, control_units, treated_units = synthetic_control_data
         wsf = SoftmaxWeightedSumFitter(sample_kwargs=sample_kwargs)
-        with pytest.raises(ValueError, match="coords must include 'coeffs'"):
-            wsf.fit(X, y, coords={"treated_units": ["unit_0"], "obs_ind": [0]})
+        result = wsf.fit(X, y)
+
+        np.testing.assert_array_equal(
+            result.posterior.coords["coeffs"].values,
+            control_units,
+        )
+        np.testing.assert_array_equal(
+            result.posterior.coords["treated_units"].values,
+            treated_units,
+        )
+        np.testing.assert_array_equal(
+            result.posterior.coords["obs_ind"].values,
+            X.coords["obs_ind"].values,
+        )
 
 
 @pytest.fixture(scope="module")

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -20,6 +20,7 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
+from causalpy.experiments.model_adapter import PyMCModelAdapter
 from causalpy.pymc_models import (
     LinearRegression,
     PyMCModel,
@@ -110,7 +111,36 @@ class TestPyMCModel:
         with pytest.raises(
             NotImplementedError, match="This method must be implemented by a subclass"
         ):
-            PyMCModel().fit(X=np.ones(2), y=np.ones(3), coords={"a": 1})
+            X = xr.DataArray(
+                np.ones((2, 1)),
+                dims=["obs_ind", "coeffs"],
+                coords={"obs_ind": [0, 1], "coeffs": ["x"]},
+            )
+            y = xr.DataArray(
+                np.ones((2, 1)),
+                dims=["obs_ind", "treated_units"],
+                coords={"obs_ind": [0, 1], "treated_units": ["unit_0"]},
+            )
+            PyMCModel().fit(X=X, y=y, coords={"a": 1})
+
+    @pytest.mark.parametrize(
+        ("X", "y"),
+        [
+            (
+                {"unit": xr.DataArray([1.0], dims=["obs_ind"])},
+                xr.DataArray([1.0], dims=["obs_ind"]),
+            ),
+            (
+                {"unit": np.array([1.0])},
+                {"unit": xr.DataArray([1.0], dims=["obs_ind"])},
+            ),
+        ],
+        ids=["mixed-direct-and-mapping", "mapping-with-non-dataarray-value"],
+    )
+    def test_fit_rejects_mixed_or_malformed_input_shapes(self, X, y) -> None:
+        """Fit rejects non-DataArray pairs before model construction."""
+        with pytest.raises(TypeError, match="both be xarray.DataArray"):
+            MyToyModel().fit(X=X, y=y)
 
     @pytest.mark.parametrize(
         argnames="coords",
@@ -967,18 +997,26 @@ class TestSyntheticDifferenceInDifferencesWeightFitter:
         }
         return X, y, coords
 
-    def test_fitting(self, sdid_data):
-        """Test that the model fits and produces omega and lam posteriors."""
+    def test_fitting_through_adapter_preserves_coordinate_labels(self, sdid_data):
+        """Fitting through the adapter preserves the specialized mapping labels."""
         X, y, coords = sdid_data
-        model = SyntheticDifferenceInDifferencesWeightFitter(
-            sample_kwargs=sample_kwargs
+        adapter = PyMCModelAdapter(
+            SyntheticDifferenceInDifferencesWeightFitter(sample_kwargs=sample_kwargs)
         )
-        result = model.fit(X, y, coords=coords)
+        result = adapter.fit(X, y, coords=coords)
 
         assert isinstance(result, xr.DataTree)
         assert "posterior" in result
         assert "omega" in result.posterior
         assert "lam" in result.posterior
+        np.testing.assert_array_equal(
+            result.posterior["omega"].coords["coeffs"].values,
+            coords["coeffs"],
+        )
+        np.testing.assert_array_equal(
+            result.posterior["lam"].coords["obs_ind"].values,
+            coords["obs_ind"],
+        )
 
     def test_omega_is_simplex(self, sdid_data):
         """Test that omega weights sum to 1."""

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -148,6 +148,14 @@ class TestPyMCModel:
         with pytest.raises(TypeError, match="does not support mapping-valued inputs"):
             PyMCModelAdapter(MyToyModel()).fit(X=data, y=data)
 
+    def test_adapter_rejects_mixed_mapping_and_array_inputs(self) -> None:
+        """The adapter requires predictor and target containers to match."""
+        data = xr.DataArray([1.0], dims=["obs_ind"])
+        with pytest.raises(
+            TypeError, match="either both be mappings or both be arrays"
+        ):
+            PyMCModelAdapter(MyToyModel()).fit(X={"unit": data}, y=data)
+
     @pytest.mark.parametrize(
         argnames="coords",
         argvalues=[None, {"a": 1}],
@@ -1032,6 +1040,18 @@ class TestSyntheticDifferenceInDifferencesWeightFitter:
 
         with pytest.raises(TypeError, match="mapping strings to xarray.DataArray"):
             adapter.fit(X, y, coords=coords)
+
+    def test_direct_fit_rejects_mixed_mapping_and_array_inputs(self, sdid_data):
+        """The direct SDID fit boundary requires matching input containers."""
+        X, y, coords = sdid_data
+        with pytest.raises(
+            TypeError, match="either both be mappings or both be arrays"
+        ):
+            SyntheticDifferenceInDifferencesWeightFitter().fit(
+                X,
+                y["unit"],
+                coords=coords,
+            )
 
     def test_omega_is_simplex(self, sdid_data):
         """Test that omega weights sum to 1."""

--- a/causalpy/tests/test_pymc_models.py
+++ b/causalpy/tests/test_pymc_models.py
@@ -142,6 +142,12 @@ class TestPyMCModel:
         with pytest.raises(TypeError, match="both be xarray.DataArray"):
             MyToyModel().fit(X=X, y=y)
 
+    def test_base_mapping_fit_rejects_unsupported_model(self) -> None:
+        """The mapping fit capability fails clearly on ordinary PyMC models."""
+        data = {"unit": xr.DataArray([1.0], dims=["obs_ind"])}
+        with pytest.raises(TypeError, match="does not support mapping-valued inputs"):
+            PyMCModelAdapter(MyToyModel()).fit(X=data, y=data)
+
     @pytest.mark.parametrize(
         argnames="coords",
         argvalues=[None, {"a": 1}],
@@ -1017,6 +1023,15 @@ class TestSyntheticDifferenceInDifferencesWeightFitter:
             result.posterior["lam"].coords["obs_ind"].values,
             coords["obs_ind"],
         )
+
+    def test_mapping_fit_rejects_malformed_values(self, sdid_data):
+        """The SDID mapping boundary rejects values without xarray labels."""
+        X, y, coords = sdid_data
+        X = {**X, "unit": np.asarray(X["unit"])}
+        adapter = PyMCModelAdapter(SyntheticDifferenceInDifferencesWeightFitter())
+
+        with pytest.raises(TypeError, match="mapping strings to xarray.DataArray"):
+            adapter.fit(X, y, coords=coords)
 
     def test_omega_is_simplex(self, sdid_data):
         """Test that omega weights sum to 1."""


### PR DESCRIPTION
## Summary

Preserve specialized SDID `dict[str, xarray.DataArray]` inputs through `PyMCModelAdapter.fit` without weakening the ordinary `PyMCModel.fit(DataArray, DataArray)` contract or its coordinate inference.

Closes #1072
Part of #1038

## Changes

- Keep the ordinary PyMC fit boundary typed to paired labeled `DataArray` inputs and infer their coordinates as before.
- Add an explicit mapping-fit capability routed by `PyMCModelAdapter`, implemented and validated only by `SyntheticDifferenceInDifferencesWeightFitter`.
- Preserve direct SDID dictionary fitting for compatibility while rejecting mixed, empty, malformed, and unsupported mapping inputs with clear errors.
- Cover adapter forwarding, SDID coordinate labels, ordinary coordinate inference, malformed mappings, and container mismatches.

## Testing

- Focused mapping, SDID, and coordinate regression selection — 8 passed.
- `mamba run -n mamba_temp_env_issue_1072 python -m pytest --no-cov -q -ra causalpy/tests/test_pymc_models.py` — 65 passed.
- `mamba run -n mamba_temp_env_issue_1072 prek run mypy --all-files` — passed.
- `mamba run -n mamba_temp_env_issue_1072 prek run --all-files` — passed.
- Affected coverage plus `diff-cover coverage.xml --compare-branch=89f36e0c07c119b257163dc34b0c23650149148c --fail-under=96 --exclude 'causalpy/tests/*'` — 98% exact-base patch coverage on final head `1eb8965762c42d78a69f1ec94a6bb8c69bea6434`.
- The exact `fitted_sdid` fixture completes fitting and reaches plotting; its plot assertion currently fails on the source-verified #1043 `az.style.library` incompatibility.
- A full-suite patch-coverage attempt was run but could not complete cleanly before #1043 because the integration base contains the known plotting failure family; it is not reported as passed.

## Integration prerequisites

- This PR targets only `pymc6_and_pymcmarketing1_migration`.
- #1045 merged through PR #1075 at integration SHA `89f36e0c07c119b257163dc34b0c23650149148c`.
- The current integration branch was merged normally into this head; no rebase or force push was used.
- Read the Docs and all applicable remote checks must pass on the final head before readiness and merge.

## Checklist

- [x] Type-safe SDID mapping boundary with no hidden cast
- [x] Focused model and adapter tests
- [x] All-files prek and mypy
- [x] Exact-base patch coverage above 96%
- [x] #1045 merged and integration branch synchronized
- [x] Read the Docs green on final head
- [x] Final checks green before ready/merge
