### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/causalpy/version.py
+++ b/causalpy/version.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 """CausalPy Version."""
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = ["causalpy.test*", "docs*"]
 
 [project]
 name = "CausalPy"
-version = "0.8.0"
+version = "0.9.0"
 description = "Causal inference for quasi-experiments in Python"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- bump the package metadata and runtime version to 0.9.0
- prepare the final PyMC 5-compatible 0.x release

## Test plan
- [x] `mamba run -n CausalPy prek run --all-files`
- [x] verified `pyproject.toml` and `causalpy.__version__` agree on `0.9.0`


Made with [Cursor](https://cursor.com)