### PR TITLE
PyMC 6 migration: establish serial notebook infrastructure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: ci
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, pymc6_and_pymcmarketing1_migration]
   push:
-    branches: [main]
+    branches: [main, pymc6_and_pymcmarketing1_migration]
 
 permissions: {}
 

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -33,6 +33,7 @@ jobs:
       contents: read
     timeout-minutes: 180
     strategy:
+      fail-fast: false
       max-parallel: 1
       matrix:
         include:

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -24,7 +24,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   notebooks:
@@ -50,8 +50,8 @@ jobs:
           - name: gallery-other
             collection: gallery
             pattern: ""
-            exclude_one: pymc
-            exclude_two: sklearn
+            exclude_one: "*-pymc.ipynb"
+            exclude_two: "*-sklearn.ipynb"
           - name: knowledgebase
             collection: knowledgebase
             pattern: ""

--- a/.github/workflows/test_notebook.yml
+++ b/.github/workflows/test_notebook.yml
@@ -2,40 +2,60 @@ name: Test Notebooks
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, pymc6_and_pymcmarketing1_migration]
     paths:
       - "pyproject.toml"
       - "causalpy/**"
       - ".github/workflows/test_notebook.yml"
       - "scripts/run_notebooks/**"
       - "docs/source/notebooks/**"
+      - "docs/source/knowledgebase/**"
   push:
-    branches: [main]
+    branches: [main, pymc6_and_pymcmarketing1_migration]
     paths:
       - "pyproject.toml"
       - "causalpy/**"
       - ".github/workflows/test_notebook.yml"
       - "scripts/run_notebooks/**"
       - "docs/source/notebooks/**"
+      - "docs/source/knowledgebase/**"
 
 permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   notebooks:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    timeout-minutes: 60
+    timeout-minutes: 180
     strategy:
+      max-parallel: 1
       matrix:
-        split:
-          - "--pattern *-pymc.ipynb"
-          - "--pattern *-sklearn.ipynb"
-          - "--exclude-pattern=pymc --exclude-pattern=sklearn"
+        include:
+          - name: gallery-pymc
+            collection: gallery
+            pattern: "*-pymc.ipynb"
+            exclude_one: ""
+            exclude_two: ""
+          - name: gallery-sklearn
+            collection: gallery
+            pattern: "*-sklearn.ipynb"
+            exclude_one: ""
+            exclude_two: ""
+          - name: gallery-other
+            collection: gallery
+            pattern: ""
+            exclude_one: pymc
+            exclude_two: sklearn
+          - name: knowledgebase
+            collection: knowledgebase
+            pattern: ""
+            exclude_one: ""
+            exclude_two: ""
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -51,7 +71,24 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
+          pip install -r docs/requirements.txt
           pip install -e ".[test,docs]"
 
       - name: Run notebooks
-        run: python scripts/run_notebooks/runner.py ${{ matrix.split }}
+        env:
+          NOTEBOOK_COLLECTION: ${{ matrix.collection }}
+          NOTEBOOK_PATTERN: ${{ matrix.pattern }}
+          NOTEBOOK_EXCLUDE_ONE: ${{ matrix.exclude_one }}
+          NOTEBOOK_EXCLUDE_TWO: ${{ matrix.exclude_two }}
+        run: |
+          args=(--collection "$NOTEBOOK_COLLECTION")
+          if [[ -n "$NOTEBOOK_PATTERN" ]]; then
+            args+=(--pattern "$NOTEBOOK_PATTERN")
+          fi
+          if [[ -n "$NOTEBOOK_EXCLUDE_ONE" ]]; then
+            args+=(--exclude-pattern "$NOTEBOOK_EXCLUDE_ONE")
+          fi
+          if [[ -n "$NOTEBOOK_EXCLUDE_TWO" ]]; then
+            args+=(--exclude-pattern "$NOTEBOOK_EXCLUDE_TWO")
+          fi
+          python scripts/run_notebooks/runner.py "${args[@]}"

