### PR TITLE
Fix docs PyMC-Marketing dependency pin

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 # This VCS dependency is intentionally docs-only: PyPI rejects direct VCS references in published package metadata.
-pymc-marketing @ git+https://github.com/pymc-labs/pymc-marketing.git@v1.0.0
+# d710dc0 is the immutable merge commit from pymc-marketing #2677, merged into upstream main; it remains reachable after the v1.0.0 ref was deleted.
+pymc-marketing @ git+https://github.com/pymc-labs/pymc-marketing.git@d710dc035b654b96d6abab2087df4f577beb66f1
+# Match the upstream dependency bound explicitly; the expected resolver selection is pymc-extras 0.12.1.
+pymc-extras>=0.11,<0.13


### PR DESCRIPTION
## Summary
- Replaces the deleted moving `pymc-marketing@v1.0.0` ref with immutable commit `d710dc035b654b96d6abab2087df4f577beb66f1` in the docs-only requirements file.
- Makes `pymc-extras>=0.11,<0.13` pip-visible and records the expected `0.12.1` selection.

## Immutable reachability
`d710dc035b654b96d6abab2087df4f577beb66f1` is the merge commit for upstream `pymc-labs/pymc-marketing` PR #2677, which was merged into upstream `main`. The SHA remains reachable from that merged history even though the `v1.0.0` named ref was deleted; unlike a branch or tag, the full SHA cannot move.

## Expected resolver stack
The pinned upstream metadata declares `pymc-marketing 1.0.0.dev0`, `pymc>=6.0.0,<6.1.0`, `pytensor>=3.0.0,<4.0`, `arviz>=1.2.0,<2.0`, and `pymc-extras>=0.11.0,<0.13.0`. Together with CausalPy's transition bounds, the expected docs resolver stack includes PyMC 6.0.1, PyTensor 3.0.7, ArviZ 1.2.0, and pymc-extras 0.12.1.

## Compatibility contract
Existing focused coverage already encodes the runtime contract, so this docs-only repair adds no static requirements test: `causalpy/tests/test_pymc_models_compat.py::test_pymc_marketing_v1_defaults_build_and_sample` exercises v1 `LinearTrend`/`YearlyFourier` BSTS defaults through sampling, while `causalpy/tests/test_integration_its_new_timeseries.py` exercises `StateSpaceTimeSeries`/InterruptedTimeSeries with `pymc_extras.statespace` and the DataTree/plot-data contract.

## Validation
No tests, resolver install, documentation build, formatter, linter, or `prek` run was executed in this concurrent wave by instruction. Coordinator validation remains pending: resolve `docs/requirements.txt`, run the focused BSTS/StateSpace compatibility coverage, and build the documentation.