### PR TITLE
Remove deprecated experiment-level hdi_prob from public plot() methods (#984)

### DIFF
--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Difference in differences."""
 
-import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -362,7 +361,6 @@ class DifferenceInDifferences(BaseExperiment):
         *,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -384,8 +382,6 @@ class DifferenceInDifferences(BaseExperiment):
             counterfactual trajectories. Must be in ``(0, 1]``. Ignored for
             OLS models. Defaults to :data:`~causalpy.constants.HDI_PROB`
             (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -420,14 +416,6 @@ class DifferenceInDifferences(BaseExperiment):
         ax : matplotlib.axes.Axes
             The axes object containing the plot.
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Interrupted Time Series Analysis."""
 
-import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -534,7 +533,6 @@ class InterruptedTimeSeries(BaseExperiment):
         *,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -555,8 +553,6 @@ class InterruptedTimeSeries(BaseExperiment):
             posterior predictive, causal impact, and cumulative impact bands.
             Must be in ``(0, 1]``. Ignored for OLS models. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -592,14 +588,6 @@ class InterruptedTimeSeries(BaseExperiment):
             The three axes (top: predictions, middle: causal impact,
             bottom: cumulative impact).
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -15,7 +15,6 @@
 
 import ast
 import re
-import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -418,7 +417,6 @@ class PiecewiseITS(BaseExperiment):
         *,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -438,8 +436,6 @@ class PiecewiseITS(BaseExperiment):
             fitted, counterfactual, causal effect, and cumulative effect
             bands. Must be in ``(0, 1]``. Ignored for OLS models. Defaults
             to :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -473,14 +469,6 @@ class PiecewiseITS(BaseExperiment):
             The three axes (top: observed, fitted and counterfactual;
             middle: causal effect; bottom: cumulative effect).
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -13,7 +13,6 @@
 #   limitations under the License.
 """Pretest/posttest nonequivalent group design."""
 
-import warnings
 from typing import Any, Literal
 
 import numpy as np
@@ -254,7 +253,6 @@ class PrePostNEGD(BaseExperiment):
         *,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -276,8 +274,6 @@ class PrePostNEGD(BaseExperiment):
             and around the posterior of the estimated treatment effect.
             Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -311,14 +307,6 @@ class PrePostNEGD(BaseExperiment):
             The two axes (top: scatter and posterior predictive bands,
             bottom: estimated treatment effect posterior).
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -316,7 +316,6 @@ class RegressionDiscontinuity(BaseExperiment):
         *,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -338,8 +337,6 @@ class RegressionDiscontinuity(BaseExperiment):
             reported in the figure title for the discontinuity at threshold.
             Must be in ``(0, 1]``. Ignored for OLS models. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -373,14 +370,6 @@ class RegressionDiscontinuity(BaseExperiment):
         ax : matplotlib.axes.Axes
             The axes object containing the plot.
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -270,7 +270,6 @@ class RegressionKink(BaseExperiment):
         *,
         round_to: int | None = 2,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -292,8 +291,6 @@ class RegressionKink(BaseExperiment):
             reported in the figure title for the change in gradient at the
             kink point. Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -327,14 +324,6 @@ class RegressionKink(BaseExperiment):
         ax : matplotlib.axes.Axes
             The axes object containing the plot.
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -406,7 +406,6 @@ class SyntheticControl(BaseExperiment):
         round_to: int | None = None,
         treated_unit: str | None = None,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -432,8 +431,6 @@ class SyntheticControl(BaseExperiment):
             posterior predictive, causal impact, and cumulative impact bands.
             Must be in ``(0, 1]``. Ignored for OLS models. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -472,14 +469,6 @@ class SyntheticControl(BaseExperiment):
             The three axes (top: predictions, middle: causal impact,
             bottom: cumulative impact).
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -592,7 +592,6 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         *,
         round_to: int | None = None,
         ci_prob: float = HDI_PROB,
-        hdi_prob: float | None = None,
         kind: Literal["ribbon", "histogram", "spaghetti"] = "ribbon",
         ci_kind: Literal["hdi", "eti"] = "hdi",
         num_samples: int = 50,
@@ -611,8 +610,6 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             posterior predictive, causal impact, and cumulative impact bands.
             Must be in ``(0, 1]``. Defaults to
             :data:`~causalpy.constants.HDI_PROB` (currently 0.94).
-        hdi_prob : float, optional
-            Deprecated. Use ``ci_prob`` instead.
         kind : {"ribbon", "histogram", "spaghetti"}, optional
             How posterior uncertainty is rendered via
             :func:`~causalpy.plot_utils.plot_posterior_over_x`. Defaults to ``"ribbon"``.
@@ -643,14 +640,6 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         ax : numpy.ndarray
             Array of the three :class:`matplotlib.axes.Axes` instances.
         """
-        if hdi_prob is not None:
-            warnings.warn(
-                "hdi_prob is deprecated and will be removed in a future release. "
-                "Use ci_prob instead.",
-                FutureWarning,
-                stacklevel=2,
-            )
-            ci_prob = hdi_prob
         return self._render_plot(
             show=show,
             legend_kwargs=legend_kwargs,

--- a/causalpy/tests/test_hdi_prob_wiring.py
+++ b/causalpy/tests/test_hdi_prob_wiring.py
@@ -12,9 +12,9 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """
-Regression tests verifying that ``ci_prob`` (and its deprecated alias
-``hdi_prob``) is wired through Bayesian plot methods so that user-supplied
-values actually change the rendered credible-interval bands.
+Regression tests verifying that ``ci_prob`` is wired through Bayesian plot
+methods so that user-supplied values actually change the rendered
+credible-interval bands.
 
 These tests guard against the regression described in GitHub issue
 `pymc-labs/CausalPy#890`_, where ``result.plot(hdi_prob=...)`` was silently
@@ -23,12 +23,18 @@ swallowed by ``**kwargs`` rather than reaching the underlying
 
 ``hdi_prob`` was the original parameter name. It was renamed to ``ci_prob``
 when ETI support was added (since the parameter controls the *credible interval*
-width, not only HDI). ``hdi_prob`` remains accepted with a ``FutureWarning``.
+width, not only HDI). The deprecated ``hdi_prob`` alias was removed from the
+public experiment ``plot()`` methods in `pymc-labs/CausalPy#984`_; passing it
+now raises ``TypeError``. ``PanelRegression`` and
+``StaggeredDifferenceInDifferences`` are not yet migrated and still take
+``hdi_prob`` as their real parameter name.
 
 .. _pymc-labs/CausalPy#890: https://github.com/pymc-labs/CausalPy/issues/890
