### PR TITLE
Add pandas 2.3 compatibility coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
           echo "environment.yml is in sync with pyproject.toml"
 
   test:
+    name: Test (Python ${{ matrix.python-version }}, pandas ${{ matrix.pandas-version }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -75,8 +76,17 @@ jobs:
         shell: bash -el {0}
     strategy:
       matrix:
-        python-version: ["3.12", "3.14"]
-
+        # Exercise the declared pandas floor separately from the pandas 3 line.
+        include:
+          - python-version: "3.12"
+            pandas-version: "3.x"
+            pandas-create-arg: "pandas>=3,<4"
+          - python-version: "3.14"
+            pandas-version: "3.x"
+            pandas-create-arg: "pandas>=3,<4"
+          - python-version: "3.12"
+            pandas-version: "2.3"
+            pandas-create-arg: "pandas>=2.3,<3"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -91,8 +101,7 @@ jobs:
           # test-only ones) come from environment.yml, regenerated from
           # pyproject.toml's `dev` + `test` extras via pyproject2conda.
           create-args: >-
-            python=${{ matrix.python-version }}
-          cache-environment: true
+            python=${{ matrix.python-version }} ${{ matrix.pandas-create-arg }}
       - name: Install package
         # --no-deps so pip does not pull pip-built pymc/pytensor on top of the
         # conda-forge ones. Runtime deps come from environment.yml.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,12 @@ jobs:
           # pyproject.toml's `dev` + `test` extras via pyproject2conda.
           create-args: >-
             python=${{ matrix.python-version }} ${{ matrix.pandas-create-arg }}
+          cache-environment: true
+          # The cache key must name the pandas leg explicitly, otherwise the
+          # 2.3 and 3.x legs on the same Python would share one cached
+          # environment and silently test the same pandas twice.
+          cache-environment-key: >-
+            micromamba-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-${{ hashFiles('environment.yml') }}
       - name: Install package
         # --no-deps so pip does not pull pip-built pymc/pytensor on top of the
         # conda-forge ones. Runtime deps come from environment.yml.
@@ -110,6 +116,28 @@ jobs:
         run: |
           micromamba list
           python -c "import pymc, pytensor; print('pymc', pymc.__version__); print('blas_ldflags=', pytensor.config.blas__ldflags)"
+      - name: Check the resolved pandas matches the matrix leg
+        # Guards against a stale cache or a solver backtrack quietly giving this
+        # leg the wrong pandas, which would make the 2.3 leg meaningless.
+        env:
+          EXPECTED_PANDAS: ${{ matrix.pandas-version }}
+        run: |
+          python - <<'PY'
+          import os
+          import pandas as pd
+
+          expected = os.environ["EXPECTED_PANDAS"]
+          expected_major, _, expected_minor = expected.partition(".")
+          major, minor = pd.__version__.split(".")[:2]
+          print(f"resolved pandas {pd.__version__}, matrix leg {expected}")
+          assert major == expected_major, (
+              f"expected pandas {expected}, got {pd.__version__}"
+          )
+          if expected_minor != "x":
+              assert minor == expected_minor, (
+                  f"expected pandas {expected}, got {pd.__version__}"
+              )
+          PY
       - name: Run doctests
         run: pytest --doctest-modules --ignore=causalpy/tests/ causalpy/ --config-file=causalpy/tests/conftest.py --no-cov
       - name: Run extra tests
@@ -124,5 +152,5 @@ jobs:
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }} # use token for more robust uploads
-          name: ${{ matrix.python-version }}
+          name: py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
           fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/source/_static/thumbnails/
 # Local scratch space (not tracked)
 .scratch/
 coverage.xml
+
+# PyTensor compilation cache
+.pytensor/

--- a/causalpy/date_utils.py
+++ b/causalpy/date_utils.py
@@ -12,12 +12,62 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 """
-Utility functions for intelligent date axis formatting.
+Utility functions for date axis formatting and datetime index validation.
 """
 
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import pandas as pd
+
+from causalpy.custom_exceptions import BadIndexException
+
+
+def validate_treatment_time_against_index(
+    index: pd.Index,
+    treatment_time: int | float | pd.Timestamp,
+    *,
+    name: str = "treatment_time",
+) -> None:
+    """Check that a treatment boundary can be compared against ``data.index``.
+
+    Experiments slice their data with comparisons such as
+    ``data.index < treatment_time``. That is only well defined when the boundary
+    is missing-free, of the same broad kind as the index (datetime vs numeric),
+    and — for :class:`pandas.DatetimeIndex` — matches the index's
+    timezone-awareness. Timezone-aware values in *different* zones compare
+    correctly in pandas, so only a naive/aware mismatch is rejected.
+
+    Parameters
+    ----------
+    index : pd.Index
+        The index the boundary will be compared against.
+    treatment_time : int, float, or pd.Timestamp
+        The treatment boundary to validate.
+    name : str, default "treatment_time"
+        Name used in error messages, e.g. ``"treatment_end_time"``.
+
+    Raises
+    ------
+    BadIndexException
+        If ``treatment_time`` cannot be compared against ``index``.
+    """
+    if pd.isna(treatment_time):
+        raise BadIndexException(f"{name} must not be missing.")
+
+    if isinstance(index, pd.DatetimeIndex):
+        if not isinstance(treatment_time, pd.Timestamp):
+            raise BadIndexException(
+                f"If data.index is DatetimeIndex, {name} must be pd.Timestamp."
+            )
+        if (index.tz is None) != (treatment_time.tz is None):
+            raise BadIndexException(
+                f"{name} and data.index must either both be timezone-aware or "
+                "both be timezone-naive."
+            )
+    elif isinstance(treatment_time, pd.Timestamp):
+        raise BadIndexException(
+            f"If data.index is not DatetimeIndex, {name} must not be pd.Timestamp."
+        )
 
 
 def _combine_datetime_indices(

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -21,7 +21,7 @@ import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import ModelDesc, build_design_matrices
+from patsy import ModelDesc
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
@@ -30,7 +30,7 @@ from causalpy.custom_exceptions import (
     FormulaException,
 )
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.formula_utils import build_formula_matrices
+from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     has_posterior_draws,
@@ -123,7 +123,8 @@ class DifferenceInDifferences(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray | float | None
-        # rename the index to "obs_ind"
+        # Work on an owned frame before normalizing its index metadata.
+        data = data.copy()
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Difference in Differences"
@@ -175,7 +176,7 @@ class DifferenceInDifferences(BaseExperiment):
             # drop the outcome variable
             .drop(self.outcome_variable_name, axis=1)
             # We may have multiple units per time point, we only want one time point
-            .groupby(self.time_variable_name)
+            .groupby(self.time_variable_name, observed=True)
             .first()
             .reset_index()
         )
@@ -192,7 +193,7 @@ class DifferenceInDifferences(BaseExperiment):
             # drop the outcome variable
             .drop(self.outcome_variable_name, axis=1)
             # We may have multiple units per time point, we only want one time point
-            .groupby(self.time_variable_name)
+            .groupby(self.time_variable_name, observed=True)
             .first()
             .reset_index()
         )
@@ -212,7 +213,7 @@ class DifferenceInDifferences(BaseExperiment):
             # drop the outcome variable
             .drop(self.outcome_variable_name, axis=1)
             # We may have multiple units per time point, we only want one time point
-            .groupby(self.time_variable_name)
+            .groupby(self.time_variable_name, observed=True)
             .first()
             .reset_index()
         )

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -20,7 +20,6 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import build_design_matrices
 from sklearn.base import RegressorMixin
 
 from causalpy._arviz_compat import hdi_bounds
@@ -28,7 +27,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.formula_utils import build_formula_matrices
+from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -162,6 +161,8 @@ class InterruptedTimeSeries(BaseExperiment):
         super().__init__(model=model)
         self.pre_design: xr.Dataset
         self.post_design: xr.Dataset
+        # Work on an owned frame before normalizing its index metadata.
+        data = data.copy()
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time, treatment_end_time)
@@ -262,6 +263,8 @@ class InterruptedTimeSeries(BaseExperiment):
                 "data.index must be unique and monotonically increasing. "
                 "Sort the data and remove duplicate index values before fitting."
             )
+        if pd.isna(treatment_time):
+            raise BadIndexException("treatment_time must not be missing.")
         if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
             treatment_time, pd.Timestamp
         ):
