### PR TITLE
Document public API boundary policy (#944)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -154,7 +154,7 @@ repos:
         entry: python scripts/check_public_exports.py --check
         language: python
         pass_filenames: false
-        files: ^(causalpy/__init__\.py|causalpy/experiments/.*|causalpy/checks/.*|docs/source/api/index\.md)$
+        files: ^(causalpy/__init__\.py|causalpy/experiments/.*|causalpy/checks/.*|causalpy/tests/test_check_public_exports\.py|docs/source/api/index\.md|scripts/check_public_exports\.py|scripts/_ast_introspection\.py)$
       - id: check-architecture-inventory
         name: Check ARCHITECTURE.md experiment inventory
         entry: python scripts/check_architecture_inventory.py --check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,11 +150,11 @@ repos:
         files: ^causalpy/.*\.py$
         exclude: ^causalpy/tests/
       - id: check-public-exports
-        name: Check public API export wiring
+        name: Check public API export and documentation wiring
         entry: python scripts/check_public_exports.py --check
         language: python
         pass_filenames: false
-        files: ^(causalpy/__init__\.py|causalpy/experiments/.*|causalpy/checks/.*)$
+        files: ^(causalpy/__init__\.py|causalpy/experiments/.*|causalpy/checks/.*|docs/source/api/index\.md)$
       - id: check-architecture-inventory
         name: Check ARCHITECTURE.md experiment inventory
         entry: python scripts/check_architecture_inventory.py --check

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ See the [python-environment skill](.agents/skills/python-environment/SKILL.md) f
   - In RST files (`.rst`): Use Sphinx syntax `:term:`glossary term``
 - **Cross-references**: For other cross-references in Markdown files, use MyST role syntax with curly braces (e.g., `{doc}path/to/doc`, `{ref}label-name`)
 - **Citations**: Use `references.bib` for citations, cite sources in example notebooks where possible. Include reference section at bottom of notebooks using `:::{bibliography}` directive with `:filter: docname in docnames`
-- **API documentation**: Auto-generated from docstrings via Sphinx autodoc, no manual API docs needed
+- **API documentation**: Sphinx autodoc generates members from docstrings. `docs/source/api/index.md` is the curated API manifest, not a manual reference; preserve its top-level `causalpy` `automodule` with `:members:`, `:undoc-members:`, and `:imported-members:`. Before promoting an export, follow the four-tier policy in `ARCHITECTURE.md`. `make check-exports` and the `check-public-exports` prek hook statically check Tier 1 bindings and Sphinx wiring; do not use importability or underscore heuristics.
 - **Build**: Use `make html` to build documentation
 - **Doctest**: Use `make doctest` to test that Python examples in doctests work
 - **Notebook validation**: `prek run --all-files` runs `validate-notebooks` to catch invalid nbformat and docs notebook convention errors.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -22,6 +22,24 @@ CausalPy implements 10+ quasi-experimental causal inference methods over two cor
 | `docs/source/notebooks/` | How-to notebooks (`{method}_{backend}.ipynb`) |
 | `docs/source/knowledgebase/` | Educational content (glossary, reporting explainers) |
 
+## Public API Policy
+
+CausalPy assigns every supported surface to one of four tiers. Membership comes from the manifests below, not from importability or a name's underscore convention. When the same object has more than one documented path, the strongest applicable tier governs its compatibility promise.
+
+1. **Tier 1 — stable top-level API.** `causalpy.__all__` is the authoritative manifest: only its names are stable as `causalpy.<name>`. `docs/source/api/index.md` documents that package with a Sphinx `automodule` using `:members:`, `:undoc-members:`, and `:imported-members:`, and `scripts/check_public_exports.py` statically requires both that documentation wiring and a local binding for every export. Removing, renaming, or incompatibly changing a Tier 1 signature, return contract, or behavior is SemVer-major work; issue a deprecation warning in a prior feature release whenever practical and provide migration or release-note guidance. Adding a Tier 1 name is backwards-compatible but creates this promise.
+
+2. **Tier 2 — documented submodule API.** A qualified symbol is Tier 2 only when its containing CausalPy module is explicitly listed in `docs/source/api/index.md` and the symbol is rendered on that module's generated Sphinx autosummary page. A whole-submodule re-export, direct import, or unprefixed name alone does not promote a symbol. Tier 2 paths are stable within a release line and may break only in a declared major release; normally warn through a deprecation first, and when that is not practical provide explicit migration and release-note guidance in that major release.
+
+3. **Tier 3 — internal implementation.** Everything not classified as Tier 1, Tier 2, or Tier 4 is internal, including unprefixed support helpers in modules such as `utils`, `plot_utils`, `date_utils`, and `custom_exceptions`. Evaluate the explicit Tier 4 protocol before this fallback, so an integration hook does not become Tier 3 merely because it has an underscore-style name. Leading underscores remain a strong signal, but are not the classifier. Tier 3 paths have no compatibility guarantee; leave ambiguous helpers here until a separately reviewed manifest and documentation decision promotes them, and use a deprecation plan before removing an import path with known users.
+
+4. **Tier 4 — protocol and integrator hooks.** `BaseExperiment.set_maketables_options()`, the `BaseExperiment.__maketables_*__` protocol, and model `_clone()` overrides consumed by CausalPy checks are supported for integrators despite their underscore-style names. They are documented for contributors and integrators here rather than as end-user Sphinx API. An incompatible protocol change is SemVer-major and needs a migration or deprecation notice. No other underscored name is Tier 4 unless this policy is updated.
+
+### Current boundary decisions
+
+`EffectSummary` is the only new Tier 1 promotion: public `effect_summary()` methods return it, and the reporting knowledgebase already names its `table` and `text` contract. Re-exporting it as `causalpy.EffectSummary` gives users a stable type path; adding `reporting` to the Sphinx API surface and its explicit `__all__` documents that type without exposing its underscored calculation helpers.
+
+The top-level Sphinx `automodule` documents every existing `causalpy.__all__` export, including established utility and transform re-exports, without adding their support modules to the autosummary list. This aligns existing Tier 1 paths with docs rather than broadly promoting `utils`, `plot_utils`, `date_utils`, `custom_exceptions`, or other ambiguous helpers. No aliases, import removals, plot signatures, or effect-summary behavior change as part of this policy.
+
 ## Backend Model
 
 Backend dispatch is centralized in `causalpy/experiments/model_adapter.py`. `BaseExperiment.__init__` calls `make_model_adapter()`, which handles sklearn coercion (`clone`/`deepcopy`, `create_causalpy_compatible_class()`, `fit_intercept=False` warning), default-model instantiation, and `supports_bayes`/`supports_ols`/`supports_pymc_forecast` validation. Each experiment stores `self._model_backend` (private) and keeps `self.model` as the public handle. Bayesian-only consumers check `ModelAdapter.supports_idata` and use `require_idata()`; the honest `idata` property returns `None` for unsupported or unfitted backends instead of using `AttributeError` as capability discovery.
@@ -97,4 +115,4 @@ Copy the closest existing experiment or model and follow the `BaseExperiment` co
 - Raise `FormulaException`, `DataException`, or `BadIndexException` from `causalpy.custom_exceptions` for formula, data, and index errors
 - Avoid backwards-compat shims for APIs introduced in the same PR
 
-**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, or data contract, update this file in the same PR. Export wiring and the experiment inventory table are enforced by `scripts/check_public_exports.py` and `scripts/check_architecture_inventory.py` (also run via prek); run `make check-exports` / `make check-architecture` locally if needed.
+**Keeping it current:** When you add, remove, or structurally change an experiment class, PyMC model, backend dispatch path, data contract, or Tier 1 export, update this file and its documented surface in the same PR. `scripts/check_public_exports.py` enforces experiment/check export wiring plus the Tier 1 top-level Sphinx directive, while `scripts/check_architecture_inventory.py` enforces the experiment inventory table (both run via prek); run `make check-exports` / `make check-architecture` locally if needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,6 +181,10 @@ For more instructions see the [Pull request checklist](#pull-request-checklist)
 
 1. Finally, to submit a pull request, go to the GitHub web page of your fork of the CausalPy repo. Click the 'Pull request' button to send your changes to the project's maintainers for review. This will send an email to the committers.
 
+## Public API compatibility
+
+The authoritative [four-tier API policy](ARCHITECTURE.md#public-api-policy) defines which paths are stable and their SemVer expectations. Before adding, promoting, or changing an API, identify its tier in the PR and update the applicable Sphinx or manifest surface. Do not infer public support from an import path, a whole-submodule re-export, or an unprefixed name; leave an ambiguous helper in Tier 3 until maintainers explicitly promote it. Tier 1 and Tier 2 changes need documentation and a compatibility or migration plan for breaking changes; add an observable contract test or deterministic checker only when the rule does not require heuristic judgment. Tier 4 protocol changes need integrator-facing migration guidance.
+
 ## Pull request checklist
 
 We recommend that your contribution complies with the following guidelines before you submit a pull request:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ check_lint: ## Check code formatting and linting without making changes
 	ruff check .
 	ruff format --diff --check .
 
-check-exports: ## Verify experiment/check public API export wiring
+check-exports: ## Verify public API export and documentation wiring
 	python scripts/check_public_exports.py --check
 
 check-architecture: ## Verify ARCHITECTURE.md experiment inventory matches code

--- a/causalpy/__init__.py
+++ b/causalpy/__init__.py
@@ -38,6 +38,7 @@ from .experiments.synthetic_difference_in_differences import (
     SyntheticDifferenceInDifferences,
 )
 from .pipeline import Pipeline, PipelineContext, PipelineResult, Step
+from .reporting import EffectSummary
 from .steps import (
     EstimateEffect,
     GenerateReport,
@@ -52,6 +53,7 @@ __all__ = [
     "create_causalpy_compatible_class",
     "DifferenceInDifferences",
     "EstimateEffect",
+    "EffectSummary",
     "extract_lift_for_mmm",
     "GenerateReport",
     "InstrumentalVariable",

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -53,6 +53,8 @@ class EffectSummary:
     table: pd.DataFrame
     text: str
 
+__all__ = ["EffectSummary"]
+
 
 # ==============================================================================
 # Helper functions for common operations

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -53,6 +53,7 @@ class EffectSummary:
     table: pd.DataFrame
     text: str
 
+
 __all__ = ["EffectSummary"]
 
 

--- a/causalpy/tests/test_check_public_exports.py
+++ b/causalpy/tests/test_check_public_exports.py
@@ -59,6 +59,71 @@ def test_detects_synthetic_did_in_experiment_exports(script_module) -> None:
     assert "SyntheticDifferenceInDifferences" in exp_imports
 
 
+
+def test_detects_unbound_top_level_export(tmp_path: Path, script_module) -> None:
+    """Tier 1 ``__all__`` entries must be locally bound."""
+    package_init = tmp_path / "__init__.py"
+    package_init.write_text(
+        'from .public import available\n\n__all__ = ["available", "missing"]\n',
+        encoding="utf-8",
+    )
+
+    errors = script_module.check_top_level_exports(package_init)
+
+    assert errors == [
+        "  causalpy/__init__.py __all__ vs top-level bindings missing: missing"
+    ]
+
+
+def test_requires_top_level_sphinx_members(tmp_path: Path, script_module) -> None:
+    """Tier 1 Sphinx coverage must render the root package members."""
+    api_index = tmp_path / "index.md"
+    api_index.write_text(
+        "```{eval-rst}\n.. automodule:: causalpy\n   :imported-members:\n```\n",
+        encoding="utf-8",
+    )
+
+    errors = script_module.check_top_level_api_docs(api_index)
+
+    assert len(errors) == 1
+    assert ":members:" in errors[0]
+
+
+
+def test_requires_top_level_sphinx_undocumented_members(
+    tmp_path: Path, script_module
+) -> None:
+    """Tier 1 Sphinx coverage must render exports without docstrings."""
+    api_index = tmp_path / "index.md"
+    api_index.write_text(
+        "```{eval-rst}\n.. automodule:: causalpy\n   :members:\n"
+        "   :imported-members:\n```\n",
+        encoding="utf-8",
+    )
+
+    errors = script_module.check_top_level_api_docs(api_index)
+
+    assert len(errors) == 1
+    assert ":undoc-members:" in errors[0]
+
+
+def test_requires_top_level_sphinx_imported_members(
+    tmp_path: Path, script_module
+) -> None:
+    """Tier 1 Sphinx coverage must render root re-exports."""
+    api_index = tmp_path / "index.md"
+    api_index.write_text(
+        "```{eval-rst}\n.. automodule:: causalpy\n   :members:\n"
+        "   :undoc-members:\n```\n",
+        encoding="utf-8",
+    )
+
+    errors = script_module.check_top_level_api_docs(api_index)
+
+    assert len(errors) == 1
+    assert ":imported-members:" in errors[0]
+
+
 def test_cli_exits_zero_when_exports_are_current() -> None:
     """CLI ``--check`` should succeed on the current repository."""
     result = subprocess.run(

--- a/causalpy/tests/test_check_public_exports.py
+++ b/causalpy/tests/test_check_public_exports.py
@@ -59,7 +59,6 @@ def test_detects_synthetic_did_in_experiment_exports(script_module) -> None:
     assert "SyntheticDifferenceInDifferences" in exp_imports
 
 
-
 def test_detects_unbound_top_level_export(tmp_path: Path, script_module) -> None:
     """Tier 1 ``__all__`` entries must be locally bound."""
     package_init = tmp_path / "__init__.py"
@@ -87,7 +86,6 @@ def test_requires_top_level_sphinx_members(tmp_path: Path, script_module) -> Non
 
     assert len(errors) == 1
     assert ":members:" in errors[0]
-
 
 
 def test_requires_top_level_sphinx_undocumented_members(

--- a/docs/source/api/index.md
+++ b/docs/source/api/index.md
@@ -1,5 +1,14 @@
 # API
 
+## Top-level API
+
+```{eval-rst}
+.. automodule:: causalpy
+   :members:
+   :undoc-members:
+   :imported-members:
+```
+
 ## Modules
 
 ```{eval-rst}
@@ -15,6 +24,7 @@
   pymc_forecast_models
   experiments
   pipeline
+  reporting
   steps
   checks
 ```

--- a/scripts/check_public_exports.py
+++ b/scripts/check_public_exports.py
@@ -31,8 +31,6 @@ API_INDEX_PATH = REPO_ROOT / "docs" / "source" / "api" / "index.md"
 TOP_LEVEL_MODULE = "causalpy"
 
 
-
-
 def _load_ast_introspection():
     path = _SCRIPTS_DIR / "_ast_introspection.py"
     spec = importlib.util.spec_from_file_location("ast_introspection", path)
@@ -128,8 +126,7 @@ def check_top_level_api_docs(api_index: Path = API_INDEX_PATH) -> list[str]:
     top_level_directives = directives.get(TOP_LEVEL_MODULE, [])
     if not top_level_directives:
         return [
-            "  Sphinx API index is missing an ``.. automodule:: causalpy`` "
-            "directive."
+            "  Sphinx API index is missing an ``.. automodule:: causalpy`` directive."
         ]
     if not any("members" in options for options in top_level_directives):
         return [
@@ -221,7 +218,6 @@ def check_exports() -> list[str]:
         )
     errors.extend(check_top_level_exports(package_init))
     errors.extend(check_top_level_api_docs())
-
 
     return errors
 

--- a/scripts/check_public_exports.py
+++ b/scripts/check_public_exports.py
@@ -1,10 +1,12 @@
-"""Verify public API export wiring for experiments and checks.
+"""Verify public API export and documentation wiring.
 
 Ensures every concrete ``BaseExperiment`` subclass is imported and listed in
 ``causalpy/experiments/__init__.py`` ``__all__`` and ``causalpy/__init__.py``
 ``__all__``, and that each package's imports stay in sync with ``__all__``.
 Concrete ``Check`` implementations in ``causalpy/checks/`` must likewise appear
-in ``causalpy/checks/__init__.py``.
+in ``causalpy/checks/__init__.py``. The Tier 1 ``causalpy.__all__`` surface must
+be locally bound and documented by the ``causalpy`` ``automodule`` in
+``docs/source/api/index.md``.
 
 Usage
 -----
@@ -24,6 +26,11 @@ from pathlib import Path
 
 _SCRIPTS_DIR = Path(__file__).resolve().parent
 REPO_ROOT = _SCRIPTS_DIR.parent
+PACKAGE_INIT_PATH = REPO_ROOT / "causalpy" / "__init__.py"
+API_INDEX_PATH = REPO_ROOT / "docs" / "source" / "api" / "index.md"
+TOP_LEVEL_MODULE = "causalpy"
+
+
 
 
 def _load_ast_introspection():
@@ -42,10 +49,10 @@ discover_experiment_class_names = _ast.discover_experiment_class_names
 
 
 def _parse_init_exports(path: Path) -> tuple[set[str], set[str]]:
-    """Return ``__all__`` names and imported public names from an ``__init__.py``."""
+    """Return ``__all__`` names and top-level bindings from an ``__init__.py``."""
     tree = ast.parse(path.read_text(encoding="utf-8"))
     all_names: set[str] = set()
-    imported_names: set[str] = set()
+    bound_names: set[str] = set()
     for node in tree.body:
         if isinstance(node, ast.Assign):
             for target in node.targets:
@@ -57,12 +64,95 @@ def _parse_init_exports(path: Path) -> tuple[set[str], set[str]]:
                     for elt in node.value.elts:
                         if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
                             all_names.add(elt.value)
-        elif isinstance(node, ast.ImportFrom) and node.module:
+                elif isinstance(target, ast.Name):
+                    bound_names.add(target.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            bound_names.add(node.target.id)
+        elif isinstance(node, ast.ImportFrom):
             for alias in node.names:
-                if alias.name == "*":
-                    continue
-                imported_names.add(alias.asname or alias.name)
-    return all_names, imported_names
+                if alias.name != "*":
+                    bound_names.add(alias.asname or alias.name)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                bound_names.add(alias.asname or alias.name.partition(".")[0])
+        elif isinstance(node, (ast.AsyncFunctionDef, ast.ClassDef, ast.FunctionDef)):
+            bound_names.add(node.name)
+    return all_names, bound_names
+
+
+def _parse_automodule_options(path: Path) -> dict[str, list[set[str]]]:
+    """Return reStructuredText ``automodule`` option sets keyed by module."""
+    directives: dict[str, list[set[str]]] = {}
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for line_index, line in enumerate(lines):
+        directive = line.strip()
+        if not directive.startswith(".. automodule::"):
+            continue
+
+        _, _, module = directive.partition("::")
+        module = module.strip()
+        if not module:
+            continue
+
+        options: set[str] = set()
+        for option_line in lines[line_index + 1 :]:
+            if not option_line.strip():
+                continue
+            if not option_line[0].isspace():
+                break
+
+            option = option_line.strip()
+            if not option.startswith(":"):
+                continue
+            name, separator, _ = option[1:].partition(":")
+            if separator:
+                options.add(name)
+
+        directives.setdefault(module, []).append(options)
+    return directives
+
+
+def check_top_level_exports(package_init: Path = PACKAGE_INIT_PATH) -> list[str]:
+    """Return errors when a Tier 1 export is not locally bound."""
+    all_names, bound_names = _parse_init_exports(package_init)
+    return _format_set_diff(
+        "causalpy/__init__.py __all__ vs top-level bindings",
+        all_names - bound_names,
+        set(),
+    )
+
+
+def check_top_level_api_docs(api_index: Path = API_INDEX_PATH) -> list[str]:
+    """Return errors when Sphinx cannot render the Tier 1 root surface."""
+    directives = _parse_automodule_options(api_index)
+    top_level_directives = directives.get(TOP_LEVEL_MODULE, [])
+    if not top_level_directives:
+        return [
+            "  Sphinx API index is missing an ``.. automodule:: causalpy`` "
+            "directive."
+        ]
+    if not any("members" in options for options in top_level_directives):
+        return [
+            "  The ``causalpy`` automodule must include ``:members:`` so "
+            "``causalpy.__all__`` is documented."
+        ]
+    if not any(
+        {"members", "undoc-members"} <= options for options in top_level_directives
+    ):
+        return [
+            "  The ``causalpy`` automodule must include ``:undoc-members:`` "
+            "with ``:members:`` so every ``causalpy.__all__`` export is rendered."
+        ]
+    if not any(
+        {"members", "undoc-members", "imported-members"} <= options
+        for options in top_level_directives
+    ):
+        return [
+            "  The ``causalpy`` automodule must include ``:imported-members:`` "
+            "with ``:members:`` and ``:undoc-members:`` so root re-exports are "
+            "documented."
+        ]
+    return []
 
 
 def _format_set_diff(label: str, missing: set[str], extra: set[str]) -> list[str]:
@@ -83,7 +173,7 @@ def check_exports() -> list[str]:
         REPO_ROOT / "causalpy" / "experiments"
     )
     experiments_init = REPO_ROOT / "causalpy" / "experiments" / "__init__.py"
-    package_init = REPO_ROOT / "causalpy" / "__init__.py"
+    package_init = PACKAGE_INIT_PATH
     checks_init = REPO_ROOT / "causalpy" / "checks" / "__init__.py"
 
     exp_all, exp_imports = _parse_init_exports(experiments_init)
@@ -129,17 +219,20 @@ def check_exports() -> list[str]:
             "  checks/__init__.py missing imports for __all__ names: "
             f"{sorted(missing_check_imports)}"
         )
+    errors.extend(check_top_level_exports(package_init))
+    errors.extend(check_top_level_api_docs())
+
 
     return errors
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Parse CLI arguments and run the export wiring check."""
+    """Parse CLI arguments and run the export/documentation wiring check."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--check",
         action="store_true",
-        help="Exit 1 when export wiring drifts from the codebase.",
+        help="Exit 1 when export or documentation wiring drifts from the codebase.",
     )
     args = parser.parse_args(argv)
     if not args.check:
@@ -150,9 +243,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print(
-        "Public export wiring drift detected. Update causalpy/__init__.py, "
-        "causalpy/experiments/__init__.py, and causalpy/checks/__init__.py "
-        "so imports and __all__ match the concrete experiment and check classes."
+        "Public API export/documentation wiring drift detected. Update "
+        "causalpy/__init__.py, causalpy/experiments/__init__.py, "
+        "causalpy/checks/__init__.py, and docs/source/api/index.md so exports "
+        "and Sphinx coverage match the public API policy."
     )
     print()
     for line in errors:


### PR DESCRIPTION
## Summary
Closes #944.

- Codifies the four API tiers, authoritative membership rules, and SemVer expectations in `ARCHITECTURE.md`, with contributor and agent guidance linked to that policy.
- Promotes only `EffectSummary` to `causalpy.EffectSummary`; it is already the documented return type of public `effect_summary()` methods, while ambiguous support helpers remain Tier 3.
- Aligns the Tier 1 root surface with Sphinx and extends the existing static export checker to catch unbound root exports or a missing/incomplete root `automodule` directive without importing CausalPy.

## Files changed
- `AGENTS.md`: records the API manifest and checker workflow for agents.
- `ARCHITECTURE.md`: adds the canonical tier policy, rationale for every API/docs decision, and checker ownership.
- `CONTRIBUTING.md`: adds the contributor-facing compatibility workflow.
- `Makefile`: updates the `check-exports` target description.
- `.pre-commit-config.yaml`: runs the existing export checker when relevant exports, API docs, checker implementation, AST helper, or focused checker test changes.
- `causalpy/__init__.py`: re-exports `EffectSummary` as the sole new Tier 1 symbol.
- `causalpy/reporting.py`: declares `EffectSummary` as the reporting module's explicit export.
- `causalpy/tests/test_check_public_exports.py`: adds deterministic drift cases for root export bindings and required Sphinx options.
- `docs/source/api/index.md`: documents the root API through `automodule` and adds the intentionally narrow `reporting` submodule surface.
- `scripts/check_public_exports.py`: statically validates Tier 1 export bindings plus Sphinx members, undocumented members, and imported re-exports.

## Contracts
- Tier 1 is exactly `causalpy.__all__`; Tier 2 is the generated Sphinx autosummary surface of explicitly listed submodules; Tier 3 is every other implementation path; Tier 4 is the named maketables and model-clone integration protocol.
- Root API documentation is structural and generic: the checker requires Sphinx to render the root package's `__all__`, rather than asserting a hard-coded list of source text.
- No plot aliases/signatures, effect-summary semantics, import removals, or helper renames are changed.

## Validation
- Coordinator ran the dedicated-environment API/inventory test selection: 17 passed.
- `make check-exports` passed.
- Changed-file `prek` passed all hooks.
- Remote Python 3.12, Python 3.14, docs, and gallery jobs pass for head `93b3db7`.

## Remaining CI
- The knowledgebase notebook job is pending the merge gate; no known source-level failure remains.
- `EffectSummary` is a backwards-compatible Tier 1 compatibility commitment; future changes to its `table` or `text` contract follow the documented SemVer process.