--- a/causalpy/tests/test_notebook_runner.py
+++ b/causalpy/tests/test_notebook_runner.py
@@ -1,0 +1,235 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for resource-safe documentation notebook selection."""
+
+from pathlib import Path
+
+import pytest
+
+from scripts.run_notebooks import runner
+
+
+@pytest.fixture
+def notebook_collections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> dict[str, Path]:
+    gallery = tmp_path / "docs" / "source" / "notebooks"
+    knowledgebase = tmp_path / "docs" / "source" / "knowledgebase"
+    gallery.mkdir(parents=True)
+    knowledgebase.mkdir(parents=True)
+    for path in (
+        gallery / "alpha-pymc.ipynb",
+        gallery / "beta-sklearn.ipynb",
+        gallery / "other.ipynb",
+        gallery / "skipped.ipynb",
+        knowledgebase / "concepts.ipynb",
+    ):
+        path.touch()
+
+    collections = {"gallery": gallery, "knowledgebase": knowledgebase}
+    monkeypatch.setattr(runner, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(runner, "NOTEBOOK_COLLECTIONS", collections)
+    monkeypatch.setattr(runner, "SKIP_NOTEBOOKS", {"gallery/skipped.ipynb"})
+    return collections
+
+
+def test_default_selection_uses_gallery_and_mock_skip_policy(
+    notebook_collections: dict[str, Path],
+) -> None:
+    notebooks = runner.get_notebooks()
+
+    assert [notebook.name for notebook in notebooks] == [
+        "alpha-pymc.ipynb",
+        "beta-sklearn.ipynb",
+        "other.ipynb",
+    ]
+
+
+def test_named_knowledgebase_collection_is_discoverable(
+    notebook_collections: dict[str, Path],
+) -> None:
+    notebooks = runner.get_notebooks(collections=["knowledgebase"])
+
+    assert [notebook.name for notebook in notebooks] == ["concepts.ipynb"]
+
+
+def test_multiple_exact_notebooks_can_cross_collections(
+    notebook_collections: dict[str, Path],
+) -> None:
+    notebooks = runner.get_notebooks(
+        notebook_paths=[
+            "docs/source/knowledgebase/concepts.ipynb",
+            "docs/source/notebooks/alpha-pymc.ipynb",
+        ]
+    )
+
+    assert notebooks == [
+        notebook_collections["knowledgebase"] / "concepts.ipynb",
+        notebook_collections["gallery"] / "alpha-pymc.ipynb",
+    ]
+
+
+def test_exact_mock_incompatible_notebook_requires_full_mode(
+    notebook_collections: dict[str, Path],
+) -> None:
+    with pytest.raises(ValueError, match="Use --full"):
+        runner.get_notebooks(notebook_paths=["docs/source/notebooks/skipped.ipynb"])
+
+    notebooks = runner.get_notebooks(
+        notebook_paths=["docs/source/notebooks/skipped.ipynb"], full=True
+    )
+    assert [notebook.name for notebook in notebooks] == ["skipped.ipynb"]
+
+
+def test_collection_full_mode_does_not_bypass_skip_policy(
+    notebook_collections: dict[str, Path],
+) -> None:
+    notebooks = runner.get_notebooks(full=True)
+
+    assert "skipped.ipynb" not in [notebook.name for notebook in notebooks]
+
+
+def test_exact_notebook_must_be_inside_documentation_collections(
+    notebook_collections: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside.ipynb"
+    outside.touch()
+
+    with pytest.raises(ValueError, match="outside configured"):
+        runner.get_notebooks(notebook_paths=[str(outside)])
+
+
+def test_pattern_and_exclusion_filters_compose(
+    notebook_collections: dict[str, Path],
+) -> None:
+    notebooks = runner.get_notebooks(pattern="*-pymc.ipynb")
+    assert [notebook.name for notebook in notebooks] == ["alpha-pymc.ipynb"]
+
+    notebooks = runner.get_notebooks(exclude_patterns=["pymc"])
+    assert [notebook.name for notebook in notebooks] == [
+        "beta-sklearn.ipynb",
+        "other.ipynb",
+    ]
+
+    notebooks = runner.get_notebooks(exclude_patterns=["pymc", "sklearn"])
+    assert [notebook.name for notebook in notebooks] == ["other.ipynb"]
+
+
+def test_workflow_shards_are_exhaustive_and_non_overlapping(
+    notebook_collections: dict[str, Path],
+) -> None:
+    shards = [
+        runner.get_notebooks(pattern="*-pymc.ipynb"),
+        runner.get_notebooks(pattern="*-sklearn.ipynb"),
+        runner.get_notebooks(exclude_patterns=["pymc", "sklearn"]),
+        runner.get_notebooks(collections=["knowledgebase"]),
+    ]
+    selected = [notebook for shard in shards for notebook in shard]
+    expected = [
+        notebook_collections["gallery"] / "alpha-pymc.ipynb",
+        notebook_collections["gallery"] / "beta-sklearn.ipynb",
+        notebook_collections["gallery"] / "other.ipynb",
+        notebook_collections["knowledgebase"] / "concepts.ipynb",
+    ]
+
+    assert len(selected) == len(set(selected))
+    assert sorted(selected) == sorted(expected)
+
+
+def test_explicit_notebooks_reject_other_selectors(
+    notebook_collections: dict[str, Path],
+) -> None:
+    with pytest.raises(ValueError, match="cannot be combined"):
+        runner.get_notebooks(
+            collections=["gallery"],
+            notebook_paths=["docs/source/notebooks/alpha-pymc.ipynb"],
+        )
+
+
+def test_collection_symlink_cannot_escape_allowed_root(
+    notebook_collections: dict[str, Path],
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside.ipynb"
+    outside.touch()
+    (notebook_collections["gallery"] / "escape.ipynb").symlink_to(outside)
+
+    with pytest.raises(ValueError, match="outside configured"):
+        runner.get_notebooks()
+
+
+def test_main_list_mode_never_executes_notebooks(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[tuple[Path, bool]] = []
+    monkeypatch.setattr(
+        runner,
+        "run_notebook",
+        lambda path, *, full=False: executed.append((path, full)),
+    )
+
+    assert runner.main(["--list"]) == 0
+    assert executed == []
+
+
+def test_main_executes_exact_notebooks_serially_and_forwards_full(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    executed: list[tuple[Path, bool]] = []
+    monkeypatch.setattr(
+        runner,
+        "run_notebook",
+        lambda path, *, full=False: executed.append((path, full)),
+    )
+
+    assert (
+        runner.main(
+            [
+                "--full",
+                "--notebook",
+                "docs/source/notebooks/alpha-pymc.ipynb",
+                "--notebook",
+                "docs/source/knowledgebase/concepts.ipynb",
+            ]
+        )
+        == 0
+    )
+    assert executed == [
+        (notebook_collections["gallery"] / "alpha-pymc.ipynb", True),
+        (notebook_collections["knowledgebase"] / "concepts.ipynb", True),
+    ]
+
+
+def test_main_rejects_empty_selection(
+    notebook_collections: dict[str, Path],
+) -> None:
+    with pytest.raises(ValueError, match="No notebooks matched"):
+        runner.main(["--pattern", "does-not-exist-*.ipynb"])
+
+
+def test_parallel_option_is_not_supported(
+    notebook_collections: dict[str, Path],
+) -> None:
+    with pytest.raises(SystemExit):
+        runner.parse_args(["--parallel"])
+
+
+def test_unknown_collection_is_rejected(
+    notebook_collections: dict[str, Path],
+) -> None:
+    with pytest.raises(ValueError, match="Unknown notebook collection"):
+        runner.get_notebooks(collections=["unknown"])

--- a/causalpy/tests/test_notebook_runner.py
+++ b/causalpy/tests/test_notebook_runner.py
@@ -13,11 +13,15 @@
 #   limitations under the License.
 """Tests for resource-safe documentation notebook selection."""
 
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from scripts.run_notebooks import runner
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -185,6 +189,22 @@ def test_main_list_mode_never_executes_notebooks(
     assert executed == []
 
 
+def test_kernel_path_prefers_active_environment(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    environment_prefix = tmp_path / "env"
+    monkeypatch.setattr(runner.sys, "prefix", str(environment_prefix))
+    monkeypatch.setenv("JUPYTER_PATH", "/custom/jupyter")
+
+    runner.configure_kernel_path()
+
+    assert runner.os.environ["JUPYTER_PATH"].split(runner.os.pathsep) == [
+        str(environment_prefix / "share" / "jupyter"),
+        "/custom/jupyter",
+    ]
+
+
 def test_main_executes_exact_notebooks_serially_and_forwards_full(
     notebook_collections: dict[str, Path],
     monkeypatch: pytest.MonkeyPatch,
@@ -226,6 +246,31 @@ def test_parallel_option_is_not_supported(
 ) -> None:
     with pytest.raises(SystemExit):
         runner.parse_args(["--parallel"])
+
+
+def test_injected_mock_builds_datatree_groups() -> None:
+    injected_path = REPO_ROOT / "scripts" / "run_notebooks" / "injected.py"
+    script = f"""
+import runpy
+import pymc as pm
+namespace = runpy.run_path({str(injected_path)!r})
+with pm.Model() as model:
+    pm.Normal("x")
+    result = namespace["mock_sample"](draws=3, random_seed=42, model=model)
+assert "posterior" in result
+assert "sample_stats" in result
+assert "prior" not in result
+assert result["posterior"]["x"].sizes["draw"] == 100
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_unknown_collection_is_rejected(

--- a/causalpy/tests/test_notebook_runner.py
+++ b/causalpy/tests/test_notebook_runner.py
@@ -18,10 +18,12 @@ import sys
 from pathlib import Path
 
 import pytest
+import yaml
 
 from scripts.run_notebooks import runner
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+PRODUCTION_NOTEBOOK_COLLECTIONS = set(runner.NOTEBOOK_COLLECTIONS)
 
 
 @pytest.fixture
@@ -36,7 +38,9 @@ def notebook_collections(
         gallery / "alpha-pymc.ipynb",
         gallery / "beta-sklearn.ipynb",
         gallery / "other.ipynb",
+        gallery / "pymc-introduction.ipynb",
         gallery / "skipped.ipynb",
+        gallery / "sklearn-overview.ipynb",
         knowledgebase / "concepts.ipynb",
     ):
         path.touch()
@@ -57,6 +61,8 @@ def test_default_selection_uses_gallery_and_mock_skip_policy(
         "alpha-pymc.ipynb",
         "beta-sklearn.ipynb",
         "other.ipynb",
+        "pymc-introduction.ipynb",
+        "sklearn-overview.ipynb",
     ]
 
 
@@ -125,6 +131,7 @@ def test_pattern_and_exclusion_filters_compose(
     assert [notebook.name for notebook in notebooks] == [
         "beta-sklearn.ipynb",
         "other.ipynb",
+        "sklearn-overview.ipynb",
     ]
 
     notebooks = runner.get_notebooks(exclude_patterns=["pymc", "sklearn"])
@@ -133,18 +140,91 @@ def test_pattern_and_exclusion_filters_compose(
 
 def test_workflow_shards_are_exhaustive_and_non_overlapping(
     notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    shards = [
-        runner.get_notebooks(pattern="*-pymc.ipynb"),
-        runner.get_notebooks(pattern="*-sklearn.ipynb"),
-        runner.get_notebooks(exclude_patterns=["pymc", "sklearn"]),
-        runner.get_notebooks(collections=["knowledgebase"]),
+    workflow = yaml.safe_load(
+        (REPO_ROOT / ".github" / "workflows" / "test_notebook.yml").read_text()
+    )
+    notebook_job = workflow["jobs"]["notebooks"]
+    strategy = notebook_job["strategy"]
+    matrix = strategy["matrix"]["include"]
+    run_step = next(
+        step for step in notebook_job["steps"] if step.get("name") == "Run notebooks"
+    )
+
+    assert workflow["concurrency"]["cancel-in-progress"] is True
+    assert strategy["fail-fast"] is False
+    assert strategy["max-parallel"] == 1
+    assert {shard["collection"] for shard in matrix} == PRODUCTION_NOTEBOOK_COLLECTIONS
+    assert run_step["env"] == {
+        "NOTEBOOK_COLLECTION": "${{ matrix.collection }}",
+        "NOTEBOOK_PATTERN": "${{ matrix.pattern }}",
+        "NOTEBOOK_EXCLUDE_ONE": "${{ matrix.exclude_one }}",
+        "NOTEBOOK_EXCLUDE_TWO": "${{ matrix.exclude_two }}",
+    }
+    for expected_fragment in (
+        'args=(--collection "$NOTEBOOK_COLLECTION")',
+        'args+=(--pattern "$NOTEBOOK_PATTERN")',
+        'args+=(--exclude-pattern "$NOTEBOOK_EXCLUDE_ONE")',
+        'args+=(--exclude-pattern "$NOTEBOOK_EXCLUDE_TWO")',
+        'python scripts/run_notebooks/runner.py "${args[@]}"',
+    ):
+        assert expected_fragment in run_step["run"]
+    assert matrix == [
+        {
+            "name": "gallery-pymc",
+            "collection": "gallery",
+            "pattern": "*-pymc.ipynb",
+            "exclude_one": "",
+            "exclude_two": "",
+        },
+        {
+            "name": "gallery-sklearn",
+            "collection": "gallery",
+            "pattern": "*-sklearn.ipynb",
+            "exclude_one": "",
+            "exclude_two": "",
+        },
+        {
+            "name": "gallery-other",
+            "collection": "gallery",
+            "pattern": "",
+            "exclude_one": "*-pymc.ipynb",
+            "exclude_two": "*-sklearn.ipynb",
+        },
+        {
+            "name": "knowledgebase",
+            "collection": "knowledgebase",
+            "pattern": "",
+            "exclude_one": "",
+            "exclude_two": "",
+        },
     ]
+
+    shards: list[list[Path]] = []
+    original_get_notebooks = runner.get_notebooks
+
+    def record_selection(*args, **kwargs) -> list[Path]:
+        selected = original_get_notebooks(*args, **kwargs)
+        shards.append(selected)
+        return selected
+
+    monkeypatch.setattr(runner, "get_notebooks", record_selection)
+    for shard in matrix:
+        argv = ["--collection", shard["collection"], "--list"]
+        if shard["pattern"]:
+            argv.extend(["--pattern", shard["pattern"]])
+        for exclude_pattern in (shard["exclude_one"], shard["exclude_two"]):
+            if exclude_pattern:
+                argv.extend(["--exclude-pattern", exclude_pattern])
+        assert runner.main(argv) == 0
     selected = [notebook for shard in shards for notebook in shard]
     expected = [
         notebook_collections["gallery"] / "alpha-pymc.ipynb",
         notebook_collections["gallery"] / "beta-sklearn.ipynb",
         notebook_collections["gallery"] / "other.ipynb",
+        notebook_collections["gallery"] / "pymc-introduction.ipynb",
+        notebook_collections["gallery"] / "sklearn-overview.ipynb",
         notebook_collections["knowledgebase"] / "concepts.ipynb",
     ]
 
@@ -170,7 +250,59 @@ def test_collection_symlink_cannot_escape_allowed_root(
     outside.touch()
     (notebook_collections["gallery"] / "escape.ipynb").symlink_to(outside)
 
-    with pytest.raises(ValueError, match="outside configured"):
+    with pytest.raises(ValueError, match="escapes its configured collection"):
+        runner.get_notebooks()
+
+
+def test_notebook_symlink_cannot_cross_collection_boundary(
+    notebook_collections: dict[str, Path],
+) -> None:
+    cross_collection_link = notebook_collections["gallery"] / "concepts.ipynb"
+    cross_collection_link.symlink_to(
+        notebook_collections["knowledgebase"] / "concepts.ipynb"
+    )
+
+    with pytest.raises(ValueError, match="escapes its configured collection"):
+        runner.get_notebooks(collections=["gallery"])
+
+    with pytest.raises(ValueError, match="escapes its configured collection"):
+        runner.get_notebooks(notebook_paths=["docs/source/notebooks/concepts.ipynb"])
+
+
+def test_collection_root_cannot_escape_repository(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    (outside / "external.ipynb").touch()
+    monkeypatch.setattr(
+        runner,
+        "NOTEBOOK_COLLECTIONS",
+        {**notebook_collections, "gallery": outside},
+    )
+
+    with pytest.raises(ValueError, match="root.*outside the repository"):
+        runner.get_notebooks()
+
+
+def test_collection_root_cannot_alias_another_collection(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    linked_collection = tmp_path / "linked-notebooks"
+    linked_collection.symlink_to(
+        notebook_collections["knowledgebase"], target_is_directory=True
+    )
+    monkeypatch.setattr(
+        runner,
+        "NOTEBOOK_COLLECTIONS",
+        {**notebook_collections, "gallery": linked_collection},
+    )
+
+    with pytest.raises(ValueError, match="root.*cannot be symlinks"):
         runner.get_notebooks()
 
 
@@ -199,6 +331,12 @@ def test_kernel_path_prefers_active_environment(
 
     runner.configure_kernel_path()
 
+    assert runner.os.environ["JUPYTER_PATH"].split(runner.os.pathsep) == [
+        str(environment_prefix / "share" / "jupyter"),
+        "/custom/jupyter",
+    ]
+
+    runner.configure_kernel_path()
     assert runner.os.environ["JUPYTER_PATH"].split(runner.os.pathsep) == [
         str(environment_prefix / "share" / "jupyter"),
         "/custom/jupyter",
@@ -234,6 +372,60 @@ def test_main_executes_exact_notebooks_serially_and_forwards_full(
     ]
 
 
+def test_main_configures_kernel_before_execution(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    environment_prefix = tmp_path / "env"
+    expected_kernel_path = str(environment_prefix / "share" / "jupyter")
+    observed_kernel_paths: list[str] = []
+    monkeypatch.setattr(runner.sys, "prefix", str(environment_prefix))
+    monkeypatch.delenv("JUPYTER_PATH", raising=False)
+    monkeypatch.setattr(
+        runner,
+        "run_notebook",
+        lambda path, *, full=False: observed_kernel_paths.append(
+            runner.os.environ["JUPYTER_PATH"]
+        ),
+    )
+
+    runner.main(["--notebook", "docs/source/notebooks/alpha-pymc.ipynb"])
+
+    assert observed_kernel_paths == [expected_kernel_path]
+
+
+def test_main_attempts_all_notebooks_before_reporting_failures(
+    notebook_collections: dict[str, Path],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    attempted: list[str] = []
+
+    def run_notebook(path: Path, *, full: bool = False) -> None:
+        attempted.append(path.name)
+        if path.name in {"alpha-pymc.ipynb", "other.ipynb"}:
+            raise ValueError("notebook failed")
+
+    monkeypatch.setattr(runner, "run_notebook", run_notebook)
+
+    with pytest.raises(
+        RuntimeError,
+        match=(
+            r"2 notebook\(s\) failed: alpha-pymc.ipynb: ValueError: notebook "
+            r"failed; other.ipynb: ValueError: notebook failed"
+        ),
+    ):
+        runner.main([])
+
+    assert attempted == [
+        "alpha-pymc.ipynb",
+        "beta-sklearn.ipynb",
+        "other.ipynb",
+        "pymc-introduction.ipynb",
+        "sklearn-overview.ipynb",
+    ]
+
+
 def test_main_rejects_empty_selection(
     notebook_collections: dict[str, Path],
 ) -> None:
@@ -253,13 +445,26 @@ def test_injected_mock_builds_datatree_groups() -> None:
     script = f"""
 import runpy
 import pymc as pm
+import xarray as xr
 namespace = runpy.run_path({str(injected_path)!r})
 with pm.Model() as model:
-    pm.Normal("x")
-    result = namespace["mock_sample"](draws=3, random_seed=42, model=model)
+    x = pm.Normal("x")
+    pm.Normal("y", x, 1, observed=[0.0])
+    pm.Normal("z", x, 1, observed=[1.0])
+    result = namespace["mock_sample"](
+        draws=3,
+        random_seed=42,
+        model=model,
+        idata_kwargs={{"log_likelihood": ["y"]}},
+    )
+assert isinstance(result, xr.DataTree)
 assert "posterior" in result
 assert "sample_stats" in result
+assert "log_likelihood" in result
+assert set(result["log_likelihood"].data_vars) == {{"y"}}
+assert {{"chain", "draw"}}.issubset(result["log_likelihood"]["y"].dims)
 assert "prior" not in result
+assert "prior_predictive" not in result
 assert result["posterior"]["x"].sizes["draw"] == 100
 """
 
@@ -271,6 +476,30 @@ assert result["posterior"]["x"].sizes["draw"] == 100
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_production_skip_configuration_is_consistent() -> None:
+    skip_notebooks = set(
+        yaml.safe_load(
+            (REPO_ROOT / "scripts" / "run_notebooks" / "skip_notebooks.yml").read_text()
+        )
+    )
+    assert skip_notebooks == {
+        "gallery/instrumental-variables-pymc.ipynb",
+        "gallery/instrumental-variables-weak-instruments.ipynb",
+        "gallery/interrupted-time-series-causalpy-vs-causalimpact.ipynb",
+    }
+
+    for key in skip_notebooks:
+        collection, relative_path = key.split("/", maxsplit=1)
+        notebook = runner.NOTEBOOK_COLLECTIONS[collection] / relative_path
+        assert notebook.is_file()
+        assert notebook.resolve() not in runner.get_notebooks(collections=[collection])
+        with pytest.raises(ValueError, match="Use --full"):
+            runner.get_notebooks(notebook_paths=[str(notebook)])
+        assert runner.get_notebooks(notebook_paths=[str(notebook)], full=True) == [
+            notebook.resolve()
+        ]
 
 
 def test_unknown_collection_is_rejected(

--- a/scripts/run_notebooks/README.md
+++ b/scripts/run_notebooks/README.md
@@ -77,7 +77,7 @@ The notebooks listed in `skip_notebooks.yml` are incompatible with mock injectio
 
 ## CI Integration
 
-The GitHub Actions workflow (`.github/workflows/test_notebook.yml`) runs four serial matrix entries (`max-parallel: 1`):
+The GitHub Actions workflow (`.github/workflows/test_notebook.yml`) runs four serial matrix entries (`max-parallel: 1`). Superseded runs are canceled so only the newest commit occupies the serial queue:
 
 - Job 1: PyMC notebooks
 - Job 2: Sklearn notebooks

--- a/scripts/run_notebooks/README.md
+++ b/scripts/run_notebooks/README.md
@@ -1,14 +1,15 @@
 # Notebook Runner
 
-This script runs Jupyter notebooks from `docs/source/notebooks/` to validate they execute without errors.
+This script runs Jupyter notebooks from the gallery (`docs/source/notebooks/`) and knowledgebase (`docs/source/knowledgebase/`) to validate they execute without errors.
 
 ## How It Works
 
 1. **Mocks `pm.sample()`** — Replaces MCMC sampling with prior predictive (1 chain × 100 draws) for speed
 2. **Uses Papermill** — Executes notebooks programmatically
-3. **Clears saved outputs** — Avoids widget state issues during execution
-4. **Guards widget updates** — Patches nbclient to ignore display_id assertion errors
-5. **Discards outputs** — Only checks for errors, doesn't save results
+3. **Runs serially** — Executes one notebook at a time to control memory use
+4. **Clears saved outputs** — Avoids widget state issues during execution
+5. **Guards widget updates** — Patches nbclient to ignore display_id assertion errors
+6. **Discards outputs** — Only checks for errors, doesn't save results
 
 ## Dependencies
 
@@ -36,12 +37,6 @@ The notebook runner mirrors the CI setup and expects a full docs/test environmen
      sudo apt-get update && sudo apt-get install -y graphviz
      ```
 
-3. **Optional: parallel execution**
-
-   ```bash
-   pip install joblib
-   ```
-
 ## Notes
 
 - The runner executes using the `python3` Jupyter kernel. Ensure your environment
@@ -65,17 +60,29 @@ python scripts/run_notebooks/runner.py --pattern "*-sklearn.ipynb"
 # Exclude PyMC and sklearn notebooks (run others)
 python scripts/run_notebooks/runner.py --exclude-pattern pymc --exclude-pattern sklearn
 
-# Run notebooks in parallel (requires joblib)
-python scripts/run_notebooks/runner.py --parallel
+# Run the knowledgebase collection
+python scripts/run_notebooks/runner.py --collection knowledgebase
+
+# List an exact pair without executing or changing files
+python scripts/run_notebooks/runner.py --list \
+  --notebook docs/source/notebooks/ancova-pymc.ipynb \
+  --notebook docs/source/knowledgebase/custom_pymc_models.ipynb
+
+# Refresh one notebook in place without mock injection
+python scripts/run_notebooks/runner.py --full \
+  --notebook docs/source/notebooks/ancova-pymc.ipynb
 ```
+
+The notebooks listed in `skip_notebooks.yml` are incompatible with mock injection and are omitted from collection/pattern mock runs. Selecting one explicitly in mock mode fails with a clear error; select it with `--full --notebook ...` for controlled, serialized execution in an environment containing its optional dependencies.
 
 ## CI Integration
 
-The GitHub Actions workflow (`.github/workflows/test_notebook.yml`) runs this script in parallel:
+The GitHub Actions workflow (`.github/workflows/test_notebook.yml`) runs four serial matrix entries (`max-parallel: 1`):
 
 - Job 1: PyMC notebooks
 - Job 2: Sklearn notebooks
 - Job 3: Other notebooks
+- Job 4: Knowledgebase notebooks
 
 ## Files
 

--- a/scripts/run_notebooks/injected.py
+++ b/scripts/run_notebooks/injected.py
@@ -12,6 +12,7 @@ def mock_sample(*args, **kwargs):
     """Mock pm.sample using prior predictive sampling for speed."""
     random_seed = kwargs.get("random_seed")
     model = kwargs.get("model")
+    idata_kwargs = kwargs.get("idata_kwargs") or {}
 
     # If no model is provided via kwargs, try to infer it from positional args
     if model is None and args:
@@ -32,6 +33,17 @@ def mock_sample(*args, **kwargs):
         draws=n_draws,
     )
     idata["posterior"] = idata["prior"].to_dataset().copy()
+
+    log_likelihood = idata_kwargs.get("log_likelihood")
+    if log_likelihood:
+        var_names = None if log_likelihood is True else log_likelihood
+        idata = pm.compute_log_likelihood(
+            idata,
+            model=model,
+            var_names=var_names,
+            extend_inferencedata=True,
+            progressbar=False,
+        )
 
     # Create mock sample stats with diverging data
     if "sample_stats" not in idata:

--- a/scripts/run_notebooks/injected.py
+++ b/scripts/run_notebooks/injected.py
@@ -31,7 +31,7 @@ def mock_sample(*args, **kwargs):
         random_seed=random_seed,
         draws=n_draws,
     )
-    idata.add_groups(posterior=idata.prior)
+    idata["posterior"] = idata["prior"].to_dataset().copy()
 
     # Create mock sample stats with diverging data
     if "sample_stats" not in idata:
@@ -44,11 +44,11 @@ def mock_sample(*args, **kwargs):
                 )
             }
         )
-        idata.add_groups(sample_stats=sample_stats)
+        idata["sample_stats"] = sample_stats
 
-    del idata.prior
+    del idata["prior"]
     if "prior_predictive" in idata:
-        del idata.prior_predictive
+        del idata["prior_predictive"]
 
     return idata
 

--- a/scripts/run_notebooks/runner.py
+++ b/scripts/run_notebooks/runner.py
@@ -1,4 +1,4 @@
-"""Script to run notebooks in docs/source/notebooks directory.
+"""Run CausalPy documentation notebooks serially.
 
 Examples
 --------
@@ -24,7 +24,12 @@ Full execution (no mock, saves outputs in place):
 
 Full execution for a single notebook:
 
-    python scripts/run_notebooks/runner.py --full --pattern "synthetic-control-sklearn.ipynb"
+    python scripts/run_notebooks/runner.py --full \
+        --notebook docs/source/notebooks/synthetic-control-sklearn.ipynb
+
+Run the knowledgebase notebooks:
+
+    python scripts/run_notebooks/runner.py --collection knowledgebase
 
 """
 
@@ -44,8 +49,13 @@ from nbformat.notebooknode import NotebookNode
 from papermill.iorw import load_notebook_node, write_ipynb
 
 HERE = Path(__file__).parent
-NOTEBOOKS_PATH = Path("docs/source/notebooks")
+REPO_ROOT = HERE.parent.parent
+NOTEBOOK_COLLECTIONS = {
+    "gallery": REPO_ROOT / "docs" / "source" / "notebooks",
+    "knowledgebase": REPO_ROOT / "docs" / "source" / "knowledgebase",
+}
 KERNEL_NAME = "python3"
+LOGGER = logging.getLogger(__name__)
 
 INJECTED_CODE_FILE = HERE / "injected.py"
 INJECTED_CODE = INJECTED_CODE_FILE.read_text()
@@ -117,7 +127,7 @@ def run_notebook(notebook_path: Path, *, full: bool = False) -> None:
         discard outputs.
     """
     mode = "full" if full else "mock"
-    logging.info(f"Running notebook ({mode}): {notebook_path.name}")
+    LOGGER.info(f"Running notebook ({mode}): {notebook_path.name}")
 
     if full:
         papermill.execute_notebook(
@@ -145,15 +155,15 @@ def run_notebook(notebook_path: Path, *, full: bool = False) -> None:
             progress_bar=True,
             cwd=notebook_path.parent,
         )
-    except Exception as e:
-        logging.error(f"Error running notebook: {notebook_path.name}")
-        raise e
+    except Exception:
+        LOGGER.error(f"Error running notebook: {notebook_path.name}")
+        raise
     finally:
         if temp_path is not None:
             try:
                 temp_path.unlink(missing_ok=True)
             except OSError as cleanup_error:
-                logging.warning(
+                LOGGER.warning(
                     "Failed to delete temporary notebook file %s: %s",
                     temp_path,
                     cleanup_error,
@@ -163,12 +173,78 @@ def run_notebook(notebook_path: Path, *, full: bool = False) -> None:
 def get_notebooks(
     pattern: str | None = None,
     exclude_patterns: list[str] | None = None,
+    collections: list[str] | None = None,
+    notebook_paths: list[str] | None = None,
+    *,
+    full: bool = False,
 ) -> list[Path]:
-    """Get list of notebooks to run, optionally filtered."""
-    notebooks = list(NOTEBOOKS_PATH.glob("*.ipynb"))
+    """Return selected notebooks after validating collection and skip policies.
 
-    # Filter out notebooks that are incompatible with the mock
-    notebooks = [nb for nb in notebooks if nb.name not in SKIP_NOTEBOOKS]
+    Explicit notebook paths are limited to the configured documentation
+    collections. Mock-incompatible notebooks can be selected explicitly only
+    in full mode; collection/pattern selection omits them in mock mode.
+    """
+    if notebook_paths and (collections or pattern or exclude_patterns):
+        raise ValueError(
+            "--notebook cannot be combined with --collection, --pattern, or "
+            "--exclude-pattern."
+        )
+
+    selected_collections = collections or ["gallery"]
+    unknown_collections = sorted(set(selected_collections) - set(NOTEBOOK_COLLECTIONS))
+    if unknown_collections:
+        raise ValueError(
+            f"Unknown notebook collection(s): {', '.join(unknown_collections)}"
+        )
+
+    roots = {
+        name: NOTEBOOK_COLLECTIONS[name].resolve() for name in selected_collections
+    }
+    allowed_roots = {
+        name: path.resolve() for name, path in NOTEBOOK_COLLECTIONS.items()
+    }
+
+    def validate_path(path: Path, raw_path: str) -> Path:
+        path = path.resolve()
+        if path.suffix != ".ipynb" or not path.is_file():
+            raise ValueError(f"Notebook does not exist: {raw_path}")
+        if not any(path.is_relative_to(root) for root in allowed_roots.values()):
+            raise ValueError(
+                f"Notebook is outside configured documentation collections: {raw_path}"
+            )
+        return path
+
+    def notebook_key(path: Path) -> str:
+        for name, root in allowed_roots.items():
+            if path.is_relative_to(root):
+                return f"{name}/{path.relative_to(root)}"
+        raise ValueError(f"Notebook is outside configured collections: {path}")
+
+    if notebook_paths:
+        notebooks = []
+        for raw_path in notebook_paths:
+            path = Path(raw_path)
+            if not path.is_absolute():
+                path = REPO_ROOT / path
+            notebooks.append(validate_path(path, raw_path))
+    else:
+        notebooks = [
+            validate_path(notebook, str(notebook))
+            for root in roots.values()
+            for notebook in root.glob("*.ipynb")
+        ]
+
+    skipped = [
+        notebook for notebook in notebooks if notebook_key(notebook) in SKIP_NOTEBOOKS
+    ]
+    if skipped and notebook_paths and not full:
+        names = ", ".join(sorted(notebook.name for notebook in skipped))
+        raise ValueError(
+            f"Mock execution is unsupported for: {names}. Use --full for explicit "
+            "serialized execution."
+        )
+    if not notebook_paths or not full:
+        notebooks = [notebook for notebook in notebooks if notebook not in skipped]
 
     if pattern:
         notebooks = [nb for nb in notebooks if Path(nb).match(pattern)]
@@ -177,10 +253,12 @@ def get_notebooks(
         for exc in exclude_patterns:
             notebooks = [nb for nb in notebooks if exc not in nb.name]
 
-    return sorted(notebooks)
+    if notebook_paths:
+        return list(dict.fromkeys(notebooks))
+    return sorted(set(notebooks))
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run CausalPy notebooks.")
     parser.add_argument(
         "--pattern",
@@ -196,10 +274,20 @@ def parse_args() -> argparse.Namespace:
         help="Pattern to exclude from notebook names (can be used multiple times)",
     )
     parser.add_argument(
-        "--parallel",
-        action="store_true",
-        default=False,
-        help="Run notebooks in parallel when possible.",
+        "--collection",
+        action="append",
+        choices=sorted(NOTEBOOK_COLLECTIONS),
+        dest="collections",
+        help="Notebook collection to run (repeatable; defaults to gallery).",
+    )
+    parser.add_argument(
+        "--notebook",
+        action="append",
+        dest="notebook_paths",
+        help=(
+            "Exact notebook path relative to the repository (repeatable). Paths must "
+            "be inside a configured documentation collection."
+        ),
     )
     parser.add_argument(
         "--full",
@@ -207,41 +295,50 @@ def parse_args() -> argparse.Namespace:
         default=False,
         help="Full execution: skip mock injection and overwrite notebooks with fresh outputs. This can take a long time.",
     )
-    return parser.parse_args()
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_only",
+        help="List the selected notebooks without executing or modifying them.",
+    )
+    return parser.parse_args(argv)
 
 
-if __name__ == "__main__":
+def main(argv: list[str] | None = None) -> int:
+    """Select and execute notebooks serially from command-line arguments."""
     setup_logging()
-    args = parse_args()
+    args = parse_args(argv)
 
     notebooks = get_notebooks(
         pattern=args.pattern,
         exclude_patterns=args.exclude_patterns,
+        collections=args.collections,
+        notebook_paths=args.notebook_paths,
+        full=args.full,
     )
 
-    logging.info(f"Found {len(notebooks)} notebooks to run")
+    LOGGER.info(f"Found {len(notebooks)} notebooks to run")
     for nb in notebooks:
-        logging.info(f"  - {nb.name}")
+        LOGGER.info(f"  - {nb.name}")
+
+    if not notebooks:
+        raise ValueError("No notebooks matched the requested selection.")
+
+    if args.list_only:
+        return 0
 
     if args.full:
-        logging.warning(
+        LOGGER.warning(
             "Full execution mode: notebooks will be run without mock injection "
             "and outputs will be saved in place. This can take a long time."
         )
 
-    if args.parallel:
-        try:
-            from joblib import Parallel, delayed
-        except ImportError as exc:
-            raise ImportError(
-                "Parallel execution requires joblib. Install it or run without --parallel."
-            ) from exc
+    for notebook in notebooks:
+        run_notebook(notebook, full=args.full)
 
-        Parallel(n_jobs=-1)(
-            delayed(run_notebook)(notebook, full=args.full) for notebook in notebooks
-        )
-    else:
-        for notebook in notebooks:
-            run_notebook(notebook, full=args.full)
+    LOGGER.info("All notebooks completed successfully!")
+    return 0
 
-    logging.info("All notebooks completed successfully!")
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_notebooks/runner.py
+++ b/scripts/run_notebooks/runner.py
@@ -91,9 +91,12 @@ def setup_logging() -> None:
 def configure_kernel_path() -> None:
     """Prefer the active Python environment's kernels over user kernels."""
     environment_jupyter_path = str(Path(sys.prefix) / "share" / "jupyter")
-    existing_path = os.environ.get("JUPYTER_PATH")
+    existing_paths = os.environ.get("JUPYTER_PATH", "").split(os.pathsep)
+    remaining_paths = [
+        path for path in existing_paths if path and path != environment_jupyter_path
+    ]
     os.environ["JUPYTER_PATH"] = os.pathsep.join(
-        filter(None, (environment_jupyter_path, existing_path))
+        [environment_jupyter_path, *remaining_paths]
     )
 
 
@@ -208,17 +211,40 @@ def get_notebooks(
             f"Unknown notebook collection(s): {', '.join(unknown_collections)}"
         )
 
-    roots = {
-        name: NOTEBOOK_COLLECTIONS[name].resolve() for name in selected_collections
-    }
+    repo_root = REPO_ROOT.resolve()
     allowed_roots = {
         name: path.resolve() for name, path in NOTEBOOK_COLLECTIONS.items()
     }
+    symlinked_roots = [
+        name for name, path in NOTEBOOK_COLLECTIONS.items() if path.is_symlink()
+    ]
+    if symlinked_roots:
+        raise ValueError(
+            "Notebook collection root(s) cannot be symlinks: "
+            f"{', '.join(sorted(symlinked_roots))}"
+        )
+    escaped_roots = [
+        name
+        for name, root in allowed_roots.items()
+        if not root.is_relative_to(repo_root)
+    ]
+    if escaped_roots:
+        raise ValueError(
+            "Notebook collection root(s) are outside the repository: "
+            f"{', '.join(sorted(escaped_roots))}"
+        )
+    roots = {name: allowed_roots[name] for name in selected_collections}
 
-    def validate_path(path: Path, raw_path: str) -> Path:
+    def validate_path(
+        path: Path,
+        raw_path: str,
+        expected_root: Path | None = None,
+    ) -> Path:
         path = path.resolve()
         if path.suffix != ".ipynb" or not path.is_file():
             raise ValueError(f"Notebook does not exist: {raw_path}")
+        if expected_root is not None and not path.is_relative_to(expected_root):
+            raise ValueError(f"Notebook escapes its configured collection: {raw_path}")
         if not any(path.is_relative_to(root) for root in allowed_roots.values()):
             raise ValueError(
                 f"Notebook is outside configured documentation collections: {raw_path}"
@@ -237,10 +263,23 @@ def get_notebooks(
             path = Path(raw_path)
             if not path.is_absolute():
                 path = REPO_ROOT / path
-            notebooks.append(validate_path(path, raw_path))
+            lexical_path = Path(os.path.abspath(path))
+            matching_roots = [
+                allowed_roots[name]
+                for name, collection_root in NOTEBOOK_COLLECTIONS.items()
+                if lexical_path.is_relative_to(Path(os.path.abspath(collection_root)))
+            ]
+            if not matching_roots:
+                raise ValueError(
+                    "Notebook is outside configured documentation collections: "
+                    f"{raw_path}"
+                )
+            notebooks.append(
+                validate_path(path, raw_path, expected_root=matching_roots[0])
+            )
     else:
         notebooks = [
-            validate_path(notebook, str(notebook))
+            validate_path(notebook, str(notebook), expected_root=root)
             for root in roots.values()
             for notebook in root.glob("*.ipynb")
         ]
@@ -262,7 +301,10 @@ def get_notebooks(
 
     if exclude_patterns:
         for exc in exclude_patterns:
-            notebooks = [nb for nb in notebooks if exc not in nb.name]
+            if any(character in exc for character in "*?["):
+                notebooks = [nb for nb in notebooks if not nb.match(exc)]
+            else:
+                notebooks = [nb for nb in notebooks if exc not in nb.name]
 
     if notebook_paths:
         return list(dict.fromkeys(notebooks))
@@ -345,8 +387,22 @@ def main(argv: list[str] | None = None) -> int:
             "and outputs will be saved in place. This can take a long time."
         )
 
+    failures: list[tuple[Path, Exception]] = []
     for notebook in notebooks:
-        run_notebook(notebook, full=args.full)
+        try:
+            run_notebook(notebook, full=args.full)
+        except Exception as error:
+            LOGGER.exception("Notebook failed: %s", notebook)
+            failures.append((notebook, error))
+
+    if failures:
+        failure_details = "; ".join(
+            f"{notebook.name}: {type(error).__name__}: {error}"
+            for notebook, error in failures
+        )
+        raise RuntimeError(
+            f"{len(failures)} notebook(s) failed: {failure_details}"
+        ) from failures[0][1]
 
     LOGGER.info("All notebooks completed successfully!")
     return 0

--- a/scripts/run_notebooks/runner.py
+++ b/scripts/run_notebooks/runner.py
@@ -35,6 +35,8 @@ Run the knowledgebase notebooks:
 
 import argparse
 import logging
+import os
+import sys
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 from uuid import uuid4
@@ -83,6 +85,15 @@ def setup_logging() -> None:
     logging.basicConfig(
         level=logging.INFO,
         format="%(asctime)s - %(levelname)s - %(message)s",
+    )
+
+
+def configure_kernel_path() -> None:
+    """Prefer the active Python environment's kernels over user kernels."""
+    environment_jupyter_path = str(Path(sys.prefix) / "share" / "jupyter")
+    existing_path = os.environ.get("JUPYTER_PATH")
+    os.environ["JUPYTER_PATH"] = os.pathsep.join(
+        filter(None, (environment_jupyter_path, existing_path))
     )
 
 
@@ -307,6 +318,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Select and execute notebooks serially from command-line arguments."""
     setup_logging()
+    configure_kernel_path()
     args = parse_args(argv)
 
     notebooks = get_notebooks(

--- a/scripts/run_notebooks/skip_notebooks.yml
+++ b/scripts/run_notebooks/skip_notebooks.yml
@@ -3,10 +3,10 @@
 # These notebooks are skipped for various reasons documented below.
 
 # Requires JAX which is not installed in the test environment.
-- instrumental-variables-pymc.ipynb
-- instrumental-variables-weak-instruments.ipynb
+- gallery/instrumental-variables-pymc.ipynb
+- gallery/instrumental-variables-weak-instruments.ipynb
 
 # Requires the third-party `causalimpact` package (Google's library, used here
 # only for side-by-side comparison) which is not a CausalPy dependency and is
 # not installed in the test environment.
-- interrupted-time-series-causalpy-vs-causalimpact.ipynb
+- gallery/interrupted-time-series-causalpy-vs-causalimpact.ipynb


### PR DESCRIPTION
## Summary

Establish the serial notebook and documentation validation infrastructure needed before the #1047 notebook migration batches branch from the PyMC 6 transition line.

Refs #1047.

## Changes

- Enable regular and notebook CI for PRs and pushes targeting `pymc6_and_pymcmarketing1_migration`.
- Serialize all four notebook workflow shards and disable cancellation of an in-progress notebook run.
- Install the PyMC-6-compatible pymc-marketing docs requirements before notebook execution.
- Add named gallery and knowledgebase collections, repeatable exact notebook paths, and a non-mutating list mode.
- Remove local parallel notebook execution and constrain skipped notebooks to explicit full-mode execution.
- Reject path escapes, symlink escapes, ambiguous selector combinations, and empty selections.
- Preserve requested PyMC 6 `DataTree` log-likelihood groups and pin execution to the launching environment's kernel.
- Attempt every notebook in a shard serially, retain each failure diagnostic, and cancel superseded workflow runs.
- Add focused tests for discovery, workflow shard coverage, skip behavior, exact paths, serial execution, and CLI safety.

## Testing

- `python -m pytest causalpy/tests/test_notebook_runner.py causalpy/tests/test_notebook_validation.py --no-cov` — 37 passed.
- `ruff check scripts/run_notebooks/runner.py causalpy/tests/test_notebook_runner.py` — passed.
- `prek run --files .github/workflows/ci.yml .github/workflows/test_notebook.yml scripts/run_notebooks/runner.py scripts/run_notebooks/README.md scripts/run_notebooks/skip_notebooks.yml causalpy/tests/test_notebook_runner.py` — passed.
- Selection-only probes confirmed disjoint shards of 15 PyMC, 5 sklearn, 11 other gallery, and 3 knowledgebase notebooks.
- `python scripts/run_notebooks/runner.py --notebook docs/source/notebooks/ancova-pymc.ipynb` — passed using the dedicated mamba environment's kernel.

## Known transition-branch baseline

Regular CI currently reports seven stale doctest expectations across six classes in `causalpy/pymc_models.py` that expect the removed `InferenceData` representation instead of PyMC 6 `DataTree`. Those examples predate and are outside this infrastructure diff; focused follow-up PR #1077 fixes them. The serialized notebook run also intentionally exposes remaining notebook-migration work, including ArviZ plotting arguments, `DataTree.extend`, and a knowledgebase LaTeX assumption; those belong to the notebook cohort PRs rather than this infrastructure diff.

## Checklist

- [x] Branches from `pymc6_and_pymcmarketing1_migration`.
- [x] No notebook outputs or gallery artifacts changed.
- [x] No full suite, full docs build, doctest sweep, or MCMC notebook execution run locally.
- [x] Focused adversarial, edge-case, and test-quality review findings addressed.
