### PR TITLE
feat: time_column for index-based experiments (3/3)

### DIFF
--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -453,6 +453,12 @@ class PlaceboInTime:
             """Create a fresh experiment with the given treatment time."""
             kw = dict(kwargs)
             kw["treatment_time"] = treatment_time
+            # This factory receives a slice of experiment.data, which is already
+            # normalized: time_column has been moved onto the index, so the
+            # column no longer exists and replaying the argument would fail.
+            # The other checks re-fit from the caller's original data and do
+            # need it, so this is dropped here rather than at the source.
+            kw.pop("time_column", None)
             if model_template is not None:
                 kw["model"] = self._clone_model_for_fold(
                     model_template, fold_random_seed

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -31,6 +31,7 @@ from causalpy.date_utils import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -57,10 +58,12 @@ class InterruptedTimeSeries(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with time series data. The index should be either
-        a DatetimeIndex or numeric (integer/float), with unique values in
-        monotonically increasing order.
+    data : dataframe-like
+        Time series data as any eager dataframe Narwhals supports. For a pandas
+        dataframe the index carries the time axis, and it should be either a
+        DatetimeIndex or numeric (integer/float), with unique values in
+        monotonically increasing order. Dataframes from other libraries have no
+        index, so those callers must pass ``time_column``.
     treatment_time : Union[int, float, pd.Timestamp]
         The time when treatment occurred, should be in reference to the data index.
         Must match the index type (DatetimeIndex requires pd.Timestamp).
@@ -81,6 +84,11 @@ class InterruptedTimeSeries(BaseExperiment):
         the analysis assumes a permanent intervention (two-period design).
         **INCLUSIVE**: Observations at exactly ``treatment_end_time`` are included in the
         post-intervention period (uses ``>=`` comparison).
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -152,17 +160,19 @@ class InterruptedTimeSeries(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         formula: str,
         model: PyMCModel | RegressorMixin | PyMCForecastModel | None = None,
         treatment_end_time: int | float | pd.Timestamp | None = None,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
         self.pre_design: xr.Dataset
         self.post_design: xr.Dataset
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time, treatment_end_time)

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -29,6 +29,7 @@ from causalpy.date_utils import (
     validate_treatment_time_against_index,
 )
 from causalpy.experiments.model_adapter import PyMCModelAdapter, build_coords
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -53,8 +54,10 @@ class SyntheticControl(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports. For a pandas dataframe the index
+        carries the time axis. Dataframes from other libraries have no index,
+        so those callers must pass ``time_column``.
     treatment_time : int, float, or pd.Timestamp
         The time when treatment occurred, in reference to the data index.
     control_units : list of str
@@ -79,6 +82,11 @@ class SyntheticControl(BaseExperiment):
         pinned explicitly, leaving the instance you passed in untouched. A model
         constructed with an explicit ``y_hat`` prior is never rescaled either
         way.
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -119,17 +127,19 @@ class SyntheticControl(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         control_units: list[str],
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
         min_donor_correlation: float = 0.0,
         auto_scale_sigma: bool = True,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -31,6 +31,7 @@ from causalpy.date_utils import (
     format_date_axes,
     validate_treatment_time_against_index,
 )
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import PyMCModel, SyntheticDifferenceInDifferencesWeightFitter
 from causalpy.reporting import EffectSummary
@@ -49,8 +50,11 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pandas.DataFrame
-        A dataframe in wide format (columns = units, rows = time periods).
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, in wide format (columns = units,
+        rows = time periods). For a pandas dataframe the index carries the time
+        axis. Dataframes from other libraries have no index, so those callers
+        must pass ``time_column``.
     treatment_time : int, float or pandas.Timestamp
         The time when treatment occurred, should be in reference to the data
         index.
@@ -61,6 +65,11 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
     model : PyMCModel or sklearn.base.RegressorMixin, optional
         A ``SyntheticDifferenceInDifferencesWeightFitter`` instance. Defaults
         to ``SyntheticDifferenceInDifferencesWeightFitter``.
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -125,15 +134,17 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         control_units: list[str],
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -146,8 +146,9 @@ def to_pandas_with_time_index(
     Raises
     ------
     DataException
-        If ``time_column`` is missing from the data, or if a non-pandas input
-        arrives without a ``time_column``.
+        If ``time_column`` is missing from the data, if a non-pandas input
+        arrives without a ``time_column``, or if ``time_column`` is given for a
+        dataframe that already carries a meaningful index.
 
     Examples
     --------
@@ -179,4 +180,33 @@ def to_pandas_with_time_index(
             f"`time_column` '{time_column}' is not a column of `{argument_name}`. "
             f"Available columns: {list(frame.columns)}."
         )
+    if not _has_default_index(frame):
+        raise DataException(
+            f"`{argument_name}` already has a meaningful index "
+            f"({frame.index.name or 'unnamed'}, {type(frame.index).__name__}), and "
+            f"`time_column` '{time_column}' was also given. Setting the column as "
+            "the index would drop the existing one, which would silently change the "
+            "time axis. Pass only one: drop `time_column` to keep the index, or "
+            "call `.reset_index(drop=True)` on the data to discard the index."
+        )
     return frame.set_index(time_column)
+
+
+def _has_default_index(frame: pd.DataFrame) -> bool:
+    """Report whether a dataframe carries no meaningful index.
+
+    A default ``RangeIndex`` with no name is what pandas assigns when nobody
+    chose an index, and it is what conversion from an index-less dataframe
+    library produces.
+
+    Parameters
+    ----------
+    frame : pandas.DataFrame
+        The dataframe to inspect.
+
+    Returns
+    -------
+    bool
+        True when the index is an unnamed ``RangeIndex``.
+    """
+    return isinstance(frame.index, pd.RangeIndex) and frame.index.name is None

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -31,7 +31,9 @@ loaders in :mod:`causalpy.data` all hand back pandas regardless of what was
 passed in. This module widens what you may pass, not what you get back.
 
 Pandas inputs retain their index. Dataframes from other libraries have no
-index concept, so conversion produces a default ``RangeIndex``.
+index concept, so conversion produces a default ``RangeIndex``. Experiments
+that read the index as a time axis take a ``time_column`` argument instead;
+see :func:`to_pandas_with_time_index`.
 """
 
 from __future__ import annotations
@@ -40,7 +42,9 @@ import narwhals as nw
 import pandas as pd
 from narwhals.typing import IntoDataFrame
 
-__all__ = ["DataFrameLike", "to_pandas"]
+from causalpy.custom_exceptions import DataException
+
+__all__ = ["DataFrameLike", "to_pandas", "to_pandas_with_time_index"]
 
 type DataFrameLike = IntoDataFrame
 """Any eager dataframe Narwhals supports: pandas, Polars, PyArrow, and others.
@@ -108,3 +112,71 @@ def to_pandas(data: DataFrameLike, *, argument_name: str = "data") -> pd.DataFra
             f"Got {type(data).__name__}.{hint}"
         ) from error
     return frame.to_pandas()
+
+
+def to_pandas_with_time_index(
+    data: DataFrameLike,
+    time_column: str | None = None,
+    *,
+    argument_name: str = "data",
+) -> pd.DataFrame:
+    """Convert a dataframe-like input and put its time axis on the index.
+
+    Experiments that compare observations against a ``treatment_time`` need a
+    time axis. Pandas callers have historically supplied it as the dataframe
+    index. Dataframes from other libraries have no index, so those callers must
+    name the column that holds the time axis.
+
+    Parameters
+    ----------
+    data : dataframe-like
+        Any eager dataframe supported by Narwhals.
+    time_column : str or None, default None
+        Column holding the time axis. When given, it becomes the index. When
+        None, the pandas index of ``data`` is used, which requires a pandas
+        input.
+    argument_name : str, default "data"
+        Name of the calling argument, used in error messages.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A pandas dataframe indexed by the time axis.
+
+    Raises
+    ------
+    DataException
+        If ``time_column`` is missing from the data, or if a non-pandas input
+        arrives without a ``time_column``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from causalpy.input_data import to_pandas_with_time_index
+    >>> frame = pd.DataFrame({"t": [1, 2], "y": [3, 4]})
+    >>> result = to_pandas_with_time_index(frame, time_column="t")
+    >>> result.index.name
+    't'
+    >>> result.index.tolist()
+    [1, 2]
+    >>> result.columns.tolist()
+    ['y']
+    """
+    has_pandas_index = isinstance(data, pd.DataFrame)
+    frame = to_pandas(data, argument_name=argument_name)
+
+    if time_column is None:
+        if not has_pandas_index:
+            raise DataException(
+                f"`{argument_name}` is not a pandas dataframe, so it carries no "
+                "index to use as the time axis. Pass `time_column` naming the "
+                "column that holds the time axis."
+            )
+        return frame
+
+    if time_column not in frame.columns:
+        raise DataException(
+            f"`time_column` '{time_column}' is not a column of `{argument_name}`. "
+            f"Available columns: {list(frame.columns)}."
+        )
+    return frame.set_index(time_column)

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -147,8 +147,9 @@ def to_pandas_with_time_index(
     ------
     DataException
         If ``time_column`` is missing from the data, if a non-pandas input
-        arrives without a ``time_column``, or if ``time_column`` is given for a
-        dataframe that already carries a meaningful index.
+        arrives without a ``time_column``, if ``time_column`` is given for a
+        dataframe that already carries a meaningful index, or if the resulting
+        time axis has duplicates or is not sorted.
 
     Examples
     --------
@@ -189,7 +190,23 @@ def to_pandas_with_time_index(
             "time axis. Pass only one: drop `time_column` to keep the index, or "
             "call `.reset_index(drop=True)` on the data to discard the index."
         )
-    return frame.set_index(time_column)
+    frame = frame.set_index(time_column)
+
+    # Only reachable through the time_column path. A dataframe library with no
+    # index also carries no row-order guarantee, so an unsorted column is an
+    # easy accident. The pre/post split is value-based and would survive it,
+    # but everything order-dependent downstream would not.
+    if not frame.index.is_unique:
+        raise DataException(
+            f"`time_column` '{time_column}' has duplicate values, so it cannot "
+            "be the time axis. Remove the duplicates before fitting."
+        )
+    if not frame.index.is_monotonic_increasing:
+        raise DataException(
+            f"`time_column` '{time_column}' is not sorted, so the time axis "
+            "would be out of order. Sort the data by that column before fitting."
+        )
+    return frame
 
 
 def _has_default_index(frame: pd.DataFrame) -> bool:

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -72,6 +72,29 @@ class TestToPandasWithTimeIndex:
         with pytest.raises(DataException, match="is not a column of"):
             to_pandas_with_time_index(frame, time_column="date")
 
+    def test_time_column_conflicting_with_named_index_raises(self):
+        """A named index plus a time_column is ambiguous, so it is refused."""
+        frame = pd.DataFrame(
+            {"t": [100, 200], "y": [1, 2]}, index=pd.Index([7, 8], name="old")
+        )
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_time_column_conflicting_with_datetime_index_raises(self):
+        """A DatetimeIndex plus a time_column is refused rather than dropped."""
+        frame = pd.DataFrame(
+            {"t": [100, 200], "y": [1, 2]},
+            index=pd.to_datetime(["2020-01-01", "2020-01-02"]),
+        )
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_time_column_with_default_index_is_allowed(self):
+        """An unnamed RangeIndex is not meaningful, so time_column is fine."""
+        frame = pd.DataFrame({"t": [100, 200], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [100, 200]
+
 
 class TestInterruptedTimeSeries:
     """InterruptedTimeSeries with an explicit time column."""
@@ -122,6 +145,19 @@ class TestInterruptedTimeSeries:
                 pd.to_datetime("2015-01-01"),
                 formula="timeseries ~ 1 + linear_trend",
                 model=LinearRegression(),
+            )
+
+    def test_time_column_with_existing_index_raises(self, its_simple_data):
+        """Passing time_column alongside a DatetimeIndex is refused."""
+        flat = its_simple_data.rename_axis("date").reset_index()
+        both = flat.set_index(pd.Index(range(len(flat)), name="row"))
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            cp.InterruptedTimeSeries(
+                both,
+                pd.to_datetime("2015-01-01"),
+                formula="timeseries ~ 1 + linear_trend",
+                model=LinearRegression(),
+                time_column="date",
             )
 
     def test_pandas_input_index_is_not_renamed(self, its_simple_data):

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -95,6 +95,23 @@ class TestToPandasWithTimeIndex:
         result = to_pandas_with_time_index(frame, time_column="t")
         assert result.index.tolist() == [100, 200]
 
+    def test_duplicate_time_column_raises(self):
+        """A time axis with repeats is refused."""
+        frame = pl.DataFrame({"t": [1, 1, 2], "y": [3, 4, 5]})
+        with pytest.raises(DataException, match="duplicate values"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_unsorted_time_column_raises(self):
+        """An out-of-order time axis is refused rather than silently accepted.
+
+        A dataframe library with no index carries no row-order guarantee, so
+        this is an easy accident. The pre/post split is value-based and would
+        survive it, but anything order-dependent downstream would not.
+        """
+        frame = pl.DataFrame({"t": [3, 1, 2], "y": [4, 5, 6]})
+        with pytest.raises(DataException, match="is not sorted"):
+            to_pandas_with_time_index(frame, time_column="t")
+
 
 class TestInterruptedTimeSeries:
     """InterruptedTimeSeries with an explicit time column."""
@@ -242,4 +259,29 @@ class TestSyntheticDifferenceInDifferences:
                 70,
                 control_units=["a", "b", "c", "d", "e", "f", "g"],
                 treated_units=["actual"],
+            )
+
+
+class TestUnsortedTimeColumnEndToEnd:
+    """An unsorted time column is refused at the experiment boundary.
+
+    SyntheticControl and SyntheticDifferenceInDifferences validate only the
+    treatment-time type, not index order, so before this guard they accepted a
+    shuffled time axis and scrambled it silently. InterruptedTimeSeries already
+    refused it via its own index validation.
+    """
+
+    @pytest.mark.parametrize(
+        "experiment", ["SyntheticControl", "SyntheticDifferenceInDifferences"]
+    )
+    def test_shuffled_time_column_raises(self, sc_data, experiment):
+        """Shuffling the rows of an otherwise valid frame is refused."""
+        shuffled = sc_data.sample(frac=1.0, random_state=1)
+        with pytest.raises(DataException, match="is not sorted"):
+            getattr(cp, experiment)(
+                to_polars_with_time(shuffled, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                time_column="time",
             )

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -27,8 +27,10 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
+from causalpy.checks.placebo_in_time import PlaceboInTime
 from causalpy.custom_exceptions import BadIndexException, DataException
 from causalpy.input_data import to_pandas_with_time_index
+from causalpy.pipeline import PipelineContext
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
@@ -272,18 +274,47 @@ class TestTimestampMismatchMessage:
     than dates lands here, which is what surfaced it.
     """
 
-    def test_non_datetime_index_with_timestamp_treatment_time(self, sc_data):
-        """A string time axis plus a Timestamp treatment time explains itself."""
-        as_text = sc_data.copy()
-        as_text.index = as_text.index.astype(str)
-        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
-            cp.SyntheticControl(
-                as_text,
-                pd.Timestamp("2020-01-01"),
-                control_units=["a", "b", "c", "d", "e", "f", "g"],
-                treated_units=["actual"],
-                model=LinearRegression(),
+    @staticmethod
+    def _build(name, data):
+        """Construct one of the three classes with a Timestamp treatment time."""
+        units = {
+            "control_units": ["a", "b", "c", "d", "e", "f", "g"],
+            "treated_units": ["actual"],
+        }
+        treatment_time = pd.Timestamp("2020-01-01")
+        if name == "InterruptedTimeSeries":
+            return cp.InterruptedTimeSeries(
+                data, treatment_time, formula="actual ~ 1 + a", model=LinearRegression()
             )
+        if name == "SyntheticControl":
+            return cp.SyntheticControl(
+                data, treatment_time, model=LinearRegression(), **units
+            )
+        return cp.SyntheticDifferenceInDifferences(data, treatment_time, **units)
+
+    @pytest.mark.parametrize(
+        "experiment",
+        [
+            "InterruptedTimeSeries",
+            "SyntheticControl",
+            "SyntheticDifferenceInDifferences",
+        ],
+    )
+    def test_non_datetime_index_with_timestamp_treatment_time(
+        self, sc_data, experiment, mock_pymc_sample
+    ):
+        """A string time axis plus a Timestamp treatment time explains itself.
+
+        Checked on all three classes, since the slip was copy-pasted into each
+        of them rather than living in one shared place.
+        """
+        as_text = sc_data.copy()
+        # Zero-padded so the string index stays sorted. Plain str() would give
+        # "10" < "9", and InterruptedTimeSeries checks monotonicity first, so
+        # it would raise about ordering before reaching the type check.
+        as_text.index = [f"{i:04d}" for i in range(len(as_text))]
+        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
+            self._build(experiment, as_text)
 
 
 class TestUnsortedTimeColumnEndToEnd:
@@ -309,3 +340,48 @@ class TestUnsortedTimeColumnEndToEnd:
                 treated_units=["actual"],
                 time_column="time",
             )
+
+
+class TestSensitivityRefit:
+    """Checks that re-fit an experiment must not replay ``time_column``.
+
+    ``PlaceboInTime`` hands its factory a slice of ``experiment.data``, which
+    is already normalized: the time column has been moved onto the index, so
+    replaying the argument raised ``DataException`` on every fold. The check
+    swallows per-fold failures, so the user saw an inconclusive result rather
+    than an error. The other checks re-fit from the caller's original data and
+    do still need the argument.
+    """
+
+    def _context(self):
+        """Build a pipeline context from a Polars frame using time_column."""
+        n = 200
+        rng = np.random.default_rng(0)
+        frame = pd.DataFrame(
+            {
+                "date": np.arange(n),
+                "trend": np.arange(n) / n,
+                "y": rng.normal(size=n),
+            }
+        )
+        step = cp.steps.EstimateEffect(
+            cp.InterruptedTimeSeries,
+            treatment_time=150,
+            formula="y ~ 1 + trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+        return step.run(PipelineContext(data=pl.from_pandas(frame)))
+
+    def test_config_still_carries_time_column(self):
+        """The recorded config keeps it, since other checks re-fit raw data."""
+        context = self._context()
+        assert context.experiment_config["time_column"] == "date"
+        assert "date" not in context.experiment.data.columns
+
+    def test_placebo_factory_refits_without_time_column(self):
+        """The placebo factory rebuilds from normalized data without raising."""
+        context = self._context()
+        factory = PlaceboInTime(n_folds=2)._get_factory(context)
+        refit = factory(context.experiment.data.iloc[:100], 75)
+        assert isinstance(refit, cp.InterruptedTimeSeries)

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -27,7 +27,7 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
-from causalpy.custom_exceptions import DataException
+from causalpy.custom_exceptions import BadIndexException, DataException
 from causalpy.input_data import to_pandas_with_time_index
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
@@ -259,6 +259,30 @@ class TestSyntheticDifferenceInDifferences:
                 70,
                 control_units=["a", "b", "c", "d", "e", "f", "g"],
                 treated_units=["actual"],
+            )
+
+
+class TestTimestampMismatchMessage:
+    """The treatment-time mismatch error states the right requirement.
+
+    The ``treatment_time`` branch read "must be pd.Timestamp" on the path that
+    fires precisely because it already is one. The sibling
+    ``treatment_end_time`` branch had it right, so this was a copy-paste slip.
+    Reachable from any backend, but a ``time_column`` holding strings rather
+    than dates lands here, which is what surfaced it.
+    """
+
+    def test_non_datetime_index_with_timestamp_treatment_time(self, sc_data):
+        """A string time axis plus a Timestamp treatment time explains itself."""
+        as_text = sc_data.copy()
+        as_text.index = as_text.index.astype(str)
+        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
+            cp.SyntheticControl(
+                as_text,
+                pd.Timestamp("2020-01-01"),
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                model=LinearRegression(),
             )
 
 

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -1,0 +1,209 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Tests for the explicit time axis on index-based experiments.
+
+InterruptedTimeSeries, SyntheticControl, and SyntheticDifferenceInDifferences
+compare observations against a treatment time. Pandas callers supply that axis
+as the dataframe index. Callers using another dataframe library have no index
+and must name the time column instead.
+"""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.custom_exceptions import DataException
+from causalpy.input_data import to_pandas_with_time_index
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def to_polars_with_time(data: pd.DataFrame, time_name: str) -> pl.DataFrame:
+    """Move a pandas index into a named column and convert to Polars."""
+    return pl.from_pandas(data.rename_axis(time_name).reset_index())
+
+
+class TestToPandasWithTimeIndex:
+    """Unit tests for the shared helper."""
+
+    def test_pandas_without_time_column_keeps_index(self):
+        """A pandas input without time_column keeps its own index."""
+        frame = pd.DataFrame({"y": [1, 2]}, index=pd.Index([10, 11], name="t"))
+        result = to_pandas_with_time_index(frame)
+        assert result.index.tolist() == [10, 11]
+
+    def test_time_column_becomes_index(self):
+        """time_column moves out of the columns and onto the index."""
+        frame = pd.DataFrame({"t": [10, 11], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [10, 11]
+        assert "t" not in result.columns
+
+    def test_polars_time_column_becomes_index(self):
+        """A Polars input with time_column gets a real time index."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [10, 11]
+
+    def test_polars_without_time_column_raises(self):
+        """A non-pandas input without time_column is rejected, not guessed."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            to_pandas_with_time_index(frame)
+
+    def test_missing_time_column_raises(self):
+        """A time_column that is not in the data is rejected."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        with pytest.raises(DataException, match="is not a column of"):
+            to_pandas_with_time_index(frame, time_column="date")
+
+
+class TestInterruptedTimeSeries:
+    """InterruptedTimeSeries with an explicit time column."""
+
+    def test_polars_matches_pandas(self, its_simple_data):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = pd.to_datetime("2015-01-01")
+
+        from_pandas = cp.InterruptedTimeSeries(
+            its_simple_data,
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+        )
+        from_polars = cp.InterruptedTimeSeries(
+            to_polars_with_time(its_simple_data, "date"),
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+        np.testing.assert_allclose(
+            np.asarray(from_polars.post_impact), np.asarray(from_pandas.post_impact)
+        )
+
+    def test_time_column_on_pandas_input(self, its_simple_data):
+        """A pandas caller can use time_column instead of setting the index."""
+        treatment_time = pd.to_datetime("2015-01-01")
+        flat = its_simple_data.rename_axis("date").reset_index()
+
+        result = cp.InterruptedTimeSeries(
+            flat,
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+        assert isinstance(result.data.index, pd.DatetimeIndex)
+
+    def test_polars_without_time_column_raises(self, its_simple_data):
+        """Without time_column the Polars input is refused, not silently ranked."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.InterruptedTimeSeries(
+                to_polars_with_time(its_simple_data, "date"),
+                pd.to_datetime("2015-01-01"),
+                formula="timeseries ~ 1 + linear_trend",
+                model=LinearRegression(),
+            )
+
+    def test_pandas_input_index_is_not_renamed(self, its_simple_data):
+        """The caller's index name survives construction."""
+        data = its_simple_data.copy()
+        data.index.name = "my_dates"
+        cp.InterruptedTimeSeries(
+            data,
+            pd.to_datetime("2015-01-01"),
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+        )
+        assert data.index.name == "my_dates"
+
+
+class TestSyntheticControl:
+    """SyntheticControl with an explicit time column."""
+
+    def test_polars_matches_pandas(self, sc_data, mock_pymc_sample):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = 70
+        control_units = ["a", "b", "c", "d", "e", "f", "g"]
+        treated_units = ["actual"]
+
+        def build(frame, time_column=None):
+            return cp.SyntheticControl(
+                frame,
+                treatment_time,
+                control_units=control_units,
+                treated_units=treated_units,
+                model=LinearRegression(),
+                time_column=time_column,
+            )
+
+        from_pandas = build(sc_data)
+        from_polars = build(to_polars_with_time(sc_data, "time"), time_column="time")
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+
+    def test_polars_without_time_column_raises(self, sc_data):
+        """Without time_column the Polars input is refused."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.SyntheticControl(
+                to_polars_with_time(sc_data, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                model=LinearRegression(),
+            )
+
+
+class TestSyntheticDifferenceInDifferences:
+    """SyntheticDifferenceInDifferences with an explicit time column."""
+
+    def test_polars_matches_pandas(self, sc_data, mock_pymc_sample):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = 70
+        control_units = ["a", "b", "c", "d", "e", "f", "g"]
+        treated_units = ["actual"]
+
+        def build(frame, time_column=None):
+            return cp.SyntheticDifferenceInDifferences(
+                frame,
+                treatment_time,
+                control_units=control_units,
+                treated_units=treated_units,
+                time_column=time_column,
+            )
+
+        from_pandas = build(sc_data)
+        from_polars = build(to_polars_with_time(sc_data, "time"), time_column="time")
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+
+    def test_polars_without_time_column_raises(self, sc_data):
+        """Without time_column the Polars input is refused."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.SyntheticDifferenceInDifferences(
+                to_polars_with_time(sc_data, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+            )


### PR DESCRIPTION
Third of three stacked PRs for #930. Based on #1088; #1087 has landed.

`InterruptedTimeSeries`, `SyntheticControl`, and `SyntheticDifferenceInDifferences` use the pandas index as the time axis: they split pre/post on `data.index < treatment_time` and validate the index type against `treatment_time`. A dataframe from another library has no index, so a converted frame would arrive with a `RangeIndex` and `treatment_time` would silently become a positional cutoff.

This PR adds an optional `time_column` argument to those three classes and a shared `to_pandas_with_time_index()` helper. When `time_column` is given, that column becomes the index. When it is omitted, the pandas index is used exactly as before, so existing code is unaffected. A non-pandas input without `time_column` raises `DataException` rather than guessing.

## Guarding the time axis

Three ways the time axis can be wrong are refused rather than accepted:

- `time_column` passed alongside a meaningful index (named, or a `DatetimeIndex`) raises, since setting the column as the index would silently drop the existing time axis. Only an unnamed `RangeIndex` counts as absent, which is what conversion from an index-less library produces.
- A `time_column` with duplicate values raises.
- A `time_column` that is not sorted raises.

The last one is worth calling out because it was reachable before this PR and silent. `SyntheticControl` and `SyntheticDifferenceInDifferences` validate only the treatment-time type, never index uniqueness or monotonicity; `InterruptedTimeSeries` validates both. So a shuffled frame produced a `datapre` index of `[3, 6, 2, 4, 7, 1, 0, 9, 8, 5]` instead of `[0..9]`, with no warning. The split is value-based, so membership stayed correct while the time order did not, which breaks anything order-dependent downstream. `time_column` is what makes this likely rather than exotic: a dataframe library with no index also carries no row-order guarantee across joins and group-bys.

The validation lives in `to_pandas_with_time_index()`, the single place the time axis is established, so it covers all three classes. It only runs on the `time_column` path, so existing pandas callers are untouched.

## Error message wording

An earlier revision of this PR also corrected `"If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."`, which fired on the branch that runs precisely because `treatment_time` already is one. That fix landed upstream first, in `date_utils.validate_treatment_time_against_index`, which also handles the timezone case, so the source change is gone from this PR. The test survives, and now checks all three classes rather than one, since the original slip was copy-pasted into each.

## Sensitivity re-fit

`PlaceboInTime` hands its factory a slice of `experiment.data`, which is already normalized: `time_column` has been moved onto the index, so the column no longer exists. Replaying the original constructor kwargs therefore raised `DataException` on every fold, and the check swallows per-fold failures, so the user got an inconclusive result rather than an error. The argument is now dropped in that factory. The other four checks re-fit from the caller's untouched `context.data` and do still need it, which is why this is fixed there rather than at the source.

## Tests

26 tests in `causalpy/tests/test_time_column.py`, covering the helper, the pandas path, the Polars path, the refusal when `time_column` is missing, each of the three guards, the message on all three classes, and the sensitivity-refit case below.

Verified on the current integration head: 2073 passed, 18 skipped; doctest sweep 39 passed, 13 skipped.

Stack: #1087 contract (merged), #1088 column-based experiments, then this PR.