+.. _pymc-labs/CausalPy#984: https://github.com/pymc-labs/CausalPy/issues/984
 """
 
 import importlib
+import inspect
 from contextlib import ExitStack
 from typing import Any
 from unittest.mock import patch
@@ -352,6 +358,12 @@ _PIECEWISE_TARGETS: list[_SpyTarget] = [
 _PANEL_TARGETS: list[_SpyTarget] = [
     ("causalpy.experiments.panel_regression.hdi_bound_arrays", "prob"),
 ]
+_SDID_TARGETS: list[_SpyTarget] = [
+    (
+        "causalpy.experiments.synthetic_difference_in_differences.plot_posterior_over_x",
+        "ci_prob",
+    ),
+]
 
 
 @pytest.mark.integration
@@ -458,59 +470,82 @@ def test_panel_plot_default_ci_prob(mock_pymc_sample, fitted_panel):
     _check_default(fitted_panel, _PANEL_TARGETS)
 
 
-# ---------------------------------------------------------------------------
-# Deprecated hdi_prob alias: verify it still works with a FutureWarning.
-# ---------------------------------------------------------------------------
+@pytest.mark.integration
+@pytest.mark.parametrize("ci_prob", _PARAMS)
+def test_sdid_plot_threads_ci_prob(mock_pymc_sample, fitted_sdid, ci_prob):
+    """SDID ``plot(ci_prob=...)`` reaches every ``plot_posterior_over_x`` call."""
+    _check_threading(fitted_sdid, _SDID_TARGETS, ci_prob)
 
 
 @pytest.mark.integration
-def test_deprecated_hdi_prob_still_wired(mock_pymc_sample, fitted_its):
-    """``plot(hdi_prob=...)`` still reaches ``plot_posterior_over_x`` via the deprecated alias.
+def test_sdid_plot_default_ci_prob(mock_pymc_sample, fitted_sdid):
+    """SDID default ``plot()`` forwards ``HDI_PROB`` as ``ci_prob``."""
+    _check_default(fitted_sdid, _SDID_TARGETS)
 