@@ -274,7 +277,16 @@ class InterruptedTimeSeries(BaseExperiment):
             raise BadIndexException(
                 "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
             )
+        if (
+            isinstance(data.index, pd.DatetimeIndex)
+            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
+        ):
+            raise BadIndexException(
+                "treatment_time timezone must match the data.index timezone."
+            )
         if treatment_end_time is not None:
+            if pd.isna(treatment_end_time):
+                raise BadIndexException("treatment_end_time must not be missing.")
             # Validate treatment_end_time matches index type
             if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
                 treatment_end_time, pd.Timestamp
@@ -287,6 +299,13 @@ class InterruptedTimeSeries(BaseExperiment):
             ):
                 raise BadIndexException(
                     "If data.index is not DatetimeIndex, treatment_end_time must not be pd.Timestamp."
+                )
+            if (
+                isinstance(data.index, pd.DatetimeIndex)
+                and data.index.tz != treatment_end_time.tz  # type: ignore[union-attr]
+            ):
+                raise BadIndexException(
+                    "treatment_end_time timezone must match the data.index timezone."
                 )
             # Validate treatment_end_time > treatment_time
             # Type check: we've already validated both match the index type, so they're compatible

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -25,7 +25,11 @@ from sklearn.base import RegressorMixin
 from causalpy._arviz_compat import hdi_bounds
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
-from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.date_utils import (
+    _combine_datetime_indices,
+    format_date_axes,
+    validate_treatment_time_against_index,
+)
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.plot_utils import (
@@ -263,50 +267,11 @@ class InterruptedTimeSeries(BaseExperiment):
                 "data.index must be unique and monotonically increasing. "
                 "Sort the data and remove duplicate index values before fitting."
             )
-        if pd.isna(treatment_time):
-            raise BadIndexException("treatment_time must not be missing.")
-        if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is DatetimeIndex, treatment_time must be pd.Timestamp."
-            )
-        if not isinstance(data.index, pd.DatetimeIndex) and isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
-            )
-        if (
-            isinstance(data.index, pd.DatetimeIndex)
-            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
-        ):
-            raise BadIndexException(
-                "treatment_time timezone must match the data.index timezone."
-            )
+        validate_treatment_time_against_index(data.index, treatment_time)
         if treatment_end_time is not None:
-            if pd.isna(treatment_end_time):
-                raise BadIndexException("treatment_end_time must not be missing.")
-            # Validate treatment_end_time matches index type
-            if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
-                treatment_end_time, pd.Timestamp
-            ):
-                raise BadIndexException(
-                    "If data.index is DatetimeIndex, treatment_end_time must be pd.Timestamp."
-                )
-            if not isinstance(data.index, pd.DatetimeIndex) and isinstance(
-                treatment_end_time, pd.Timestamp
-            ):
-                raise BadIndexException(
-                    "If data.index is not DatetimeIndex, treatment_end_time must not be pd.Timestamp."
-                )
-            if (
-                isinstance(data.index, pd.DatetimeIndex)
-                and data.index.tz != treatment_end_time.tz  # type: ignore[union-attr]
-            ):
-                raise BadIndexException(
-                    "treatment_end_time timezone must match the data.index timezone."
-                )
+            validate_treatment_time_against_index(
+                data.index, treatment_end_time, name="treatment_end_time"
+            )
             # Validate treatment_end_time > treatment_time
             # Type check: we've already validated both match the index type, so they're compatible
             # NOTE: Both treatment_time and treatment_end_time are INCLUSIVE (>=) in their respective periods

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -431,7 +431,7 @@ class SklearnModelAdapter(ModelAdapter):
             )
 
         obs_ind = (
-            np.asarray(X.coords["obs_ind"])
+            X.get_index("obs_ind")
             if isinstance(X, xr.DataArray) and "obs_ind" in X.coords
             else np.arange(values.shape[0])
         )

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -199,7 +199,8 @@ class PanelRegression(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
 
-        # Rename the index to "obs_ind" (on original, before copying)
+        # Work on an owned frame before normalizing its index metadata.
+        data = data.copy()
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Panel Regression"
@@ -237,6 +238,12 @@ class PanelRegression(BaseExperiment):
             raise DataException(
                 f"time_fe_variable '{self.time_fe_variable}' not found in data columns"
             )
+
+        for variable in (self.unit_fe_variable, self.time_fe_variable):
+            if variable is not None and self.data[variable].isna().any():
+                raise DataException(
+                    f"Fixed-effect variable '{variable}' must not contain missing values"
+                )
 
         if self.fe_method not in ["dummies", "demeaned"]:
             raise ValueError(
@@ -362,9 +369,13 @@ class PanelRegression(BaseExperiment):
         data = data.copy()
 
         # Identify numeric and boolean columns to demean (exclude group variables).
-        # Boolean columns (e.g. treatment indicators) must be included; pandas
-        # select_dtypes(include=[np.number]) excludes bool.
-        numeric_cols = data.select_dtypes(include=[np.number, "bool"]).columns.tolist()
+        # Predicates include pandas extension dtypes such as ``BooleanDtype``.
+        numeric_cols = [
+            column
+            for column, dtype in data.dtypes.items()
+            if pd.api.types.is_numeric_dtype(dtype)
+            or pd.api.types.is_bool_dtype(dtype)
+        ]
         group_vars_to_exclude = [self.unit_fe_variable]
         if self.time_fe_variable:
             group_vars_to_exclude.append(self.time_fe_variable)
@@ -375,19 +386,19 @@ class PanelRegression(BaseExperiment):
         # numeric results (bool - float would otherwise raise or produce
         # unexpected dtypes).
         for col in numeric_cols:
-            if data[col].dtype == "bool":
+            if pd.api.types.is_bool_dtype(data[col]):
                 data[col] = data[col].astype(float)
 
         # Store group means from the ORIGINAL data (before any demeaning in
         # prior calls) so that fixed effects can be recovered post-hoc.
         if group_var not in self._group_means:
-            self._group_means[group_var] = self._original_data.groupby(group_var)[
-                numeric_cols
-            ].mean()
+            self._group_means[group_var] = self._original_data.groupby(
+                group_var, observed=True
+            )[numeric_cols].mean()
 
         # Demean each numeric column
         for col in numeric_cols:
-            group_mean = data.groupby(group_var)[col].transform("mean")
+            group_mean = data.groupby(group_var, observed=True)[col].transform("mean")
             data[col] = data[col] - group_mean
 
         return data
@@ -899,18 +910,18 @@ class PanelRegression(BaseExperiment):
                 selected_units = rng.choice(all_units, size=n_sample, replace=False)  # type: ignore[assignment]
             elif select == "extreme":
                 # Select units with the largest and smallest mean outcomes
-                unit_means = self.data.groupby(self.unit_fe_variable)[
-                    self.outcome_variable_name
-                ].mean()
+                unit_means = self.data.groupby(
+                    self.unit_fe_variable, observed=True
+                )[self.outcome_variable_name].mean()
                 n_each = max(1, n_sample // 2)
                 top = unit_means.nlargest(n_each).index.tolist()
                 bottom = unit_means.nsmallest(n_sample - n_each).index.tolist()
                 selected_units = top + bottom
             elif select == "high_variance":
                 # Select units with the most within-unit variation
-                unit_var = self.data.groupby(self.unit_fe_variable)[
-                    self.outcome_variable_name
-                ].var()
+                unit_var = self.data.groupby(
+                    self.unit_fe_variable, observed=True
+                )[self.outcome_variable_name].var()
                 selected_units = unit_var.nlargest(n_sample).index.tolist()
 
         if len(selected_units) == 0:

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -373,8 +373,11 @@ class PanelRegression(BaseExperiment):
         numeric_cols = [
             column
             for column, dtype in data.dtypes.items()
-            if pd.api.types.is_numeric_dtype(dtype)
-            or pd.api.types.is_bool_dtype(dtype)
+            if isinstance(column, str)
+            and (
+                pd.api.types.is_numeric_dtype(dtype)
+                or pd.api.types.is_bool_dtype(dtype)
+            )
         ]
         group_vars_to_exclude = [self.unit_fe_variable]
         if self.time_fe_variable:
@@ -910,18 +913,18 @@ class PanelRegression(BaseExperiment):
                 selected_units = rng.choice(all_units, size=n_sample, replace=False)  # type: ignore[assignment]
             elif select == "extreme":
                 # Select units with the largest and smallest mean outcomes
-                unit_means = self.data.groupby(
-                    self.unit_fe_variable, observed=True
-                )[self.outcome_variable_name].mean()
+                unit_means = self.data.groupby(self.unit_fe_variable, observed=True)[
+                    self.outcome_variable_name
+                ].mean()
                 n_each = max(1, n_sample // 2)
                 top = unit_means.nlargest(n_each).index.tolist()
                 bottom = unit_means.nsmallest(n_sample - n_each).index.tolist()
                 selected_units = top + bottom
             elif select == "high_variance":
                 # Select units with the most within-unit variation
-                unit_var = self.data.groupby(
-                    self.unit_fe_variable, observed=True
-                )[self.outcome_variable_name].var()
+                unit_var = self.data.groupby(self.unit_fe_variable, observed=True)[
+                    self.outcome_variable_name
+                ].var()
                 selected_units = unit_var.nlargest(n_sample).index.tolist()
 
         if len(selected_units) == 0:

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -21,14 +21,13 @@ import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
-from patsy import build_design_matrices
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import (
     DataException,
 )
 from causalpy.experiments.model_adapter import build_coords
-from causalpy.formula_utils import build_formula_matrices
+from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     plot_posterior_over_x,

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -21,10 +21,10 @@ import numpy as np
 import pandas as pd
 import seaborn as sns
 from matplotlib import pyplot as plt
-from patsy import ModelDesc, build_design_matrices
+from patsy import ModelDesc
 from sklearn.base import RegressorMixin
 
-from causalpy.formula_utils import build_formula_matrices
+from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
     DataException,
@@ -126,6 +126,8 @@ class RegressionDiscontinuity(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Discontinuity"
+        # Work on an owned frame before normalizing the treated indicator.
+        data = data.copy()
         self.data = data
         self.formula = formula
         self.running_variable_name = running_variable_name
@@ -269,10 +271,9 @@ class RegressionDiscontinuity(BaseExperiment):
                 f"({self.bandwidth}) when bandwidth is finite."
             )
 
-        # Convert integer treated variable to boolean if needed
-        if self.data["treated"].dtype in ["int64", "int32"]:
-            # Make a copy to avoid SettingWithCopyWarning
-            self.data = self.data.copy()
+        # Convert integer treated variables, including pandas nullable integers,
+        # without mutating the caller's DataFrame.
+        if pd.api.types.is_integer_dtype(self.data["treated"]):
             self.data["treated"] = self.data["treated"].astype(bool)
 
     def _is_treated(self, x: np.ndarray | pd.Series) -> np.ndarray:

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -22,9 +22,9 @@ from matplotlib import pyplot as plt
 import numpy as np
 import pandas as pd
 import seaborn as sns
-from patsy import ModelDesc, build_design_matrices
+from patsy import ModelDesc
 import xarray as xr
-from causalpy.formula_utils import build_formula_matrices
+from causalpy.formula_utils import build_design_matrices, build_formula_matrices
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -334,9 +334,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         """Compute event time (t - G) for each observation."""
         # Construct a floating result before adding missing never-treated values:
         # pandas 3 disallows dtype-changing in-place assignment.
-        event_time = (
-            self.data[self.time_variable_name] - self.data["G"]
-        ).astype(float)
+        event_time = (self.data[self.time_variable_name] - self.data["G"]).astype(float)
         self.data["event_time"] = event_time.where(
             self.data["G"] != self.never_treated_value, np.nan
         )
@@ -692,7 +690,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         """
         # --- Group-time ATTs (post-treatment only) ---
         att_gt = (
-            treated_data.groupby(["G", self.time_variable_name], observed=True)["tau_hat"]
+            treated_data.groupby(["G", self.time_variable_name], observed=True)[
+                "tau_hat"
+            ]
             .agg(["mean", "std", "count"])
             .reset_index()
         )
@@ -1226,9 +1226,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             - pretreatment_data["y_hat0"].to_numpy()
         )
         att_gt = (
-            pretreatment_data.groupby(
-                ["G", self.time_variable_name], observed=True
-            )["tau_hat"]
+            pretreatment_data.groupby(["G", self.time_variable_name], observed=True)[
+                "tau_hat"
+            ]
             .agg(["mean", "std", "count"])
             .reset_index()
         )

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -240,6 +240,10 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         for col in required_cols:
             if col not in self.data.columns:
                 raise DataException(f"Required column '{col}' not found in data")
+            if self.data[col].isna().any():
+                raise DataException(
+                    f"Required column '{col}' must not contain missing values"
+                )
 
         # Check treated variable exists (either directly or via treatment_time)
         if self.treatment_time_variable_name is not None:
@@ -248,10 +252,20 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
                     f"Treatment time column '{self.treatment_time_variable_name}' "
                     "not found in data"
                 )
+            if self.data[self.treatment_time_variable_name].isna().any():
+                raise DataException(
+                    f"Treatment time column '{self.treatment_time_variable_name}' "
+                    "must not contain missing values"
+                )
         elif self.treated_variable_name not in self.data.columns:
             raise DataException(
                 f"Treated column '{self.treated_variable_name}' not found in data. "
                 "Either provide treated_variable_name or treatment_time_variable_name."
+            )
+        elif self.data[self.treated_variable_name].isna().any():
+            raise DataException(
+                f"Treated column '{self.treated_variable_name}' "
+                "must not contain missing values"
             )
 
         # Validate absorbing treatment (once treated, always treated)
@@ -290,7 +304,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             # Use provided treatment time column
             # Get unique treatment time per unit
             g_map = (
-                self.data.groupby(self.unit_variable_name)[
+                self.data.groupby(self.unit_variable_name, observed=True)[
                     self.treatment_time_variable_name
                 ]
                 .first()
@@ -318,9 +332,14 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     def _compute_event_times(self) -> None:
         """Compute event time (t - G) for each observation."""
-        self.data["event_time"] = self.data[self.time_variable_name] - self.data["G"]
-        # Set event_time to NaN for never-treated units
-        self.data.loc[self.data["G"] == self.never_treated_value, "event_time"] = np.nan
+        # Construct a floating result before adding missing never-treated values:
+        # pandas 3 disallows dtype-changing in-place assignment.
+        event_time = (
+            self.data[self.time_variable_name] - self.data["G"]
+        ).astype(float)
+        self.data["event_time"] = event_time.where(
+            self.data["G"] != self.never_treated_value, np.nan
+        )
 
     def _identify_untreated_observations(self) -> None:
         """Identify untreated observations for the training set."""
@@ -569,7 +588,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         event_time_treated = np.asarray(treated_data["event_time"].values)
 
         # --- Group-time ATTs (post-treatment only) ---
-        gt_groups = treated_data.groupby(["G", self.time_variable_name]).groups
+        gt_groups = treated_data.groupby(
+            ["G", self.time_variable_name], observed=True
+        ).groups
         att_gt_rows: list[dict] = []
         for key, idx in gt_groups.items():
             g_val = key[0]  # type: ignore[index]
@@ -671,7 +692,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         """
         # --- Group-time ATTs (post-treatment only) ---
         att_gt = (
-            treated_data.groupby(["G", self.time_variable_name])["tau_hat"]
+            treated_data.groupby(["G", self.time_variable_name], observed=True)["tau_hat"]
             .agg(["mean", "std", "count"])
             .reset_index()
         )
@@ -698,7 +719,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             ]
 
         att_et = (
-            event_data.groupby("event_time")["tau_hat"]
+            event_data.groupby("event_time", observed=True)["tau_hat"]
             .agg(["mean", "std", "count"])
             .reset_index()
         )
@@ -1058,7 +1079,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         att_gt, x_col, x_label, y_label = self._get_group_time_plot_data(
             x_axis=x_axis, include_placebo=include_placebo
         )
-        cohort_groups = list(att_gt.groupby("cohort", sort=True))
+        cohort_groups = list(att_gt.groupby("cohort", observed=True, sort=True))
         sharex = x_axis == "event_time"
         fig, axes = self._make_group_time_axes(
             att_gt=att_gt,
@@ -1173,7 +1194,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         tau_draws_all = y_observed - mu_draws.values
 
         att_gt_rows: list[dict[str, Any]] = []
-        gt_groups = pretreatment_data.groupby(["G", self.time_variable_name]).groups
+        gt_groups = pretreatment_data.groupby(
+            ["G", self.time_variable_name], observed=True
+        ).groups
         for key, idx in gt_groups.items():
             g_val = key[0]  # type: ignore[index]
             t_val = key[1]  # type: ignore[index]
@@ -1203,7 +1226,9 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             - pretreatment_data["y_hat0"].to_numpy()
         )
         att_gt = (
-            pretreatment_data.groupby(["G", self.time_variable_name])["tau_hat"]
+            pretreatment_data.groupby(
+                ["G", self.time_variable_name], observed=True
+            )["tau_hat"]
             .agg(["mean", "std", "count"])
             .reset_index()
         )

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -23,8 +23,11 @@ from matplotlib import pyplot as plt
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
-from causalpy.custom_exceptions import BadIndexException
-from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.date_utils import (
+    _combine_datetime_indices,
+    format_date_axes,
+    validate_treatment_time_against_index,
+)
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
@@ -334,27 +337,7 @@ class SyntheticControl(BaseExperiment):
         treatment_time : int, float, or pd.Timestamp
             The treatment time, expected to be compatible with ``data.index``.
         """
-        if pd.isna(treatment_time):
-            raise BadIndexException("treatment_time must not be missing.")
-        if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is DatetimeIndex, treatment_time must be pd.Timestamp."
-            )
-        if not isinstance(data.index, pd.DatetimeIndex) and isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
-            )
-        if (
-            isinstance(data.index, pd.DatetimeIndex)
-            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
-        ):
-            raise BadIndexException(
-                "treatment_time timezone must match the data.index timezone."
-            )
+        validate_treatment_time_against_index(data.index, treatment_time)
 
     def _pre_treatment_correlations(self) -> dict[str, float]:
         """Compute Pearson correlation between each treated unit and its

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -111,7 +111,8 @@ class SyntheticControl(BaseExperiment):
         **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
-        # rename the index to "obs_ind"
+        # Work on an owned frame before normalizing its index metadata.
+        data = data.copy()
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)
@@ -333,6 +334,8 @@ class SyntheticControl(BaseExperiment):
         treatment_time : int, float, or pd.Timestamp
             The treatment time, expected to be compatible with ``data.index``.
         """
+        if pd.isna(treatment_time):
+            raise BadIndexException("treatment_time must not be missing.")
         if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
             treatment_time, pd.Timestamp
         ):
@@ -344,6 +347,13 @@ class SyntheticControl(BaseExperiment):
         ):
             raise BadIndexException(
                 "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
+            )
+        if (
+            isinstance(data.index, pd.DatetimeIndex)
+            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
+        ):
+            raise BadIndexException(
+                "treatment_time timezone must match the data.index timezone."
             )
 
     def _pre_treatment_correlations(self) -> dict[str, float]:

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -26,8 +26,11 @@ from sklearn.base import RegressorMixin
 
 from causalpy._arviz_compat import hdi_bounds
 from causalpy.constants import HDI_PROB
-from causalpy.custom_exceptions import BadIndexException
-from causalpy.date_utils import _combine_datetime_indices, format_date_axes
+from causalpy.date_utils import (
+    _combine_datetime_indices,
+    format_date_axes,
+    validate_treatment_time_against_index,
+)
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import PyMCModel, SyntheticDifferenceInDifferencesWeightFitter
 from causalpy.reporting import EffectSummary
@@ -174,27 +177,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             The time when treatment occurred, should be in reference to the
             data index.
         """
-        if pd.isna(treatment_time):
-            raise BadIndexException("treatment_time must not be missing.")
-        if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is DatetimeIndex, treatment_time must be pd.Timestamp."
-            )
-        if not isinstance(data.index, pd.DatetimeIndex) and isinstance(
-            treatment_time, pd.Timestamp
-        ):
-            raise BadIndexException(
-                "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
-            )
-        if (
-            isinstance(data.index, pd.DatetimeIndex)
-            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
-        ):
-            raise BadIndexException(
-                "treatment_time timezone must match the data.index timezone."
-            )
+        validate_treatment_time_against_index(data.index, treatment_time)
 
     def _prepare_data(self) -> None:
         """Bundle control and treated data into ``xr.Dataset`` objects per period.

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -132,7 +132,8 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         **kwargs: dict,
     ) -> None:
         super().__init__(model=model)
-        # rename the index to "obs_ind"
+        # Work on an owned frame before normalizing its index metadata.
+        data = data.copy()
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)
@@ -173,6 +174,8 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
             The time when treatment occurred, should be in reference to the
             data index.
         """
+        if pd.isna(treatment_time):
+            raise BadIndexException("treatment_time must not be missing.")
         if isinstance(data.index, pd.DatetimeIndex) and not isinstance(
             treatment_time, pd.Timestamp
         ):
@@ -184,6 +187,13 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         ):
             raise BadIndexException(
                 "If data.index is not DatetimeIndex, treatment_time must be pd.Timestamp."  # noqa: E501
+            )
+        if (
+            isinstance(data.index, pd.DatetimeIndex)
+            and data.index.tz != treatment_time.tz  # type: ignore[union-attr]
+        ):
+            raise BadIndexException(
+                "treatment_time timezone must match the data.index timezone."
             )
 
     def _prepare_data(self) -> None:

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -24,8 +24,10 @@ from patsy import (
     EvalFactor,
     ModelDesc,
     Term,
-    build_design_matrices as patsy_build_design_matrices,
     dmatrices,
+)
+from patsy import (
+    build_design_matrices as patsy_build_design_matrices,
 )
 
 from causalpy.transforms import elapsed, ramp, step
