### PR TITLE
feat: accept dataframe-like inputs in column-based experiments (2/3)

### DIFF
--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -16,7 +16,6 @@
 from typing import Any, Literal
 
 import numpy as np
-import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
@@ -30,6 +29,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     has_posterior_draws,
@@ -63,8 +63,9 @@ class DifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     time_variable_name : str
@@ -110,7 +111,7 @@ class DifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         time_variable_name: str,
         group_variable_name: str,
@@ -119,8 +120,9 @@ class DifferenceInDifferences(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray | float | None
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas returns a copy, so index metadata is normalized on an
+        # owned frame rather than the caller's.
+        data = to_pandas(data)
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Difference in Differences"

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -16,7 +16,6 @@
 import warnings  # noqa: I001
 
 import numpy as np
-import pandas as pd
 from patsy import PatsyError
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
@@ -25,6 +24,7 @@ import arviz as az
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.pymc_models import InstrumentalVariableRegression
 from causalpy.utils import round_num
 
@@ -37,13 +37,14 @@ class InstrumentalVariable(BaseExperiment):
 
     Parameters
     ----------
-    instruments_data : pd.DataFrame
-        A pandas dataframe of instruments for our treatment variable.
-        Should contain instruments Z, and treatment t.
-    data : pd.DataFrame
-        A pandas dataframe of covariates for fitting the focal regression
-        of interest. Should contain covariates X including treatment t and
-        outcome y.
+    instruments_data : dataframe-like
+        Instruments for our treatment variable, as any eager dataframe
+        Narwhals supports, such as pandas, Polars, or PyArrow. Should contain
+        instruments Z, and treatment t. Converted to pandas internally.
+    data : dataframe-like
+        Covariates for fitting the focal regression of interest, as any eager
+        dataframe Narwhals supports. Should contain covariates X including
+        treatment t and outcome y. Converted to pandas internally.
     instruments_formula : str
         A statistical model formula for the instrumental stage regression,
         e.g. ``t ~ 1 + z1 + z2 + z3``.
@@ -125,8 +126,8 @@ class InstrumentalVariable(BaseExperiment):
 
     def __init__(
         self,
-        instruments_data: pd.DataFrame,
-        data: pd.DataFrame,
+        instruments_data: DataFrameLike,
+        data: DataFrameLike,
         instruments_formula: str,
         formula: str,
         model: InstrumentalVariableRegression | None = None,
@@ -137,8 +138,10 @@ class InstrumentalVariable(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Instrumental Variable Regression"
-        self.data = data
-        self.instruments_data = instruments_data
+        self.data = to_pandas(data)
+        self.instruments_data = to_pandas(
+            instruments_data, argument_name="instruments_data"
+        )
         self.formula = formula
         self.instruments_formula = instruments_formula
         self.vs_prior_type = vs_prior_type

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -27,6 +27,7 @@ from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 from causalpy.custom_exceptions import DataException
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.pymc_models import PropensityScore
 
 from .base import BaseExperiment
@@ -37,8 +38,9 @@ class InversePropensityWeighting(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula for the propensity model.
     outcome_variable : str
@@ -84,7 +86,7 @@ class InversePropensityWeighting(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         outcome_variable: str,
         weighting_scheme: str,
@@ -92,7 +94,7 @@ class InversePropensityWeighting(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Inverse Propensity Score Weighting"
-        self.data = data
+        self.data = to_pandas(data)
         self.formula = formula
         self.outcome_variable = outcome_variable
         self.weighting_scheme = weighting_scheme

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -29,6 +29,7 @@ from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import _plot_interval_band
 from causalpy.pymc_models import PyMCModel
 from causalpy.utils import round_num
@@ -44,9 +45,10 @@ class PanelRegression(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with panel data. Each row is an observation for a
-        unit at a time period.
+    data : dataframe-like
+        Panel data as any eager dataframe Narwhals supports, such as pandas,
+        Polars, or PyArrow. Each row is an observation for a unit at a time
+        period. Converted to pandas internally.
     formula : str
         A statistical model formula using patsy syntax. For the unpooled
         dummy-variable fixed-effects approach, include ``C(unit_var)`` (and
@@ -186,7 +188,7 @@ class PanelRegression(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         unit_fe_variable: str,
         time_fe_variable: str | None = None,
@@ -195,8 +197,9 @@ class PanelRegression(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
 
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas returns a copy, so this rename lands on ours, not the
+        # caller's dataframe.
+        data = to_pandas(data)
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Panel Regression"

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -28,6 +28,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -61,8 +62,11 @@ class PiecewiseITS(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas DataFrame containing the time series data.
+    data : dataframe-like
+        Time series data as any eager dataframe Narwhals supports, such as
+        pandas, Polars, or PyArrow. The time axis comes from the ``step()`` or
+        ``ramp()`` column in the formula, not from the index, so a dataframe
+        without an index works here. Converted to pandas internally.
     formula : str
         A patsy formula specifying the model. Must include at least one
         ``step()`` or ``ramp()`` term, and all such terms must use the same
@@ -156,7 +160,7 @@ class PiecewiseITS(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         model: PyMCModel | RegressorMixin | None = None,
     ) -> None:
@@ -165,7 +169,7 @@ class PiecewiseITS(BaseExperiment):
         # Store configuration
         self.expt_type = "Piecewise Interrupted Time Series"
         self.formula = formula
-        self.data = data.copy()
+        self.data = to_pandas(data)
 
         # Rename the index to "obs_ind" for consistency
         self.data.index.name = "obs_ind"

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -27,6 +27,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     plot_posterior_over_x,
@@ -45,8 +46,9 @@ class PrePostNEGD(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     group_variable_name : str
@@ -101,7 +103,7 @@ class PrePostNEGD(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         group_variable_name: str,
         pretreatment_variable_name: str,
@@ -112,7 +114,7 @@ class PrePostNEGD(BaseExperiment):
         self.pred_xi: np.ndarray
         self.pred_untreated: xr.DataArray
         self.pred_treated: xr.DataArray
-        self.data = data
+        self.data = to_pandas(data)
         self.expt_type = "Pretest/posttest Nonequivalent Group Design"
         self.formula = formula
         self.group_variable_name = group_variable_name

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -25,6 +25,7 @@ from patsy import ModelDesc
 from sklearn.base import RegressorMixin
 
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
     DataException,
@@ -55,8 +56,9 @@ class RegressionDiscontinuity(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     treatment_threshold : float
@@ -112,7 +114,7 @@ class RegressionDiscontinuity(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         treatment_threshold: float,
         model: PyMCModel | RegressorMixin | None = None,
@@ -123,9 +125,9 @@ class RegressionDiscontinuity(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Discontinuity"
-        # Work on an owned frame before normalizing the treated indicator.
-        data = data.copy()
-        self.data = data
+        # to_pandas returns a copy, so the treated indicator is normalized on
+        # an owned frame rather than the caller's.
+        self.data = to_pandas(data)
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.treatment_threshold = treatment_threshold

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -25,6 +25,7 @@ import seaborn as sns
 from patsy import ModelDesc
 import xarray as xr
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
@@ -51,8 +52,9 @@ class RegressionKink(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     kink_point : float
@@ -81,7 +83,7 @@ class RegressionKink(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         kink_point: float,
         model: PyMCModel | None = None,
@@ -91,7 +93,7 @@ class RegressionKink(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Kink"
-        self.data = data
+        self.data = to_pandas(data)
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.kink_point = kink_point

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -32,6 +32,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import has_posterior_draws
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -52,8 +53,10 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with panel data (unit x time observations).
+    data : dataframe-like
+        Panel data (unit x time observations) as any eager dataframe Narwhals
+        supports, such as pandas, Polars, or PyArrow. Converted to pandas
+        internally.
     formula : str
         A statistical model formula. Recommended: "y ~ 1 + C(unit) + C(time)"
         for unit and time fixed effects.
@@ -161,7 +164,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         unit_variable_name: str,
         time_variable_name: str,
@@ -185,8 +188,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         self.event_window = event_window
         self.reference_event_time = reference_event_time
 
-        # Make a copy of data to avoid modifying the original
-        data = data.copy()
+        # to_pandas returns a copy, so the caller's dataframe is left alone
+        data = to_pandas(data)
         data.index.name = "obs_ind"
 
         # Input validation

--- a/causalpy/tests/test_dataframe_backends.py
+++ b/causalpy/tests/test_dataframe_backends.py
@@ -1,0 +1,379 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Tests that column-based experiments accept non-pandas dataframes.
+
+Each experiment is built twice, once from the pandas fixture and once from the
+same data as a Polars dataframe. The two runs must agree. Experiments that
+treat the pandas index as a time axis are not covered here; they need an
+explicit time column first.
+"""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.data.simulate_data import (
+    generate_ancova_data,
+    generate_piecewise_its_data,
+    generate_staggered_did_data,
+)
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def to_polars(data: pd.DataFrame) -> pl.DataFrame:
+    """Convert a pandas fixture to Polars, dropping the index."""
+    return pl.from_pandas(data.reset_index(drop=True))
+
+
+def assert_data_matches(result_pandas, result_polars, attribute="data"):
+    """The stored dataframe must agree between the two backends.
+
+    The index is dropped before comparing because the two backends are not
+    expected to agree on it. A Polars input has no index to carry over, so it
+    gets a positional one. That contract is asserted separately, per
+    experiment, by ``assert_positional_obs_ind``.
+    """
+    left = getattr(result_pandas, attribute).reset_index(drop=True)
+    right = getattr(result_polars, attribute).reset_index(drop=True)
+    pd.testing.assert_frame_equal(left, right, check_dtype=False)
+
+
+def assert_positional_obs_ind(result_polars, attribute="data"):
+    """A converted input carries a positional observation coordinate.
+
+    Polars and PyArrow have no index to carry over, so conversion assigns
+    ``0..n-1``. Asserted for every experiment rather than one representative,
+    since the coordinate reaches user-facing results.
+    """
+    index = getattr(result_polars, attribute).index
+    assert index.tolist() == list(range(len(index)))
+
+
+def assert_model_input_matches(result_pandas, result_polars):
+    """The model must see identical inputs from both backends.
+
+    Sampling is mocked suite-wide, so posterior draws from two separate
+    constructions are not comparable. The design matrices are a deterministic
+    function of the data and the formula, which is what a conversion bug would
+    actually corrupt.
+    """
+    assert result_polars.labels == result_pandas.labels
+    if hasattr(result_pandas, "design"):
+        pairs = [
+            (result_pandas.design[key], result_polars.design[key]) for key in ("X", "y")
+        ]
+    else:
+        pairs = [
+            (result_pandas.X, result_polars.X),
+            (result_pandas.y, result_polars.y),
+        ]
+    for from_pandas, from_polars in pairs:
+        np.testing.assert_allclose(
+            np.asarray(from_polars, dtype=float), np.asarray(from_pandas, dtype=float)
+        )
+
+
+def test_did_accepts_polars(did_data):
+    """DifferenceInDifferences gives the same fit from pandas and Polars."""
+
+    def build(data):
+        return cp.DifferenceInDifferences(
+            data,
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(did_data)
+    from_polars = build(to_polars(did_data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert from_polars.causal_impact == pytest.approx(from_pandas.causal_impact)
+
+
+def test_regression_discontinuity_accepts_polars(rd_data):
+    """RegressionDiscontinuity gives the same fit from pandas and Polars."""
+
+    def build(data):
+        return cp.RegressionDiscontinuity(
+            data,
+            formula="y ~ 1 + x + treated",
+            model=LinearRegression(),
+            treatment_threshold=0.5,
+        )
+
+    from_pandas = build(rd_data)
+    from_polars = build(to_polars(rd_data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert np.asarray(from_polars.discontinuity_at_threshold).item() == pytest.approx(
+        np.asarray(from_pandas.discontinuity_at_threshold).item()
+    )
+
+
+def test_regression_kink_accepts_polars(mock_pymc_sample):
+    """RegressionKink accepts a Polars dataframe."""
+    from causalpy.tests.conftest import setup_regression_kink_data
+
+    kink = 0.5
+    data = setup_regression_kink_data(kink)
+
+    def build(frame):
+        return cp.RegressionKink(
+            frame,
+            formula=f"y ~ 1 + x + I((x-{kink})*treated)",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+            kink_point=kink,
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_prepostnegd_accepts_polars(mock_pymc_sample):
+    """PrePostNEGD accepts a Polars dataframe."""
+    data = generate_ancova_data(seed=42)
+
+    def build(frame):
+        return cp.PrePostNEGD(
+            frame,
+            formula="post ~ 1 + C(group) + pre",
+            group_variable_name="group",
+            pretreatment_variable_name="pre",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_inverse_propensity_weighting_accepts_polars(mock_pymc_sample):
+    """InversePropensityWeighting accepts a Polars dataframe."""
+    data = cp.load_data("nhefs")
+
+    def build(frame):
+        return cp.InversePropensityWeighting(
+            data=frame,
+            formula="trt ~ 1 + age + race",
+            outcome_variable="outcome",
+            weighting_scheme="robust",
+            model=cp.pymc_models.PropensityScore(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_instrumental_variable_accepts_polars(mock_pymc_sample):
+    """InstrumentalVariable converts both of its dataframe arguments."""
+    df = cp.load_data("risk")
+    instruments_data = df[["risk", "logmort0"]]
+    data = df[["loggdp", "risk"]]
+
+    def build(instruments, covariates):
+        return cp.InstrumentalVariable(
+            instruments_data=instruments,
+            data=covariates,
+            instruments_formula="risk ~ 1 + logmort0",
+            formula="loggdp ~ 1 + risk",
+            model=cp.pymc_models.InstrumentalVariableRegression(
+                sample_kwargs=sample_kwargs
+            ),
+        )
+
+    from_pandas = build(instruments_data, data)
+    from_polars = build(to_polars(instruments_data), to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_data_matches(from_pandas, from_polars, attribute="instruments_data")
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_panel_regression_accepts_polars(mock_pymc_sample):
+    """PanelRegression accepts a Polars dataframe."""
+    rng = np.random.default_rng(42)
+    data = pd.DataFrame(
+        {
+            "unit": np.repeat([f"unit_{i}" for i in range(5)], 10),
+            "time": np.tile(range(10), 5),
+            "treatment": np.tile([0] * 5 + [1] * 5, 5),
+            "x1": rng.normal(size=50),
+            "y": rng.normal(size=50),
+        }
+    )
+
+    def build(frame):
+        return cp.PanelRegression(
+            data=frame,
+            formula="y ~ C(unit) + C(time) + treatment + x1",
+            unit_fe_variable="unit",
+            time_fe_variable="time",
+            fe_method="dummies",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_staggered_did_accepts_polars(mock_pymc_sample):
+    """StaggeredDifferenceInDifferences accepts a Polars dataframe."""
+    data = generate_staggered_did_data(n_units=30, n_time_periods=15, seed=42)
+
+    def build(frame):
+        return cp.StaggeredDifferenceInDifferences(
+            frame,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    pd.testing.assert_frame_equal(
+        from_pandas.att_event_time_.reset_index(drop=True),
+        from_polars.att_event_time_.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_piecewise_its_accepts_polars():
+    """PiecewiseITS reads time from the step() column, so Polars works."""
+    data, _ = generate_piecewise_its_data(N=100, seed=42)
+
+    def build(frame):
+        return cp.PiecewiseITS(
+            frame,
+            formula="y ~ 1 + t + step(t, 50) + ramp(t, 50)",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert from_polars.time_col == from_pandas.time_col
+
+
+def test_polars_input_leaves_caller_frame_alone(did_data):
+    """Constructing an experiment does not mutate the caller's dataframe."""
+    data = to_polars(did_data)
+    before = data.clone()
+    cp.DifferenceInDifferences(
+        data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    assert data.equals(before)
+
+
+def test_pandas_input_index_is_not_renamed(did_data):
+    """Constructing an experiment no longer renames the caller's index."""
+    data = did_data.copy()
+    data.index.name = "my_index"
+    cp.DifferenceInDifferences(
+        data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    assert data.index.name == "my_index"
+
+
+def test_panel_regression_pandas_input_index_is_not_renamed(mock_pymc_sample):
+    """PanelRegression also leaves the caller's index name alone."""
+    rng = np.random.default_rng(42)
+    data = pd.DataFrame(
+        {
+            "unit": np.repeat([f"unit_{i}" for i in range(5)], 10),
+            "time": np.tile(range(10), 5),
+            "treatment": np.tile([0] * 5 + [1] * 5, 5),
+            "x1": rng.normal(size=50),
+            "y": rng.normal(size=50),
+        }
+    )
+    data.index.name = "my_index"
+    cp.PanelRegression(
+        data=data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    assert data.index.name == "my_index"
+
+
+def test_polars_input_gets_positional_obs_ind(did_data):
+    """A dataframe without an index gets a positional observation coordinate.
+
+    Pandas callers keep whatever their index holds. Polars and PyArrow have no
+    index to carry over, so conversion assigns ``0..n-1``. That coordinate is
+    row identity for these column-based classes, not a semantic axis, and no
+    existing caller can regress: a frame with no index never had labels to
+    lose. Pinned here so the contract is explicit rather than incidental.
+    """
+
+    def build(data):
+        return cp.DifferenceInDifferences(
+            data,
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=LinearRegression(),
+        )
+
+    labelled = did_data.copy()
+    labelled.index = pd.Index([f"row_{i}" for i in range(len(labelled))], name="key")
+
+    from_pandas = build(labelled)
+    from_polars = build(to_polars(did_data))
+
+    assert from_pandas.data.index.tolist() == labelled.index.tolist()
+    assert from_polars.data.index.tolist() == list(range(len(did_data)))


### PR DESCRIPTION
Second of three stacked PRs for #930. #1087 has landed, so this now targets the integration branch directly.

Routes nine constructors through `to_pandas()`: `DifferenceInDifferences`, `StaggeredDifferenceInDifferences`, `PanelRegression`, `RegressionDiscontinuity`, `RegressionKink`, `InversePropensityWeighting`, `InstrumentalVariable` (both `data` and `instruments_data`), `PrePostNEGD`, and `PiecewiseITS`. These read their time and unit information from columns, so they need no index and convert cleanly.

`PiecewiseITS` is in this group rather than with the index-based classes. Its time axis comes from the `step()`/`ramp()` column in the formula, not from the index.

## obs_ind contract

A pandas caller keeps whatever their index holds. Polars and PyArrow have no index, so conversion assigns `0..n-1`. For these nine classes `obs_ind` is row identity rather than a semantic axis, and no existing caller can regress: a frame with no index never had labels to lose. Adding an optional id column later stays purely additive. Pinned by `test_polars_input_gets_positional_obs_ind`.

## Behavior change

`to_pandas()` always copies, so `data.index.name = "obs_ind"` now lands on CausalPy's copy instead of the caller's dataframe. That in-place rename was observable before. Covered by `test_pandas_input_index_is_not_renamed` and `test_panel_regression_pandas_input_index_is_not_renamed`, the two classes whose behavior actually changed.

## Tests

13 tests in `causalpy/tests/test_dataframe_backends.py`. Each experiment is built twice, from the pandas fixture and from the same data as Polars. Content is compared with `assert_data_matches`, and `assert_model_input_matches` compares the design matrices and labels, which are a deterministic function of data and formula. Posterior draws are not compared, since sampling is mocked suite-wide.

Verified on the current integration head: 2045 passed, 18 skipped.

Stack: #1087 contract (merged), this PR, then #1089 `time_column` for the index-based classes.