-    Ensures that existing user code does not silently break after the rename
-    to ``ci_prob``. The deprecated alias must emit a ``FutureWarning`` and
-    forward the value to ``plot_posterior_over_x`` as ``ci_prob``.
-    """
-    stack, recorded = _record_hdi_prob_calls(
-        [
-            (
-                "causalpy.experiments.interrupted_time_series.plot_posterior_over_x",
-                "ci_prob",
-            )
-        ]
+
+# ---------------------------------------------------------------------------
+# Removed hdi_prob alias (pymc-labs/CausalPy#984).
+#
+# The deprecated experiment-level ``hdi_prob`` alias is gone from the public
+# ``plot()`` methods of the eight migrated classes. Because those signatures
+# are keyword-only with no ``**kwargs`` escape hatch, passing ``hdi_prob``
+# must now raise ``TypeError`` rather than being silently swallowed. Each
+# case also asserts that ``ci_prob`` still threads through, so a future
+# over-eager removal of the ``ci_prob`` wiring cannot pass these tests.
+# ---------------------------------------------------------------------------
+
+# (experiment class name, fitted fixture name, spy targets)
+_MIGRATED_EXPERIMENTS: list[tuple[str, str, list[_SpyTarget]]] = [
+    ("InterruptedTimeSeries", "fitted_its", _ITS_TARGETS),
+    ("DifferenceInDifferences", "fitted_did", _DID_TARGETS),
+    ("PrePostNEGD", "fitted_prepost", _PREPOST_TARGETS),
+    ("RegressionDiscontinuity", "fitted_rd", _RD_TARGETS),
+    ("RegressionKink", "fitted_rkink", _RKINK_TARGETS),
+    ("SyntheticControl", "fitted_sc", _SC_TARGETS),
+    ("SyntheticDifferenceInDifferences", "fitted_sdid", _SDID_TARGETS),
+    ("PiecewiseITS", "fitted_piecewise", _PIECEWISE_TARGETS),
+]
+
+_MIGRATED_CLASS_NAMES = [name for name, _, _ in _MIGRATED_EXPERIMENTS]
+
+
+def test_migrated_experiments_list_covers_all_eight() -> None:
+    """Guard the coverage list itself against silent shrinkage."""
+    assert len(_MIGRATED_EXPERIMENTS) == 8
+    assert len(set(_MIGRATED_CLASS_NAMES)) == 8
+
+
+@pytest.mark.parametrize("class_name", _MIGRATED_CLASS_NAMES)
+def test_public_plot_has_no_hdi_prob_parameter(class_name: str) -> None:
+    """``plot()`` exposes ``ci_prob`` and no longer declares ``hdi_prob``."""
+    params = inspect.signature(getattr(cp, class_name).plot).parameters
+    assert "hdi_prob" not in params, (
+        f"{class_name}.plot() still declares a deprecated hdi_prob parameter"
     )
-    import warnings
-
-    with stack, warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        fitted_its.plot(hdi_prob=0.75)
-
-    assert any(issubclass(w.category, FutureWarning) for w in caught), (
-        "Expected a FutureWarning when hdi_prob is passed to plot()"
+    assert "ci_prob" in params, f"{class_name}.plot() lost its ci_prob parameter"
+    # No ``**kwargs`` escape hatch that could re-absorb ``hdi_prob`` silently.
+    assert not any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()), (
+        f"{class_name}.plot() must not accept **kwargs"
     )
-    _assert_threads(recorded, 0.75)
 
 
 @pytest.mark.integration
 @pytest.mark.parametrize(
-    "fixture_name",
-    [
-        "fitted_did",
-        "fitted_rd",
-        "fitted_rkink",
-        "fitted_prepost",
-        "fitted_piecewise",
-        "fitted_sc",
-        "fitted_sdid",
-    ],
+    ("fixture_name", "targets"),
+    [(fixture, targets) for _, fixture, targets in _MIGRATED_EXPERIMENTS],
+    ids=_MIGRATED_CLASS_NAMES,
 )
-def test_deprecated_hdi_prob_alias_emits_futurewarning(
-    mock_pymc_sample, request, fixture_name
-):
-    """hdi_prob deprecated alias emits FutureWarning on all migrated experiment classes."""
+def test_removed_hdi_prob_raises_typeerror_and_ci_prob_still_wired(
+    mock_pymc_sample, request, fixture_name: str, targets: list[_SpyTarget]
+) -> None:
+    """``plot(hdi_prob=...)`` raises ``TypeError``; ``plot(ci_prob=...)`` still threads."""
     fitted = request.getfixturevalue(fixture_name)
-    with pytest.warns(FutureWarning, match="hdi_prob is deprecated"):
+
+    with pytest.raises(TypeError, match="hdi_prob"):
         fitted.plot(hdi_prob=0.75)
+
+    # The removal must not have taken the ci_prob wiring with it.
+    _check_threading(fitted, targets, 0.75)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #984.

## What

Removes the deprecated experiment-level `hdi_prob` parameter, and its `FutureWarning` block, from the eight migrated public `plot()` methods:

`InterruptedTimeSeries`, `DifferenceInDifferences`, `PrePostNEGD`, `RegressionDiscontinuity`, `RegressionKink`, `SyntheticControl`, `SyntheticDifferenceInDifferences`, `PiecewiseITS`.

`import warnings` became unused in `interrupted_time_series.py`, `diff_in_diff.py`, `prepostnegd.py` and `piecewise_its.py`, so it is dropped there. It is retained in the other four, which still use it for unrelated warnings.

## Tests

Per the issue, the two deprecated-alias tests are removed from `test_hdi_prob_wiring.py`: `test_deprecated_hdi_prob_still_wired` and `test_deprecated_hdi_prob_alias_emits_futurewarning`. No other test was deleted. The `ci_prob` wiring tests are kept.

Added in their place:

- `test_public_plot_has_no_hdi_prob_parameter` — signature-level check per class: `hdi_prob` absent, `ci_prob` present, and no `**kwargs` escape hatch that could silently re-absorb `hdi_prob`.
- `test_removed_hdi_prob_raises_typeerror_and_ci_prob_still_wired` — behavioural negative proof per class: `plot(hdi_prob=...)` raises `TypeError`, and the same test then re-runs the `ci_prob` threading assertion so the removal cannot take the `ci_prob` wiring with it.
- `test_migrated_experiments_list_covers_all_eight` — guards the coverage list against silent shrinkage.
- `test_sdid_plot_threads_ci_prob` / `test_sdid_plot_default_ci_prob` — `SyntheticDifferenceInDifferences` had no `ci_prob` wiring test of its own and was only exercised by one of the deleted alias tests, so it would otherwise have lost coverage entirely.

Both new checks were mutation-tested: re-adding the alias to one class fails exactly that class's two new tests, and dropping `ci_prob=ci_prob` from one class's `_render_plot` call fails its retained threading tests.

## Out of scope, deliberately untouched

- the silent (non-warning) `hdi_prob` back-compat alias on `plot_posterior_over_x`
- the not-yet-migrated `PanelRegression` and `StaggeredDifferenceInDifferences`, where `hdi_prob` is the real parameter name
- genuine HDI helpers: `get_hdi_to_df`, `_compute_statistics`, `hdi_bounds`, `hdi_bound_arrays`, `get_plot_data`, `effect_summary`, `set_maketables_options`, `_draw_singleton_hdi_marker`
- no docs or notebooks needed changing: none of them pass `hdi_prob` to any of the eight `plot()` methods

Base is `pymc6_and_pymcmarketing1_migration`, not `main`.

## Rebase provenance and coordinator follow-up

- **Daimon provenance:** the original reviewed patch is `4e3f5758c16aa9965cb2ee294ece8b9942a8c227`, authored by `daimon-pymclabs <daimon@pymc-labs.com>`.
- **Rebase:** it was rebased unchanged onto transition merge `9c8c967898b30bd161c09145b5d266607a63c146`, yielding `cbc538bfe01038fc8df587bf0fcbff7997b0b047`. No conflicts occurred; the original and rebased diffs have the same stable patch ID (`766254f0442e0076de561cb2cd9681d5a743a087`).
- **Original verification:** the contract and mutation checks documented above remain the original Daimon review evidence. Before the rebase, the coordinator also passed 56 focused tests and changed-file `prek`.
- **Independent coordinator review:** two independent reviews found no defects.
- **Fresh coordinator validation:** on `cbc538bfe01038fc8df587bf0fcbff7997b0b047`, `python -m pytest causalpy/tests/test_hdi_prob_wiring.py --no-cov -q` passed 56/56 and changed-file `prek` passed every hook. The obsolete second test path is not in the rebased tree and was intentionally excluded; the canonical `test_hdi_prob_wiring.py` file collects all 56 contracts. Remote CI remains pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)