@@ -54,10 +56,7 @@ def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
         position
         for position, dtype in enumerate(data.dtypes)
         if isinstance(dtype, pd.StringDtype)
-        or (
-            isinstance(dtype, pd.ArrowDtype)
-            and pd.api.types.is_string_dtype(dtype)
-        )
+        or (isinstance(dtype, pd.ArrowDtype) and pd.api.types.is_string_dtype(dtype))
     ]
     if not string_column_positions:
         return data
@@ -65,9 +64,8 @@ def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
     normalized_data = data.copy()
     for position in string_column_positions:
         column = normalized_data.iloc[:, position]
-        normalized_data.isetitem(
-            position, column.astype(object).where(column.notna(), np.nan)
-        )
+        normalized_column = column.astype(object).where(column.notna(), np.nan)
+        normalized_data.isetitem(position, normalized_column.to_numpy())
     return normalized_data
 
 
@@ -79,6 +77,20 @@ def build_design_matrices(
     This applies the same extension-string normalization as
     :func:`build_formula_matrices`, so predictions using Patsy's fitted
     ``design_info`` remain compatible with pandas 2.3 and 3.
+
+    Parameters
+    ----------
+    design_infos : list[Any]
+        Patsy design information fitted on the training data.
+    data : pd.DataFrame
+        New data used to construct matrices with the fitted design information.
+    **kwargs : Any
+        Keyword arguments forwarded to :func:`patsy.build_design_matrices`.
+
+    Returns
+    -------
+    list[Any]
+        Patsy design matrices corresponding to ``design_infos``.
     """
     return patsy_build_design_matrices(
         design_infos, _normalize_patsy_data(data), **kwargs

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -24,10 +24,8 @@ from patsy import (
     EvalFactor,
     ModelDesc,
     Term,
-    dmatrices,
-)
-from patsy import (
     build_design_matrices as patsy_build_design_matrices,
+    dmatrices,
 )
 
 from causalpy.transforms import elapsed, ramp, step

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -17,8 +17,16 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pandas as pd
-from patsy import EvalEnvironment, EvalFactor, ModelDesc, Term, dmatrices
+from patsy import (
+    EvalEnvironment,
+    EvalFactor,
+    ModelDesc,
+    Term,
+    build_design_matrices as patsy_build_design_matrices,
+    dmatrices,
+)
 
 from causalpy.transforms import elapsed, ramp, step
 
@@ -31,6 +39,50 @@ def _datetime_columns(data: pd.DataFrame) -> set[str]:
         if isinstance(column, str)
         and pd.api.types.is_datetime64_any_dtype(data[column])
     }
+
+
+def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
+    """Convert only pandas extension-string columns to Patsy-compatible objects.
+
+    Pandas 3 infers its dedicated ``StringDtype`` for string columns. Patsy #206
+    historically could not interpret that dtype, particularly for Arrow-backed
+    strings. Convert extension strings on an owned frame while leaving categorical,
+    numeric, object, and datetime columns unchanged. Missing string values remain
+    missing as ``np.nan``, which Patsy's NA handling recognizes.
+    """
+    string_column_positions = [
+        position
+        for position, dtype in enumerate(data.dtypes)
+        if isinstance(dtype, pd.StringDtype)
+        or (
+            isinstance(dtype, pd.ArrowDtype)
+            and pd.api.types.is_string_dtype(dtype)
+        )
+    ]
+    if not string_column_positions:
+        return data
+
+    normalized_data = data.copy()
+    for position in string_column_positions:
+        column = normalized_data.iloc[:, position]
+        normalized_data.isetitem(
+            position, column.astype(object).where(column.notna(), np.nan)
+        )
+    return normalized_data
+
+
+def build_design_matrices(
+    design_infos: list[Any], data: pd.DataFrame, **kwargs: Any
+) -> list[Any]:
+    """Build Patsy matrices from fitted design information.
+
+    This applies the same extension-string normalization as
+    :func:`build_formula_matrices`, so predictions using Patsy's fitted
+    ``design_info`` remain compatible with pandas 2.3 and 3.
+    """
+    return patsy_build_design_matrices(
+        design_infos, _normalize_patsy_data(data), **kwargs
+    )
 
 
 def _rewrite_datetime_terms(
@@ -90,12 +142,13 @@ def build_formula_matrices(
     **kwargs : Any
         Keyword arguments forwarded to :func:`patsy.dmatrices`.
     """
+    data_for_patsy = _normalize_patsy_data(data)
     eval_env = EvalEnvironment.capture(1).with_outer_namespace(
         {"elapsed": elapsed, "ramp": ramp, "step": step}
     )
     return dmatrices(
-        datetime_continuous_formula(formula, data),
-        data,
+        datetime_continuous_formula(formula, data_for_patsy),
+        data_for_patsy,
         eval_env=eval_env,
         **kwargs,
     )

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -61,11 +61,17 @@ def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
     if not string_column_positions:
         return data
 
-    normalized_data = data.copy()
+    string_column_names = [
+        data.columns[position] for position in string_column_positions
+    ]
+    normalized_data = data.astype(
+        {column: object for column in string_column_names}
+    )
     for position in string_column_positions:
         column = normalized_data.iloc[:, position]
-        normalized_column = column.astype(object).where(column.notna(), np.nan)
-        normalized_data.isetitem(position, normalized_column.to_numpy())
+        normalized_data.iloc[:, position] = column.where(
+            column.notna(), np.nan
+        ).to_numpy()
     return normalized_data
 
 

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -24,8 +24,10 @@ from patsy import (
     EvalFactor,
     ModelDesc,
     Term,
-    build_design_matrices as patsy_build_design_matrices,
     dmatrices,
+)
+from patsy import (
+    build_design_matrices as patsy_build_design_matrices,
 )
 
 from causalpy.transforms import elapsed, ramp, step
@@ -62,9 +64,7 @@ def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
     string_column_names = [
         data.columns[position] for position in string_column_positions
     ]
-    normalized_data = data.astype(
-        {column: object for column in string_column_names}
-    )
+    normalized_data = data.astype(dict.fromkeys(string_column_names, object))
     for position in string_column_positions:
         column = normalized_data.iloc[:, position]
         normalized_data.iloc[:, position] = column.where(

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -43,33 +43,61 @@ def _datetime_columns(data: pd.DataFrame) -> set[str]:
     }
 
 
-def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
-    """Convert only pandas extension-string columns to Patsy-compatible objects.
+def _uses_pd_na_string_dtype(dtype: Any) -> bool:
+    """Report whether ``dtype`` is a string dtype whose missing value is ``pd.NA``.
 
-    Pandas 3 infers its dedicated ``StringDtype`` for string columns. Patsy #206
-    historically could not interpret that dtype, particularly for Arrow-backed
-    strings. Convert extension strings on an owned frame while leaving categorical,
-    numeric, object, and datetime columns unchanged. Missing string values remain
-    missing as ``np.nan``, which Patsy's NA handling recognizes.
+    Parameters
+    ----------
+    dtype : Any
+        A pandas dtype, typically an entry of ``DataFrame.dtypes``.
+
+    Returns
+    -------
+    bool
+        ``True`` for nullable (``pd.NA``-sentinel) string dtypes, including
+        Arrow-backed strings.
+    """
+    if isinstance(dtype, pd.StringDtype):
+        # pandas 3's default inferred ``str`` dtype is also a StringDtype, but
+        # it uses ``np.nan`` as its missing value and needs no conversion.
+        return dtype.na_value is pd.NA
+    return isinstance(dtype, pd.ArrowDtype) and pd.api.types.is_string_dtype(dtype)
+
+
+def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
+    """Convert ``pd.NA``-backed string columns to Patsy-compatible object columns.
+
+    Patsy evaluates missingness with ``bool(value)``, which raises
+    ``TypeError: boolean value of NA is ambiguous`` for nullable string columns
+    (upstream Patsy #206). This affects both pandas 2.3 and pandas 3, and only
+    for the ``pd.NA`` sentinel: pandas 3's default inferred ``str`` dtype uses
+    ``np.nan`` and passes through untouched, as do categorical, numeric, object
+    and datetime columns.
+
+    Affected columns are rewritten to object dtype with ``np.nan`` for missing
+    values on a frame this function owns, so the caller's DataFrame is never
+    modified. Frames with no affected column are returned as-is, without a copy.
     """
     string_column_positions = [
         position
         for position, dtype in enumerate(data.dtypes)
-        if isinstance(dtype, pd.StringDtype)
-        or (isinstance(dtype, pd.ArrowDtype) and pd.api.types.is_string_dtype(dtype))
+        if _uses_pd_na_string_dtype(dtype)
     ]
     if not string_column_positions:
         return data
 
-    string_column_names = [
-        data.columns[position] for position in string_column_positions
-    ]
-    normalized_data = data.astype(dict.fromkeys(string_column_names, object))
+    # Positional access rather than by name: patsy is given whatever frame the
+    # caller built, which may carry duplicate column labels.
+    normalized_data = data.copy(deep=False)
     for position in string_column_positions:
-        column = normalized_data.iloc[:, position]
-        normalized_data.iloc[:, position] = column.where(
-            column.notna(), np.nan
-        ).to_numpy()
+        values = data.iloc[:, position].to_numpy(dtype=object, na_value=np.nan)
+        # An explicit object Series, not a bare ndarray: pandas 3 would
+        # otherwise re-infer its own string dtype from the object array.
+        # ``isetitem`` accepts a Series at runtime; pandas-stubs omits it.
+        normalized_data.isetitem(
+            position,
+            pd.Series(values, index=data.index, dtype=object),  # type: ignore[arg-type]
+        )
     return normalized_data
 
 

--- a/causalpy/tests/test_input_validation.py
+++ b/causalpy/tests/test_input_validation.py
@@ -678,7 +678,7 @@ def test_regression_discontinuity_int_treatment():
     """Test that RegressionDiscontinuity works with integer treatment variables."""
     threshold = 0.5
     df = setup_regression_discontinuity_data(threshold)
-    assert df["treated"].dtype == np.int64  # Ensure treatment is int
+    assert pd.api.types.is_integer_dtype(df["treated"])  # Ensure treatment is int
 
     # This should work now with our fix
     result = cp.RegressionDiscontinuity(
@@ -689,7 +689,7 @@ def test_regression_discontinuity_int_treatment():
     )
 
     # Check that the treatment variable was converted to bool
-    assert result.data["treated"].dtype == bool
+    assert pd.api.types.is_bool_dtype(result.data["treated"])
 
 
 def test_regression_discontinuity_bool_treatment():
@@ -697,7 +697,7 @@ def test_regression_discontinuity_bool_treatment():
     threshold = 0.5
     df = setup_regression_discontinuity_data(threshold)
     df["treated"] = df["treated"].astype(bool)  # Convert to bool
-    assert df["treated"].dtype == bool  # Ensure treatment is bool
+    assert pd.api.types.is_bool_dtype(df["treated"])  # Ensure treatment is bool
 
     # This should work as before
     result = cp.RegressionDiscontinuity(
@@ -708,7 +708,7 @@ def test_regression_discontinuity_bool_treatment():
     )
 
     # Check that the treatment variable is still bool
-    assert result.data["treated"].dtype == bool
+    assert pd.api.types.is_bool_dtype(result.data["treated"])
 
 
 def test_rd_donut_hole_zero_same_as_default():

--- a/causalpy/tests/test_pandas_compat.py
+++ b/causalpy/tests/test_pandas_compat.py
@@ -236,6 +236,12 @@ def test_interrupted_time_series_predicts_with_string_extension_covariates():
 
     assert result.pre_design["X"].sizes["obs_ind"] == 6
     assert result.post_design["X"].sizes["obs_ind"] == 6
+    assert result.pre_design.indexes["obs_ind"].equals(
+        result.pre_pred.indexes["obs_ind"]
+    )
+    assert result.post_design.indexes["obs_ind"].equals(
+        result.post_pred.indexes["obs_ind"]
+    )
     pd.testing.assert_frame_equal(data, original)
 
 
@@ -258,6 +264,12 @@ def test_interrupted_time_series_preserves_timezone_aware_boundary_and_input():
 
     assert result.datapre.index.max() == dates[5]
     assert result.datapost.index.min() == treatment_time
+    assert result.pre_design.indexes["obs_ind"].equals(
+        result.pre_pred.indexes["obs_ind"]
+    )
+    assert result.post_design.indexes["obs_ind"].equals(
+        result.post_pred.indexes["obs_ind"]
+    )
     pd.testing.assert_frame_equal(data, original)
 
     with pytest.raises(BadIndexException, match="treatment_time must not be missing"):

--- a/causalpy/tests/test_pandas_compat.py
+++ b/causalpy/tests/test_pandas_compat.py
@@ -1,0 +1,269 @@
+#   Copyright 2026 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Behavioral regressions for pandas 2.3 and 3 compatibility."""
+
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.custom_exceptions import BadIndexException, DataException
+from causalpy.data.simulate_data import generate_time_series_data_simple
+from causalpy.formula_utils import _normalize_patsy_data, build_formula_matrices
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pd.Series(["north", "north", "south", "south"]),
+        pd.Series(["north", "north", "south", "south"], dtype="string"),
+    ],
+    ids=["inferred-strings", "StringDtype"],
+)
+def test_formula_matrices_accept_string_columns_without_mutating_input(unit):
+    """Patsy formulas accept pandas 3-style strings without changing the frame."""
+    data = pd.DataFrame({"unit": unit, "y": [1.0, 2.0, 3.0, 4.0]})
+    original = data.copy(deep=True)
+
+    y, X = build_formula_matrices("y ~ 1 + C(unit)", data)
+
+    assert y.shape == (4, 1)
+    assert X.shape == (4, 2)
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_patsy_normalization_leaves_non_string_extension_dtypes_unchanged():
+    """Only extension strings are normalized before Patsy consumes mixed frames."""
+    data = pd.DataFrame(
+        {
+            "unit": pd.Series(["north", "south"], dtype="string"),
+            "category": pd.Series(pd.Categorical(["a", "b"])),
+            "number": pd.Series([1, 2], dtype="Int64"),
+            "y": [1.0, 2.0],
+        }
+    )
+    original = data.copy(deep=True)
+
+    normalized = _normalize_patsy_data(data)
+
+    assert normalized is not data
+    assert normalized["unit"].dtype == object
+    assert isinstance(normalized["category"].dtype, pd.CategoricalDtype)
+    assert normalized["number"].dtype == data["number"].dtype
+
+    y, X = build_formula_matrices("y ~ 1 + C(unit) + C(category)", data)
+
+    assert y.shape == (2, 1)
+    assert X.shape == (2, 3)
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_formula_matrices_preserve_extension_string_missingness():
+    """Extension-string missing values retain Patsy's normal row-dropping behavior."""
+    data = pd.DataFrame(
+        {
+            "unit": pd.Series(["north", "south", pd.NA, "north"], dtype="string"),
+            "y": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    original = data.copy(deep=True)
+
+    y, X = build_formula_matrices("y ~ 1 + C(unit)", data)
+
+    assert y.shape == (3, 1)
+    assert X.shape == (3, 2)
+    assert pd.isna(data.loc[2, "unit"])
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_regression_discontinuity_normalizes_nullable_integers_without_mutation():
+    """Nullable integer indicators become boolean only on the experiment-owned frame."""
+    x = np.linspace(0.0, 1.0, 20)
+    data = pd.DataFrame(
+        {
+            "x": x,
+            "treated": pd.Series((x >= 0.5).astype(int), dtype="Int64"),
+            "y": 1.0 + 2.0 * x + (x >= 0.5),
+        }
+    )
+    original = data.copy(deep=True)
+
+    result = cp.RegressionDiscontinuity(
+        data,
+        formula="y ~ 1 + x + treated + x:treated",
+        treatment_threshold=0.5,
+        model=LinearRegression(),
+    )
+
+    assert pd.api.types.is_bool_dtype(result.data["treated"])
+    assert pd.api.types.is_integer_dtype(data["treated"])
+    pd.testing.assert_frame_equal(data, original)
+
+
+@pytest.mark.parametrize(
+    "unit",
+    [
+        pd.Series(["north", "north", "south", "south"]),
+        pd.Series(["north", "north", "south", "south"], dtype="string"),
+    ],
+    ids=["inferred-strings", "StringDtype"],
+)
+def test_panel_regression_uses_observed_categorical_groups(unit):
+    """Demeaning ignores unused category levels and accepts string fixed effects."""
+    data = pd.DataFrame(
+        {
+            "unit": unit,
+            "time": pd.Categorical([0, 1, 0, 1], categories=[0, 1, 2]),
+            "treatment": pd.Series([False, True, False, True], dtype="boolean"),
+            "y": [1.0, 3.0, 2.0, 4.0],
+        }
+    )
+    original = data.copy(deep=True)
+
+    result = cp.PanelRegression(
+        data,
+        formula="y ~ treatment",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="demeaned",
+        model=LinearRegression(),
+    )
+
+    assert list(result._group_means["unit"].index) == ["north", "south"]
+    assert list(result._group_means["time"].index) == [0, 1]
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_panel_regression_rejects_missing_string_fixed_effects():
+    """Missing fixed-effect identifiers are rejected before grouping can drop them."""
+    data = pd.DataFrame(
+        {
+            "unit": pd.Series(["north", pd.NA, "south", "south"], dtype="string"),
+            "time": [0, 1, 0, 1],
+            "treatment": [False, True, False, True],
+            "y": [1.0, 3.0, 2.0, 4.0],
+        }
+    )
+    original = data.copy(deep=True)
+
+    with pytest.raises(
+        DataException,
+        match="Fixed-effect variable 'unit' must not contain missing values",
+    ):
+        cp.PanelRegression(
+            data,
+            formula="y ~ treatment",
+            unit_fe_variable="unit",
+            time_fe_variable="time",
+            fe_method="demeaned",
+            model=LinearRegression(),
+        )
+
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_staggered_did_creates_float_event_times_without_mutating_input():
+    """Never-treated rows receive missing float event times without mutating callers."""
+    data = pd.DataFrame(
+        {
+            "unit": [0, 0, 1, 1, 2, 2],
+            "time": [0, 1, 0, 1, 0, 1],
+            "treated": [0, 1, 0, 1, 0, 0],
+            "y": [1.0, 3.0, 2.0, 4.0, 1.5, 1.7],
+        }
+    )
+    original = data.copy(deep=True)
+
+    result = cp.StaggeredDifferenceInDifferences(
+        data,
+        formula="y ~ 1 + C(unit) + C(time)",
+        unit_variable_name="unit",
+        time_variable_name="time",
+        model=LinearRegression(),
+    )
+
+    assert pd.api.types.is_float_dtype(result.data_["event_time"])
+    assert result.data_.loc[result.data_["unit"] == 2, "event_time"].isna().all()
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_time_series_generator_has_explicit_datetime_treatment_boundary():
+    """Generated series retains a datetime index and exclusive treatment boundary."""
+    treatment_time = pd.Timestamp("2015-01-31")
+
+    data = generate_time_series_data_simple(treatment_time=treatment_time, seed=42)
+
+    expected_index = pd.date_range(
+        start="2010-01-01", end="2020-01-01", freq="ME", name="date"
+    )
+    pd.testing.assert_index_equal(data.index, expected_index, exact=True)
+    assert data.loc[:treatment_time, "causal effect"].eq(0).all()
+    assert data.loc[data.index > treatment_time, "causal effect"].eq(2).all()
+
+
+def test_interrupted_time_series_predicts_with_string_extension_covariates():
+    """Fit and prediction matrices handle ``StringDtype`` at the Patsy boundary."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="MS")
+    data = pd.DataFrame(
+        {
+            "y": np.arange(len(dates), dtype=float),
+            "segment": pd.array(
+                ["north", "south", "north", "south"] * 3, dtype="string"
+            ),
+        },
+        index=dates,
+    )
+    original = data.copy(deep=True)
+
+    result = cp.InterruptedTimeSeries(
+        data,
+        treatment_time=dates[6],
+        formula="y ~ 1 + C(segment)",
+        model=LinearRegression(),
+    )
+
+    assert result.pre_design["X"].sizes["obs_ind"] == 6
+    assert result.post_design["X"].sizes["obs_ind"] == 6
+    pd.testing.assert_frame_equal(data, original)
+
+
+def test_interrupted_time_series_preserves_timezone_aware_boundary_and_input():
+    """Timezone-aware treatment dates split periods correctly and reject ``NaT``."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="MS", tz="UTC")
+    data = pd.DataFrame(
+        {"y": np.arange(len(dates), dtype=float)},
+        index=dates,
+    )
+    original = data.copy(deep=True)
+    treatment_time = dates[6]
+
+    result = cp.InterruptedTimeSeries(
+        data,
+        treatment_time=treatment_time,
+        formula="y ~ 1",
+        model=LinearRegression(),
+    )
+
+    assert result.datapre.index.max() == dates[5]
+    assert result.datapost.index.min() == treatment_time
+    pd.testing.assert_frame_equal(data, original)
+
+    with pytest.raises(BadIndexException, match="treatment_time must not be missing"):
+        cp.InterruptedTimeSeries(
+            data,
+            treatment_time=pd.NaT,
+            formula="y ~ 1",
+            model=LinearRegression(),
+        )

--- a/causalpy/tests/test_pandas_compat.py
+++ b/causalpy/tests/test_pandas_compat.py
@@ -13,6 +13,8 @@
 #   limitations under the License.
 """Behavioral regressions for pandas 2.3 and 3 compatibility."""
 
+from datetime import timedelta, timezone
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -21,7 +23,12 @@ from sklearn.linear_model import LinearRegression
 import causalpy as cp
 from causalpy.custom_exceptions import BadIndexException, DataException
 from causalpy.data.simulate_data import generate_time_series_data_simple
+from causalpy.date_utils import validate_treatment_time_against_index
 from causalpy.formula_utils import _normalize_patsy_data, build_formula_matrices
+
+# Fixed offsets rather than named zones: tzdata is not guaranteed to be
+# installed in every environment the matrix builds.
+MINUS_FIVE = timezone(timedelta(hours=-5))
 
 
 @pytest.mark.parametrize(
@@ -278,4 +285,244 @@ def test_interrupted_time_series_preserves_timezone_aware_boundary_and_input():
             treatment_time=pd.NaT,
             formula="y ~ 1",
             model=LinearRegression(),
+        )
+
+
+@pytest.mark.parametrize(
+    "index, treatment_time, match",
+    [
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS"),
+            pd.NaT,
+            "treatment_time must not be missing",
+        ),
+        (
+            pd.RangeIndex(3),
+            np.nan,
+            "treatment_time must not be missing",
+        ),
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS"),
+            1,
+            "If data.index is DatetimeIndex, treatment_time must be pd.Timestamp",
+        ),
+        (
+            pd.RangeIndex(3),
+            pd.Timestamp("2020-01-01"),
+            "If data.index is not DatetimeIndex, treatment_time must not be "
+            "pd.Timestamp",
+        ),
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS", tz="UTC"),
+            pd.Timestamp("2020-02-01"),
+            "either both be timezone-aware or both be timezone-naive",
+        ),
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS"),
+            pd.Timestamp("2020-02-01", tz="UTC"),
+            "either both be timezone-aware or both be timezone-naive",
+        ),
+    ],
+    ids=[
+        "NaT-datetime-index",
+        "nan-numeric-index",
+        "numeric-boundary-datetime-index",
+        "timestamp-boundary-numeric-index",
+        "naive-boundary-aware-index",
+        "aware-boundary-naive-index",
+    ],
+)
+def test_validate_treatment_time_rejects_incomparable_boundaries(
+    index, treatment_time, match
+):
+    """Boundaries that cannot be compared against the index are rejected."""
+    with pytest.raises(BadIndexException, match=match):
+        validate_treatment_time_against_index(index, treatment_time)
+
+
+def test_validate_treatment_time_uses_the_supplied_name_in_messages():
+    """The helper reports the caller's parameter name, e.g. treatment_end_time."""
+    with pytest.raises(BadIndexException, match="treatment_end_time must not be"):
+        validate_treatment_time_against_index(
+            pd.RangeIndex(3), np.nan, name="treatment_end_time"
+        )
+
+
+@pytest.mark.parametrize(
+    "index, treatment_time",
+    [
+        (pd.RangeIndex(3), 1),
+        (pd.Index([0.0, 1.0, 2.0]), 1.5),
+        (pd.date_range("2020-01-01", periods=3, freq="MS"), pd.Timestamp("2020-02-01")),
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS", tz="UTC"),
+            pd.Timestamp("2020-02-01", tz="UTC"),
+        ),
+        (
+            pd.date_range("2020-01-01", periods=3, freq="MS", tz="UTC"),
+            pd.Timestamp("2020-02-01", tz=MINUS_FIVE),
+        ),
+    ],
+    ids=[
+        "int-index",
+        "float-index",
+        "naive-datetime",
+        "same-timezone",
+        "different-timezones",
+    ],
+)
+def test_validate_treatment_time_accepts_comparable_boundaries(index, treatment_time):
+    """Comparable boundaries pass, including tz-aware pairs in different zones."""
+    validate_treatment_time_against_index(index, treatment_time)
+    # The comparison the experiments actually perform must not raise.
+    assert (index < treatment_time).dtype == bool
+
+
+def test_interrupted_time_series_validates_the_treatment_end_boundary():
+    """``treatment_end_time`` gets the same missing-value and timezone checks."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="MS", tz="UTC")
+    data = pd.DataFrame({"y": np.arange(len(dates), dtype=float)}, index=dates)
+
+    with pytest.raises(
+        BadIndexException, match="treatment_end_time must not be missing"
+    ):
+        cp.InterruptedTimeSeries(
+            data,
+            treatment_time=dates[4],
+            formula="y ~ 1",
+            model=LinearRegression(),
+            treatment_end_time=pd.NaT,
+        )
+
+    with pytest.raises(
+        BadIndexException,
+        match="treatment_end_time and data.index must either both be timezone-aware",
+    ):
+        cp.InterruptedTimeSeries(
+            data,
+            treatment_time=dates[4],
+            formula="y ~ 1",
+            model=LinearRegression(),
+            treatment_end_time=pd.Timestamp("2020-09-01"),
+        )
+
+
+def test_interrupted_time_series_rejects_timezone_naive_treatment_time():
+    """A naive boundary against a tz-aware index fails before any slicing."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="MS", tz="UTC")
+    data = pd.DataFrame({"y": np.arange(len(dates), dtype=float)}, index=dates)
+
+    with pytest.raises(
+        BadIndexException,
+        match="treatment_time and data.index must either both be timezone-aware",
+    ):
+        cp.InterruptedTimeSeries(
+            data,
+            treatment_time=pd.Timestamp("2020-07-01"),
+            formula="y ~ 1",
+            model=LinearRegression(),
+        )
+
+
+def _synthetic_control_data(tz=None):
+    """Build a small donor/treated panel indexed by dates in ``tz``."""
+    dates = pd.date_range("2020-01-01", periods=12, freq="MS", tz=tz)
+    rng = np.random.default_rng(42)
+    control = rng.normal(size=(len(dates), 2)) + 10.0
+    return pd.DataFrame(
+        {
+            "c0": control[:, 0],
+            "c1": control[:, 1],
+            "t0": control.mean(axis=1) + 1.0,
+        },
+        index=dates,
+    )
+
+
+@pytest.mark.parametrize(
+    "experiment",
+    [cp.SyntheticControl, cp.SyntheticDifferenceInDifferences],
+    ids=["SyntheticControl", "SyntheticDifferenceInDifferences"],
+)
+@pytest.mark.parametrize(
+    "treatment_time, match",
+    [
+        (pd.NaT, "treatment_time must not be missing"),
+        (
+            pd.Timestamp("2020-07-01"),
+            "treatment_time and data.index must either both be timezone-aware",
+        ),
+    ],
+    ids=["missing", "timezone-mismatch"],
+)
+def test_synthetic_experiments_validate_treatment_time(
+    experiment, treatment_time, match
+):
+    """Both synthetic designs share the treatment-time boundary contract."""
+    data = _synthetic_control_data(tz="UTC")
+
+    with pytest.raises(BadIndexException, match=match):
+        experiment(
+            data,
+            treatment_time=treatment_time,
+            control_units=["c0", "c1"],
+            treated_units=["t0"],
+            model=LinearRegression(),
+        )
+
+
+def _staggered_did_data():
+    """Build a small staggered-adoption panel with an explicit adoption time."""
+    return pd.DataFrame(
+        {
+            "unit": [0, 0, 1, 1, 2, 2],
+            "time": [0, 1, 0, 1, 0, 1],
+            "treated": [0, 1, 0, 1, 0, 0],
+            "adoption": [1.0, 1.0, 1.0, 1.0, np.inf, np.inf],
+            "y": [1.0, 3.0, 2.0, 4.0, 1.5, 1.7],
+        }
+    )
+
+
+@pytest.mark.parametrize(
+    "column, kwargs, match",
+    [
+        (
+            "unit",
+            {},
+            "Required column 'unit' must not contain missing values",
+        ),
+        (
+            "time",
+            {},
+            "Required column 'time' must not contain missing values",
+        ),
+        (
+            "treated",
+            {},
+            "Treated column 'treated' must not contain missing values",
+        ),
+        (
+            "adoption",
+            {"treatment_time_variable_name": "adoption"},
+            "Treatment time column 'adoption' must not contain missing values",
+        ),
+    ],
+    ids=["unit", "time", "treated", "treatment-time"],
+)
+def test_staggered_did_rejects_missing_values_in_grouping_columns(
+    column, kwargs, match
+):
+    """Missing keys would be silently dropped by ``groupby``, so reject them."""
+    data = _staggered_did_data().astype({column: "Float64"})
+    data.loc[0, column] = pd.NA
+
+    with pytest.raises(DataException, match=match):
+        cp.StaggeredDifferenceInDifferences(
+            data,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            model=LinearRegression(),
+            **kwargs,
         )

--- a/causalpy/tests/test_pandas_compat.py
+++ b/causalpy/tests/test_pandas_compat.py
@@ -77,6 +77,23 @@ def test_patsy_normalization_leaves_non_string_extension_dtypes_unchanged():
     pd.testing.assert_frame_equal(data, original)
 
 
+def test_patsy_normalization_is_a_no_op_for_nan_backed_string_columns():
+    """Only ``pd.NA``-sentinel string columns need the Patsy #206 workaround.
+
+    Plain string literals give an object column on pandas 2.3 and the default
+    ``str`` dtype (``np.nan`` sentinel) on pandas 3. Neither trips Patsy, so
+    neither should pay for a copy.
+    """
+    data = pd.DataFrame({"unit": ["north", None, "south"], "y": [1.0, 2.0, 3.0]})
+
+    assert _normalize_patsy_data(data) is data
+
+    y, X = build_formula_matrices("y ~ 1 + C(unit)", data)
+
+    assert y.shape == (2, 1)
+    assert X.shape == (2, 2)
+
+
 def test_formula_matrices_preserve_extension_string_missingness():
     """Extension-string missing values retain Patsy's normal row-dropping behavior."""
     data = pd.DataFrame(

--- a/causalpy/tests/test_synthetic_data.py
+++ b/causalpy/tests/test_synthetic_data.py
@@ -53,7 +53,7 @@ def test_generate_regression_discontinuity_data():
     assert "y" in df.columns
     assert "treated" in df.columns
     assert len(df) == 100  # default N value
-    assert df["treated"].dtype == bool or df["treated"].dtype == np.bool_
+    assert pd.api.types.is_bool_dtype(df["treated"])
 
     # Test with custom parameters
     df_custom = generate_regression_discontinuity_data(

--- a/environment.yml
+++ b/environment.yml
@@ -23,7 +23,7 @@ dependencies:
   - nbconvert
   - nbformat
   - numpy
-  - pandas
+  - pandas<4,>=2.3
   - papermill
   - patsy
   - prek

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "jinja2",
     "matplotlib>=3.5.3",
     "numpy",
-    "pandas",
+    "pandas>=2.3,<4",
     "patsy",
     # Floors per the PyMC 6 migration (#1039). Deliberately NOT pymc>=6.1
     # (pymc-marketing v1.0.0 caps pymc<6.1.0, which would make the docs env


### PR DESCRIPTION
## Summary
- Rebased onto transition `94937675`, inheriting the docs pin required by notebook/docs CI.
- Declare and exercise the supported pandas range as `pandas>=2.3,<4`, with dedicated pandas 2.3 and pandas 3 CI matrix entries.
- Normalize pandas `StringDtype` and Arrow-string inputs on copied frames at both fitted and prediction Patsy boundaries (upstream Patsy #206), preserving explicit object dtype in pandas 3 while leaving categorical, numeric, datetime, and caller-owned data unchanged.
- Preserve exact pandas timezone-aware `obs_ind` coordinates through sklearn prediction containers, then audit experiment mutation, nullable dtype, datetime, and categorical-grouping paths.

## Exact files changed
- `pyproject.toml`
- `environment.yml` (generated by coordinator `prek`; not hand-edited)
- `.github/workflows/ci.yml`
- `causalpy/formula_utils.py`
- `causalpy/experiments/diff_in_diff.py`
- `causalpy/experiments/interrupted_time_series.py`
- `causalpy/experiments/model_adapter.py`
- `causalpy/experiments/panel_regression.py`
- `causalpy/experiments/prepostnegd.py`
- `causalpy/experiments/regression_discontinuity.py`
- `causalpy/experiments/regression_kink.py`
- `causalpy/experiments/staggered_did.py`
- `causalpy/experiments/synthetic_control.py`
- `causalpy/experiments/synthetic_difference_in_differences.py`
- `causalpy/tests/test_input_validation.py` (coordinator formatting)
- `causalpy/tests/test_pandas_compat.py`
- `causalpy/tests/test_synthetic_data.py` (coordinator formatting)

## Contracts covered
- String extension inputs, including missing values, build correct Patsy fit matrices without mutating callers; the same normalization applies to out-of-sample prediction matrices.
- Categorical and nullable numeric extension columns are not coerced by the string workaround.
- Sklearn predictions retain the exact source `obs_ind` index, including timezone-aware `DatetimeIndex` metadata, so the ITS impact-alignment invariants hold for both pre- and post-treatment data.
- Experiment-owned copies protect caller frames while nullable treatments, categorical `groupby(..., observed=True)`, float event times, and timezone-aware/`NaT` datetime boundaries retain their intended behavior.

## Validation status
- Dedicated coordinator verification passed all 30 focused pandas and model-adapter tests.
- `prek`, pre-commit.ci, and `check-environment-yml` pass on head `0a9813e`. Coordinator-generated `environment.yml` is committed and in sync.
- Fresh full CI is running, including the new pandas 2.3 and pandas 3 test legs, notebooks, and docs. Those pending checks are the remaining validation risk.

## Risk
- The branch keeps the pandas 2.3 floor because the CI matrix runs the targeted regressions on both pandas 2.3 and pandas 3. Full CI remains the final confirmation for the rebased head.