### PR TITLE
Data-scale SyntheticControl observation-noise priors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ docs/source/_static/thumbnails/
 # Local scratch space (not tracked)
 .scratch/
 coverage.xml
+
+# PyTensor compilation cache
+.pytensor/

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -303,7 +303,9 @@ class SyntheticControl(BaseExperiment):
 
     def algorithm(self) -> None:
         """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
-        # Auto-scale the sigma prior if the user didn't customize it
+        # Auto-scale the sigma prior if the user didn't customize it.
+        # Triggers only for certain model backends because only these expose
+        # a y_hat prior.
         if (
             self.auto_scale_sigma
             and isinstance(self.model, (WeightedSumFitter, SoftmaxWeightedSumFitter))

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -34,9 +34,10 @@ from causalpy.plot_utils import (
     plot_posterior_over_x,
 )
 from causalpy.pymc_models import (
+    _LEGACY_Y_HAT_PRIOR,
     PyMCModel,
-    SoftmaxWeightedSumFitter,
     WeightedSumFitter,
+    _uses_stock_y_hat_default,
 )
 from causalpy.reporting import EffectSummary
 from causalpy.utils import check_convex_hull_violation
@@ -65,14 +66,16 @@ class SyntheticControl(BaseExperiment):
         threshold trigger a ``UserWarning``. Defaults to ``0.0`` (warn on
         negatively correlated donors).
     auto_scale_sigma : bool, default True
-        If ``True`` (default) and the model is a ``WeightedSumFitter`` or
-        ``SoftmaxWeightedSumFitter`` whose ``y_hat`` prior has not been
-        explicitly overridden, the ``sigma ~ HalfNormal(1)`` default prior is
+        If ``True`` (default) and the model still carries the weighted-sum
+        fitters' stock ``y_hat`` prior, that ``sigma ~ HalfNormal(1)`` default is
         replaced by ``sigma ~ Exponential(2/s)``. The scale is computed per
         treated unit, with *s* the standard deviation of that unit's
         pre-treatment data, so units on different scales are each calibrated
-        separately. Set to ``False`` to use the original ``HalfNormal(1)``
-        default.
+        separately. Set to ``False`` to keep the original ``HalfNormal(1)``
+        default; the experiment then fits a copy of the model with that prior
+        pinned explicitly, leaving the instance you passed in untouched. A model
+        constructed with an explicit ``y_hat`` prior is never rescaled either
+        way.
     **kwargs
         Additional keyword arguments forwarded to :class:`BaseExperiment`.
 
@@ -134,6 +137,8 @@ class SyntheticControl(BaseExperiment):
         self.labels = control_units
         self.treated_units = treated_units
         self.auto_scale_sigma = auto_scale_sigma
+        if not auto_scale_sigma:
+            self._pin_legacy_sigma_prior()
         # Backend-identity check is justified here: constructor-time
         # capability validation (trust boundary), not statistical dispatch.
         if self._model_backend.is_ols and len(treated_units) > 1:
@@ -300,44 +305,42 @@ class SyntheticControl(BaseExperiment):
             }
         )
 
-    def _clone_weighted_sum_fitter_for_opt_out(self) -> bool:
-        """Clone a stock fitter only when a fit must retain its legacy prior."""
+    def _pin_legacy_sigma_prior(self) -> None:
+        """Swap in a model that carries the legacy noise prior explicitly.
+
+        Automatic scaling only reaches models that still declare the stock
+        ``y_hat`` default and were not given an explicit ``y_hat`` prior, so
+        those are the only models the opt-out has to touch. Expressing the
+        opt-out as an ordinary user prior on a fresh instance — rather than as a
+        fit-local flag — means it survives refits and later clones, such as the
+        ones the sensitivity checks make, and leaves the caller's own model
+        untouched.
+        """
         model = self.model
-        if self.auto_scale_sigma or not isinstance(
-            model, (WeightedSumFitter, SoftmaxWeightedSumFitter)
-        ):
-            return False
-        if type(model) not in (WeightedSumFitter, SoftmaxWeightedSumFitter):
-            return False
-        if "y_hat" in (model._user_priors or {}):
-            return False
-        cloned_model = model._clone()
-        if not isinstance(cloned_model, (WeightedSumFitter, SoftmaxWeightedSumFitter)):
-            raise RuntimeError(
-                f"{type(model).__name__}._clone() returned an incompatible model"
-            )
-        cloned_model._auto_scale_sigma = False
-        self.model = cloned_model
-        self._model_backend = PyMCModelAdapter(cloned_model)
-        return True
+        if not isinstance(model, PyMCModel) or not _uses_stock_y_hat_default(model):
+            return
+        user_priors = model._user_priors or {}
+        if "y_hat" in user_priors:
+            return
+        pinned = type(model)(
+            sample_kwargs=dict(model.sample_kwargs),
+            priors={**user_priors, "y_hat": _LEGACY_Y_HAT_PRIOR},
+        )
+        self.model = pinned
+        self._model_backend = PyMCModelAdapter(pinned)
 
     def algorithm(self) -> None:
         """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
-        reset_auto_scale_sigma = self._clone_weighted_sum_fitter_for_opt_out()
-        try:
-            # fit the model to the observed (pre-intervention) data
-            self._model_backend.fit(
-                X=self.pre_design["control"],
-                y=self.pre_design["treated"],
-                coords=build_coords(
-                    self.control_units,
-                    self.datapre.shape[0],
-                    treated_units=self.treated_units,
-                ),
-            )
-        finally:
-            if reset_auto_scale_sigma:
-                delattr(self.model, "_auto_scale_sigma")
+        # fit the model to the observed (pre-intervention) data
+        self._model_backend.fit(
+            X=self.pre_design["control"],
+            y=self.pre_design["treated"],
+            coords=build_coords(
+                self.control_units,
+                self.datapre.shape[0],
+                treated_units=self.treated_units,
+            ),
+        )
 
         # score the goodness of fit to the pre-intervention data
         self.score = self._model_backend.score(

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -302,17 +302,23 @@ class SyntheticControl(BaseExperiment):
 
     def _clone_weighted_sum_fitter_for_opt_out(self) -> bool:
         """Clone a stock fitter only when a fit must retain its legacy prior."""
-        if (
-            self.auto_scale_sigma
-            or type(self.model)
-            not in (WeightedSumFitter, SoftmaxWeightedSumFitter)
-            or "y_hat" in (self.model._user_priors or {})
+        model = self.model
+        if self.auto_scale_sigma or not isinstance(
+            model, (WeightedSumFitter, SoftmaxWeightedSumFitter)
         ):
             return False
-        model = self.model._clone()
-        setattr(model, "_auto_scale_sigma", False)
-        self.model = model
-        self._model_backend = PyMCModelAdapter(model)
+        if type(model) not in (WeightedSumFitter, SoftmaxWeightedSumFitter):
+            return False
+        if "y_hat" in (model._user_priors or {}):
+            return False
+        cloned_model = model._clone()
+        if not isinstance(cloned_model, (WeightedSumFitter, SoftmaxWeightedSumFitter)):
+            raise RuntimeError(
+                f"{type(model).__name__}._clone() returned an incompatible model"
+            )
+        cloned_model._auto_scale_sigma = False
+        self.model = cloned_model
+        self._model_backend = PyMCModelAdapter(cloned_model)
         return True
 
     def algorithm(self) -> None:

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -20,6 +20,7 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
+from pymc_extras.prior import Prior
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
@@ -60,6 +61,14 @@ class SyntheticControl(BaseExperiment):
         treated unit in the pre-treatment period. Control units below this
         threshold trigger a ``UserWarning``. Defaults to ``0.0`` (warn on
         negatively correlated donors).
+    auto_scale_sigma : bool, default True
+        If ``True`` (default) and the model is a ``WeightedSumFitter`` whose
+        ``y_hat`` prior has not been explicitly overridden, the
+        ``sigma ~ HalfNormal(1)`` default prior is replaced by
+        ``sigma ~ Exponential(2/s)`` where *s* is the standard deviation of the
+        pre-treatment treated-unit data. This keeps the prior well-calibrated
+        regardless of the outcome's scale. Set to ``False`` to use the original
+        ``HalfNormal(1)`` default.
     **kwargs
         Additional keyword arguments forwarded to :class:`BaseExperiment`.
 
@@ -108,6 +117,7 @@ class SyntheticControl(BaseExperiment):
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
         min_donor_correlation: float = 0.0,
+        auto_scale_sigma: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(model=model)
@@ -119,6 +129,7 @@ class SyntheticControl(BaseExperiment):
         self.control_units = control_units
         self.labels = control_units
         self.treated_units = treated_units
+        self.auto_scale_sigma = auto_scale_sigma
         # Backend-identity check is justified here: constructor-time
         # capability validation (trust boundary), not statistical dispatch.
         if self._model_backend.is_ols and len(treated_units) > 1:
@@ -287,6 +298,22 @@ class SyntheticControl(BaseExperiment):
 
     def algorithm(self) -> None:
         """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
+        # Auto-scale the sigma prior if the user didn't customize it
+        if (
+            self.auto_scale_sigma
+            and isinstance(self.model, WeightedSumFitter)
+            and (
+                self.model._user_priors is None
+                or "y_hat" not in self.model._user_priors
+            )
+        ):
+            y_std = float(self.pre_design["treated"].std(dim="obs_ind", ddof=1).mean())
+            self.model.priors["y_hat"] = Prior(
+                "Normal",
+                sigma=Prior("Exponential", lam=2 / y_std, dims=["treated_units"]),
+                dims=["obs_ind", "treated_units"],
+            )
+
         # fit the model to the observed (pre-intervention) data
         self._model_backend.fit(
             X=self.pre_design["control"],

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -34,7 +34,11 @@ from causalpy.plot_utils import (
     has_posterior_draws,
     plot_posterior_over_x,
 )
-from causalpy.pymc_models import PyMCModel, WeightedSumFitter
+from causalpy.pymc_models import (
+    PyMCModel,
+    SoftmaxWeightedSumFitter,
+    WeightedSumFitter,
+)
 from causalpy.reporting import EffectSummary
 from causalpy.utils import check_convex_hull_violation
 
@@ -62,13 +66,14 @@ class SyntheticControl(BaseExperiment):
         threshold trigger a ``UserWarning``. Defaults to ``0.0`` (warn on
         negatively correlated donors).
     auto_scale_sigma : bool, default True
-        If ``True`` (default) and the model is a ``WeightedSumFitter`` whose
-        ``y_hat`` prior has not been explicitly overridden, the
-        ``sigma ~ HalfNormal(1)`` default prior is replaced by
-        ``sigma ~ Exponential(2/s)``. The scale is computed per treated unit,
-        with *s* the standard deviation of that unit's pre-treatment data, so
-        units on different scales are each calibrated separately. Set to
-        ``False`` to use the original ``HalfNormal(1)`` default.
+        If ``True`` (default) and the model is a ``WeightedSumFitter`` or
+        ``SoftmaxWeightedSumFitter`` whose ``y_hat`` prior has not been
+        explicitly overridden, the ``sigma ~ HalfNormal(1)`` default prior is
+        replaced by ``sigma ~ Exponential(2/s)``. The scale is computed per
+        treated unit, with *s* the standard deviation of that unit's
+        pre-treatment data, so units on different scales are each calibrated
+        separately. Set to ``False`` to use the original ``HalfNormal(1)``
+        default.
     **kwargs
         Additional keyword arguments forwarded to :class:`BaseExperiment`.
 
@@ -301,7 +306,7 @@ class SyntheticControl(BaseExperiment):
         # Auto-scale the sigma prior if the user didn't customize it
         if (
             self.auto_scale_sigma
-            and isinstance(self.model, WeightedSumFitter)
+            and isinstance(self.model, (WeightedSumFitter, SoftmaxWeightedSumFitter))
             and (
                 self.model._user_priors is None
                 or "y_hat" not in self.model._user_priors

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -20,13 +20,12 @@ import numpy as np
 import pandas as pd
 import xarray as xr
 from matplotlib import pyplot as plt
-from pymc_extras.prior import Prior
 from sklearn.base import RegressorMixin
 
 from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import BadIndexException
 from causalpy.date_utils import _combine_datetime_indices, format_date_axes
-from causalpy.experiments.model_adapter import build_coords
+from causalpy.experiments.model_adapter import PyMCModelAdapter, build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -301,48 +300,38 @@ class SyntheticControl(BaseExperiment):
             }
         )
 
-    def algorithm(self) -> None:
-        """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
-        # Auto-scale the sigma prior if the user didn't customize it.
-        # Triggers only for certain model backends because only these expose
-        # a y_hat prior.
+    def _clone_weighted_sum_fitter_for_opt_out(self) -> bool:
+        """Clone a stock fitter only when a fit must retain its legacy prior."""
         if (
             self.auto_scale_sigma
-            and isinstance(self.model, (WeightedSumFitter, SoftmaxWeightedSumFitter))
-            and (
-                self.model._user_priors is None
-                or "y_hat" not in self.model._user_priors
-            )
+            or type(self.model)
+            not in (WeightedSumFitter, SoftmaxWeightedSumFitter)
+            or "y_hat" in (self.model._user_priors or {})
         ):
-            # Per-unit pre-treatment standard deviation of the treated series, so
-            # each treated unit gets a sigma prior scaled to its own outcome.
-            y_std = self.pre_design["treated"].std(dim="obs_ind", ddof=1)
-            if not np.all(np.isfinite(y_std.values)) or np.any(y_std.values == 0):
-                raise ValueError(
-                    "Cannot auto-scale the sigma prior: the pre-treatment standard "
-                    "deviation of one or more treated units is zero or undefined "
-                    "(e.g. a constant pre-treatment series, or only a single "
-                    "pre-treatment observation). Pass auto_scale_sigma=False or "
-                    "supply an explicit y_hat prior on the model."
-                )
-            self.model.priors["y_hat"] = Prior(
-                "Normal",
-                sigma=Prior(
-                    "Exponential", lam=(2 / y_std).values, dims=["treated_units"]
-                ),
-                dims=["obs_ind", "treated_units"],
-            )
+            return False
+        model = self.model._clone()
+        setattr(model, "_auto_scale_sigma", False)
+        self.model = model
+        self._model_backend = PyMCModelAdapter(model)
+        return True
 
-        # fit the model to the observed (pre-intervention) data
-        self._model_backend.fit(
-            X=self.pre_design["control"],
-            y=self.pre_design["treated"],
-            coords=build_coords(
-                self.control_units,
-                self.datapre.shape[0],
-                treated_units=self.treated_units,
-            ),
-        )
+    def algorithm(self) -> None:
+        """Run the experiment algorithm: fit model, predict, and calculate causal impact."""
+        reset_auto_scale_sigma = self._clone_weighted_sum_fitter_for_opt_out()
+        try:
+            # fit the model to the observed (pre-intervention) data
+            self._model_backend.fit(
+                X=self.pre_design["control"],
+                y=self.pre_design["treated"],
+                coords=build_coords(
+                    self.control_units,
+                    self.datapre.shape[0],
+                    treated_units=self.treated_units,
+                ),
+            )
+        finally:
+            if reset_auto_scale_sigma:
+                delattr(self.model, "_auto_scale_sigma")
 
         # score the goodness of fit to the pre-intervention data
         self.score = self._model_backend.score(

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -65,10 +65,10 @@ class SyntheticControl(BaseExperiment):
         If ``True`` (default) and the model is a ``WeightedSumFitter`` whose
         ``y_hat`` prior has not been explicitly overridden, the
         ``sigma ~ HalfNormal(1)`` default prior is replaced by
-        ``sigma ~ Exponential(2/s)`` where *s* is the standard deviation of the
-        pre-treatment treated-unit data. This keeps the prior well-calibrated
-        regardless of the outcome's scale. Set to ``False`` to use the original
-        ``HalfNormal(1)`` default.
+        ``sigma ~ Exponential(2/s)``. The scale is computed per treated unit,
+        with *s* the standard deviation of that unit's pre-treatment data, so
+        units on different scales are each calibrated separately. Set to
+        ``False`` to use the original ``HalfNormal(1)`` default.
     **kwargs
         Additional keyword arguments forwarded to :class:`BaseExperiment`.
 
@@ -307,10 +307,22 @@ class SyntheticControl(BaseExperiment):
                 or "y_hat" not in self.model._user_priors
             )
         ):
-            y_std = float(self.pre_design["treated"].std(dim="obs_ind", ddof=1).mean())
+            # Per-unit pre-treatment standard deviation of the treated series, so
+            # each treated unit gets a sigma prior scaled to its own outcome.
+            y_std = self.pre_design["treated"].std(dim="obs_ind", ddof=1)
+            if not np.all(np.isfinite(y_std.values)) or np.any(y_std.values == 0):
+                raise ValueError(
+                    "Cannot auto-scale the sigma prior: the pre-treatment standard "
+                    "deviation of one or more treated units is zero or undefined "
+                    "(e.g. a constant pre-treatment series, or only a single "
+                    "pre-treatment observation). Pass auto_scale_sigma=False or "
+                    "supply an explicit y_hat prior on the model."
+                )
             self.model.priors["y_hat"] = Prior(
                 "Normal",
-                sigma=Prior("Exponential", lam=2 / y_std, dims=["treated_units"]),
+                sigma=Prior(
+                    "Exponential", lam=(2 / y_std).values, dims=["treated_units"]
+                ),
                 dims=["obs_ind", "treated_units"],
             )
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -671,12 +671,7 @@ def _data_scaled_y_hat_prior(y: xr.DataArray) -> Prior:
             scales = np.std(y_values, axis=0, ddof=1)
     with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
         rates = 2 / scales
-    invalid = (
-        ~np.isfinite(scales)
-        | (scales <= 0)
-        | ~np.isfinite(rates)
-        | (rates <= 0)
-    )
+    invalid = ~np.isfinite(scales) | (scales <= 0) | ~np.isfinite(rates) | (rates <= 0)
     if np.any(invalid):
         invalid_units = ", ".join(repr(str(unit)) for unit in treated_units[invalid])
         raise ValueError(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -764,9 +764,18 @@ class WeightedSumFitter(PyMCModel):
         \mu &= X \cdot \beta \\
         y &\sim \operatorname{Normal}(\mu, \sigma)
 
-    The rate gives :math:`\sigma_i` a prior mean of :math:`s_i / 2`. A custom
-    ``y_hat`` prior takes precedence. ``SyntheticControl`` can retain the legacy
-    ``HalfNormal(1)`` prior for a fit with ``auto_scale_sigma=False``.
+    The rate gives :math:`\sigma_i` a prior mean of :math:`s_i / 2`, so the
+    prior says the same thing about the noise whatever units the outcome is in.
+    The fixed ``HalfNormal(1)`` used before only suited outcomes on a unit-ish
+    scale: on a larger outcome it pushed the posterior :math:`\sigma` far into
+    its own tail, which narrows the ridge NUTS has to explore and costs both
+    effective sample size and wall time. A treated unit whose pre-treatment
+    series is constant has no estimable :math:`s_i`, so it falls back to
+    :math:`s_i = 1` and warns.
+
+    A custom ``y_hat`` prior, or one declared as a subclass default, takes
+    precedence. ``SyntheticControl(auto_scale_sigma=False)`` keeps the legacy
+    ``HalfNormal(1)`` prior.
 
     Examples
     --------
@@ -919,11 +928,13 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         \mu &= X \cdot \beta \\
         y &\sim \mathrm{Normal}(\mu, \sigma_y) \\
 
-    At fit time, the stock fitter assigns each treated outcome an independent
-    observation-noise prior ``Exponential(lam=2 / s_i)``, where ``s_i`` is that
-    outcome's sample standard deviation. A custom ``y_hat`` prior takes
-    precedence. ``SyntheticControl(auto_scale_sigma=False)`` retains the legacy
-    ``HalfNormal(1)`` prior for a fit.
+    At fit time each treated outcome gets an independent observation-noise prior
+    ``Exponential(lam=2 / s_i)``, where ``s_i`` is that outcome's sample standard
+    deviation, so the prior means the same thing whatever units the outcome is
+    in. See :class:`WeightedSumFitter` for the rationale and the constant-series
+    fallback. A custom ``y_hat`` prior, or one declared as a subclass default,
+    takes precedence, and ``SyntheticControl(auto_scale_sigma=False)`` retains
+    the legacy ``HalfNormal(1)`` prior.
 
     Notes
     -----

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -657,34 +657,65 @@ class LinearRegression(PyMCModel):
             self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
 
 
+#: Fallback outcome scale used when a treated unit's pre-treatment spread cannot
+#: be estimated (a constant series, or fewer than two observations). Keeping the
+#: scale at 1 reproduces the legacy ``HalfNormal(1)`` order of magnitude for
+#: those degenerate units instead of failing a fit that used to work.
+_DEGENERATE_OUTCOME_SCALE = 1.0
+
+
 def _data_scaled_y_hat_prior(y: xr.DataArray) -> Prior:
-    """Build a per-treated-unit observation-noise prior from outcome scale."""
+    """Build a per-treated-unit observation-noise prior from outcome scale.
+
+    Each treated unit's rate is ``2 / s_i``, giving ``sigma_i`` a prior mean of
+    ``s_i / 2``, where ``s_i`` is that unit's sample standard deviation. Units
+    whose spread is not estimable fall back to ``s_i = 1`` with a warning;
+    non-finite outcomes are a data error and are rejected.
+    """
     y_values = np.asarray(
         y.transpose("obs_ind", "treated_units").values,
         dtype=float,
     )
     treated_units = np.asarray(y.get_index("treated_units"))
-    if y_values.shape[0] < 2:
-        scales = np.full(y_values.shape[1], np.nan)
-    else:
-        with np.errstate(invalid="ignore"):
-            scales = np.std(y_values, axis=0, ddof=1)
-    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
-        rates = 2 / scales
-    invalid = ~np.isfinite(scales) | (scales <= 0) | ~np.isfinite(rates) | (rates <= 0)
-    if np.any(invalid):
-        invalid_units = ", ".join(repr(str(unit)) for unit in treated_units[invalid])
+    non_finite = ~np.isfinite(y_values).all(axis=0)
+    if np.any(non_finite):
         raise ValueError(
-            "Cannot data-scale the y_hat observation-noise prior: fitted outcome "
-            "standard deviations must be finite and positive for treated unit(s) "
-            f"{invalid_units}. Pass a custom y_hat prior; SyntheticControl callers "
-            "can alternatively use auto_scale_sigma=False to retain HalfNormal(1)."
+            "Cannot data-scale the y_hat observation-noise prior: the fitted "
+            "outcome contains non-finite values for treated unit(s) "
+            f"{_format_treated_units(treated_units[non_finite])}. Clean the data, "
+            "or pass a custom y_hat prior; SyntheticControl callers can "
+            "alternatively use auto_scale_sigma=False to retain HalfNormal(1)."
         )
+    if y_values.shape[0] < 2:
+        scales = np.zeros(y_values.shape[1])
+    else:
+        scales = np.std(y_values, axis=0, ddof=1)
+    with np.errstate(divide="ignore", over="ignore"):
+        rates = 2 / scales
+    # A zero (or subnormal) spread carries no scale information, so there is
+    # nothing to calibrate against and the fallback scale is used instead.
+    degenerate = ~np.isfinite(rates) | (rates <= 0)
+    if np.any(degenerate):
+        warnings.warn(
+            "Cannot estimate the pre-treatment outcome scale for treated unit(s) "
+            f"{_format_treated_units(treated_units[degenerate])}; the series is "
+            "constant or has fewer than two observations. Falling back to an "
+            f"observation-noise scale of {_DEGENERATE_OUTCOME_SCALE} for those "
+            "units. Pass a custom y_hat prior to control this explicitly.",
+            UserWarning,
+            stacklevel=2,
+        )
+        rates = np.where(degenerate, 2 / _DEGENERATE_OUTCOME_SCALE, rates)
     return Prior(
         "Normal",
         sigma=Prior("Exponential", lam=rates, dims=["treated_units"]),
         dims=["obs_ind", "treated_units"],
     )
+
+
+def _format_treated_units(units: np.ndarray) -> str:
+    """Render treated-unit labels for use in diagnostics."""
+    return ", ".join(repr(str(unit)) for unit in units)
 
 
 class WeightedSumFitter(PyMCModel):

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -403,9 +403,15 @@ class PyMCModel(pm.Model):
         # sample_posterior_predictive() if provided in sample_kwargs.
         random_seed = self.sample_kwargs.get("random_seed", None)
 
-        # Merge priors with precedence: user-specified > data-driven > defaults
-        # Data-driven priors are computed first, then user-specified priors override them
-        self.priors = {**self.priors_from_data(X, y), **self.priors}
+        # Rebuild effective priors for every fit so data-derived priors never
+        # leak into a later fit. User configuration always has final precedence.
+        self.priors = {**self.default_priors, **(self._user_priors or {})}
+        data_priors = self.priors_from_data(X, y)
+        self.priors = {
+            **self.default_priors,
+            **data_priors,
+            **(self._user_priors or {}),
+        }
 
         self.build_model(X, y, coords)
         with self:
@@ -651,17 +657,58 @@ class LinearRegression(PyMCModel):
             self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
 
 
+def _data_scaled_y_hat_prior(y: xr.DataArray) -> Prior:
+    """Build a per-treated-unit observation-noise prior from outcome scale."""
+    y_values = np.asarray(
+        y.transpose("obs_ind", "treated_units").values,
+        dtype=float,
+    )
+    treated_units = np.asarray(y.get_index("treated_units"))
+    if y_values.shape[0] < 2:
+        scales = np.full(y_values.shape[1], np.nan)
+    else:
+        with np.errstate(invalid="ignore"):
+            scales = np.std(y_values, axis=0, ddof=1)
+    with np.errstate(divide="ignore", invalid="ignore", over="ignore"):
+        rates = 2 / scales
+    invalid = (
+        ~np.isfinite(scales)
+        | (scales <= 0)
+        | ~np.isfinite(rates)
+        | (rates <= 0)
+    )
+    if np.any(invalid):
+        invalid_units = ", ".join(repr(str(unit)) for unit in treated_units[invalid])
+        raise ValueError(
+            "Cannot data-scale the y_hat observation-noise prior: fitted outcome "
+            "standard deviations must be finite and positive for treated unit(s) "
+            f"{invalid_units}. Pass a custom y_hat prior; SyntheticControl callers "
+            "can alternatively use auto_scale_sigma=False to retain HalfNormal(1)."
+        )
+    return Prior(
+        "Normal",
+        sigma=Prior("Exponential", lam=rates, dims=["treated_units"]),
+        dims=["obs_ind", "treated_units"],
+    )
+
+
 class WeightedSumFitter(PyMCModel):
     r"""
     Used for synthetic control experiments.
 
-    Defines the PyMC model:
+    Defines the PyMC model. At fit time, the default observation-noise prior is
+    independently scaled for each treated unit:
 
     .. math::
-        \sigma &\sim \mathrm{HalfNormal}(1) \\
-        \beta &\sim \mathrm{Dirichlet}(1,...,1) \\
+        s_i &= \operatorname{sd}(y_i) \\
+        \sigma_i &\sim \operatorname{Exponential}(2 / s_i) \\
+        \beta &\sim \operatorname{Dirichlet}(1,\ldots,1) \\
         \mu &= X \cdot \beta \\
-        y &\sim \mathrm{Normal}(\mu, \sigma) \\
+        y &\sim \operatorname{Normal}(\mu, \sigma)
+
+    The rate gives :math:`\sigma_i` a prior mean of :math:`s_i / 2`. A custom
+    ``y_hat`` prior takes precedence. ``SyntheticControl`` can retain the legacy
+    ``HalfNormal(1)`` prior for a fit with ``auto_scale_sigma=False``.
 
     Examples
     --------
@@ -698,14 +745,17 @@ class WeightedSumFitter(PyMCModel):
         ),
     }
 
-    def priors_from_data(self, X, y) -> dict[str, Any]:
-        """
-        Set Dirichlet prior for weights based on number of control units.
+    _auto_scale_sigma = True
 
-        For synthetic control models, this method sets the shape parameter of the
-        Dirichlet prior on the control unit weights (`beta`) to be uniform across
-        all available control units. This ensures that all control units have
-        equal prior probability of contributing to the synthetic control.
+    def priors_from_data(self, X, y) -> dict[str, Any]:
+        """Set data-dependent priors for weights and observation noise.
+
+        The Dirichlet weight prior is uniform across available control units. For
+        the stock fitter, the default ``y_hat`` prior uses an independent
+        ``Exponential(lam=2 / s_i)`` noise scale for each treated outcome, where
+        ``s_i`` is its sample standard deviation. A user-provided ``y_hat`` prior
+        takes precedence, and ``SyntheticControl(auto_scale_sigma=False)`` leaves
+        the legacy ``HalfNormal(1)`` prior in place.
 
         Parameters
         ----------
@@ -716,17 +766,21 @@ class WeightedSumFitter(PyMCModel):
 
         Returns
         -------
-        Dict[str, Prior]
-            Dictionary containing:
-
-            - "beta": Dirichlet prior with shape=(1,...,1) for n_control_units
+        dict[str, Prior]
+            Data-dependent ``beta`` and, when enabled, ``y_hat`` priors.
         """
-        n_predictors = X.shape[1]
-        return {
+        priors = {
             "beta": Prior(
-                "Dirichlet", a=np.ones(n_predictors), dims=["treated_units", "coeffs"]
+                "Dirichlet", a=np.ones(X.shape[1]), dims=["treated_units", "coeffs"]
             ),
         }
+        if (
+            type(self) is WeightedSumFitter
+            and self._auto_scale_sigma
+            and "y_hat" not in (self._user_priors or {})
+        ):
+            priors["y_hat"] = _data_scaled_y_hat_prior(y)
+        return priors
 
     def build_model(
         self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None
@@ -818,6 +872,12 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         \mu &= X \cdot \beta \\
         y &\sim \mathrm{Normal}(\mu, \sigma_y) \\
 
+    At fit time, the stock fitter assigns each treated outcome an independent
+    observation-noise prior ``Exponential(lam=2 / s_i)``, where ``s_i`` is that
+    outcome's sample standard deviation. A custom ``y_hat`` prior takes
+    precedence. ``SyntheticControl(auto_scale_sigma=False)`` retains the legacy
+    ``HalfNormal(1)`` prior for a fit.
+
     Notes
     -----
     The softmax-Normal parameterization and the Dirichlet prior used by
@@ -877,38 +937,22 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         ),
     }
 
+    _auto_scale_sigma = True
+
     def priors_from_data(self, X, y) -> dict[str, Any]:
-        """
-        Set Normal prior for logit weights based on number of control units.
+        """Set data-dependent priors for logits and observation noise.
 
-        The prior is placed on ``N - 1`` unconstrained logits (the first logit is
-        pinned to zero). The default scale ``sigma=1.0`` provides moderate
-        regularization, equivalent to ``zeta=1.0`` in the frequentist SDiD.
+        The Normal prior on the ``N - 1`` unconstrained logits uses
+        ``sigma=1.0`` by default. For the stock fitter, the default ``y_hat``
+        prior uses an independent ``Exponential(lam=2 / s_i)`` noise scale for
+        each treated outcome, where ``s_i`` is its sample standard deviation. A
+        user-provided ``y_hat`` prior takes precedence, and
+        ``SyntheticControl(auto_scale_sigma=False)`` leaves the legacy
+        ``HalfNormal(1)`` prior in place.
 
-        Unlike :meth:`WeightedSumFitter.priors_from_data`, which must read
-        ``X.shape[1]`` to size the Dirichlet concentration vector, the Normal
-        prior here broadcasts automatically via its ``dims``, so the data shape
-        is not needed.
-
-        To control regularization strength, pass a custom ``beta_raw`` prior::
-
-            # Tighter regularization (more DiD-like, near-uniform weights):
-            model = SoftmaxWeightedSumFitter(
-                priors={
-                    "beta_raw": Prior(
-                        "Normal", mu=0, sigma=0.1, dims=["treated_units", "coeffs_raw"]
-                    )
-                }
-            )
-
-            # Looser regularization (more SC-like, data-driven sparse weights):
-            model = SoftmaxWeightedSumFitter(
-                priors={
-                    "beta_raw": Prior(
-                        "Normal", mu=0, sigma=10, dims=["treated_units", "coeffs_raw"]
-                    )
-                }
-            )
+        Unlike :meth:`WeightedSumFitter.priors_from_data`, the Normal logit prior
+        broadcasts automatically via its ``dims``, so the predictor shape is not
+        needed.
 
         Parameters
         ----------
@@ -920,11 +964,9 @@ class SoftmaxWeightedSumFitter(PyMCModel):
         Returns
         -------
         dict[str, Prior]
-            Dictionary containing:
-
-            - "beta_raw": Normal prior with dims ["treated_units", "coeffs_raw"]
+            Data-dependent ``beta_raw`` and, when enabled, ``y_hat`` priors.
         """
-        return {
+        priors = {
             "beta_raw": Prior(
                 "Normal",
                 mu=0,
@@ -932,6 +974,13 @@ class SoftmaxWeightedSumFitter(PyMCModel):
                 dims=["treated_units", "coeffs_raw"],
             ),
         }
+        if (
+            type(self) is SoftmaxWeightedSumFitter
+            and self._auto_scale_sigma
+            and "y_hat" not in (self._user_priors or {})
+        ):
+            priors["y_hat"] = _data_scaled_y_hat_prior(y)
+        return priors
 
     def build_model(
         self, X: xr.DataArray, y: xr.DataArray, coords: dict[str, Any] | None

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -657,6 +657,36 @@ class LinearRegression(PyMCModel):
             self.priors["y_hat"].create_likelihood_variable("y_hat", mu=mu, observed=y)
 
 
+#: The observation-noise prior both weighted-sum fitters carried before #887 made
+#: the scale data-derived. It stays their declared default (so a fit that never
+#: reaches ``priors_from_data`` is unchanged) and doubles as the opt-out prior.
+_LEGACY_Y_HAT_PRIOR = Prior(
+    "Normal",
+    sigma=Prior("HalfNormal", sigma=1, dims=["treated_units"]),
+    dims=["obs_ind", "treated_units"],
+)
+
+
+def _uses_stock_y_hat_default(model: "PyMCModel") -> bool:
+    """Report whether a model still declares the stock ``y_hat`` default prior.
+
+    Automatic scaling replaces a default the user never chose. A subclass that
+    declares its own ``y_hat`` default *has* chosen one, so it is left alone;
+    subclasses that only customise other parts of the model are still scaled.
+
+    Parameters
+    ----------
+    model : PyMCModel
+        Model whose declared default priors are inspected.
+
+    Returns
+    -------
+    bool
+        ``True`` when the ``y_hat`` default is ``_LEGACY_Y_HAT_PRIOR``.
+    """
+    return type(model).default_priors.get("y_hat") is _LEGACY_Y_HAT_PRIOR
+
+
 #: Fallback outcome scale used when a treated unit's pre-treatment spread cannot
 #: be estimated (a constant series, or fewer than two observations). Keeping the
 #: scale at 1 reproduces the legacy ``HalfNormal(1)`` order of magnitude for
@@ -763,25 +793,18 @@ class WeightedSumFitter(PyMCModel):
     >>> _ = wsf.fit(X, y, coords=coords)
     """  # noqa: W605
 
-    default_priors = {
-        "y_hat": Prior(
-            "Normal",
-            sigma=Prior("HalfNormal", sigma=1, dims=["treated_units"]),
-            dims=["obs_ind", "treated_units"],
-        ),
-    }
-
-    _auto_scale_sigma = True
+    default_priors = {"y_hat": _LEGACY_Y_HAT_PRIOR}
 
     def priors_from_data(self, X, y) -> dict[str, Any]:
         """Set data-dependent priors for weights and observation noise.
 
-        The Dirichlet weight prior is uniform across available control units. For
-        the stock fitter, the default ``y_hat`` prior uses an independent
-        ``Exponential(lam=2 / s_i)`` noise scale for each treated outcome, where
-        ``s_i`` is its sample standard deviation. A user-provided ``y_hat`` prior
-        takes precedence, and ``SyntheticControl(auto_scale_sigma=False)`` leaves
-        the legacy ``HalfNormal(1)`` prior in place.
+        The Dirichlet weight prior is uniform across available control units. The
+        default ``y_hat`` prior uses an independent ``Exponential(lam=2 / s_i)``
+        noise scale for each treated outcome, where ``s_i`` is its sample standard
+        deviation. A user-provided ``y_hat`` prior, or a ``y_hat`` default
+        declared by a subclass, takes precedence; so does
+        ``SyntheticControl(auto_scale_sigma=False)``, which leaves the legacy
+        ``HalfNormal(1)`` prior in place.
 
         Parameters
         ----------
@@ -800,11 +823,7 @@ class WeightedSumFitter(PyMCModel):
                 "Dirichlet", a=np.ones(X.shape[1]), dims=["treated_units", "coeffs"]
             ),
         }
-        if (
-            type(self) is WeightedSumFitter
-            and self._auto_scale_sigma
-            and "y_hat" not in (self._user_priors or {})
-        ):
+        if _uses_stock_y_hat_default(self) and "y_hat" not in (self._user_priors or {}):
             priors["y_hat"] = _data_scaled_y_hat_prior(y)
         return priors
 
@@ -955,25 +974,17 @@ class SoftmaxWeightedSumFitter(PyMCModel):
     >>> _ = wsf.fit(X, y, coords=coords)
     """  # noqa: W605
 
-    default_priors = {
-        "y_hat": Prior(
-            "Normal",
-            sigma=Prior("HalfNormal", sigma=1, dims=["treated_units"]),
-            dims=["obs_ind", "treated_units"],
-        ),
-    }
-
-    _auto_scale_sigma = True
+    default_priors = {"y_hat": _LEGACY_Y_HAT_PRIOR}
 
     def priors_from_data(self, X, y) -> dict[str, Any]:
         """Set data-dependent priors for logits and observation noise.
 
         The Normal prior on the ``N - 1`` unconstrained logits uses
-        ``sigma=1.0`` by default. For the stock fitter, the default ``y_hat``
-        prior uses an independent ``Exponential(lam=2 / s_i)`` noise scale for
-        each treated outcome, where ``s_i`` is its sample standard deviation. A
-        user-provided ``y_hat`` prior takes precedence, and
-        ``SyntheticControl(auto_scale_sigma=False)`` leaves the legacy
+        ``sigma=1.0`` by default. The default ``y_hat`` prior uses an independent
+        ``Exponential(lam=2 / s_i)`` noise scale for each treated outcome, where
+        ``s_i`` is its sample standard deviation. A user-provided ``y_hat`` prior,
+        or a ``y_hat`` default declared by a subclass, takes precedence; so does
+        ``SyntheticControl(auto_scale_sigma=False)``, which leaves the legacy
         ``HalfNormal(1)`` prior in place.
 
         Unlike :meth:`WeightedSumFitter.priors_from_data`, the Normal logit prior
@@ -1000,11 +1011,7 @@ class SoftmaxWeightedSumFitter(PyMCModel):
                 dims=["treated_units", "coeffs_raw"],
             ),
         }
-        if (
-            type(self) is SoftmaxWeightedSumFitter
-            and self._auto_scale_sigma
-            and "y_hat" not in (self._user_priors or {})
-        ):
+        if _uses_stock_y_hat_default(self) and "y_hat" not in (self._user_priors or {}):
             priors["y_hat"] = _data_scaled_y_hat_prior(y)
         return priors
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -403,13 +403,15 @@ class PyMCModel(pm.Model):
         # sample_posterior_predictive() if provided in sample_kwargs.
         random_seed = self.sample_kwargs.get("random_seed", None)
 
-        # Rebuild effective priors for every fit so data-derived priors never
-        # leak into a later fit. User configuration always has final precedence.
+        # Rebuild the effective priors from scratch on every fit, so that a
+        # previous fit's data-derived priors cannot leak into this one. The
+        # configured state is restored first, which is also what the model is
+        # left in if priors_from_data rejects the data. Precedence is
+        # defaults -> data-derived -> user.
         self.priors = {**self.default_priors, **(self._user_priors or {})}
-        data_priors = self.priors_from_data(X, y)
         self.priors = {
             **self.default_priors,
-            **data_priors,
+            **self.priors_from_data(X, y),
             **(self._user_priors or {}),
         }
 

--- a/causalpy/skills/running-causalpy-experiments/reference/custom_priors.md
+++ b/causalpy/skills/running-causalpy-experiments/reference/custom_priors.md
@@ -1,6 +1,6 @@
 # Scale-Aware Custom Priors
 
-Use custom priors whenever CausalPy is fitting a PyMC model to predictors and outcomes that are not already on comparable, interpretable scales. Defaults are useful for examples, but a default such as `Normal(0, 50)` on coefficients or `HalfNormal(1)` on outcome noise can be too weak, too tight, or simply mismatched when outcomes are revenue, deaths, log-sales, percentages, or standardized scores.
+Use custom priors whenever CausalPy is fitting a PyMC model to predictors and outcomes that are not already on comparable, interpretable scales. Defaults are useful for examples, but a default such as `Normal(0, 50)` on coefficients or `HalfNormal(1)` on outcome noise can be too weak, too tight, or simply mismatched when outcomes are revenue, deaths, log-sales, percentages, or standardized scores. The synthetic-control weighted-sum fitters are the exception: their observation-noise default is derived from the data (see below).
 
 ## Basic Workflow
 
@@ -51,6 +51,15 @@ model = cp.pymc_models.WeightedSumFitter(
     }
 )
 ```
+
+### Observation noise is data-scaled by default
+
+`WeightedSumFitter` and `SoftmaxWeightedSumFitter` do not use a fixed noise prior. At fit time each treated unit *i* gets `sigma_i ~ Exponential(2 / s_i)`, where `s_i` is the standard deviation of that unit's pre-treatment outcome, giving `sigma_i` a prior mean of `s_i / 2`. This keeps the default weakly informative on outcomes of any magnitude, instead of fighting the data whenever the outcome's spread is much larger than 1. A unit whose pre-treatment series is constant (or has fewer than two observations) has no estimable spread, so it falls back to `s_i = 1` and warns.
+
+Two ways to take over:
+
+- Pass your own `y_hat` prior, as in the example above. An explicit prior always wins over the data-derived one.
+- Pass `cp.SyntheticControl(..., auto_scale_sigma=False)` to keep the pre-1.0 `HalfNormal(1)` default, for example when reproducing an older analysis. The experiment then fits a copy of your model with that prior pinned.
 
 `SoftmaxWeightedSumFitter` controls regularization through the scale of `beta_raw`. Smaller `sigma` pulls weights toward uniform; larger `sigma` lets weights concentrate on better-matching donors.
 

--- a/causalpy/skills/running-causalpy-experiments/reference/synthetic_control.md
+++ b/causalpy/skills/running-causalpy-experiments/reference/synthetic_control.md
@@ -12,6 +12,7 @@ cp.SyntheticControl(
     treated_units,
     model=None,
     min_donor_correlation=0.0,
+    auto_scale_sigma=True,
     **kwargs
 )
 ```
@@ -27,6 +28,8 @@ cp.SyntheticControl(
 ## Model Guidance
 
 The default PyMC model is `WeightedSumFitter`, which uses Dirichlet donor weights. Use `SoftmaxWeightedSumFitter` when you want logit-scale regularization over simplex weights. Sklearn regressors are also supported after adaptation. For donor-weight and likelihood priors, see [scale-aware custom priors](custom_priors.md).
+
+Both weighted-sum fitters derive their observation-noise prior from each treated unit's pre-treatment spread, so the outcome does not need to be standardized for the default to behave. `auto_scale_sigma=False` restores the pre-1.0 fixed `HalfNormal(1)` prior, which is what you want when reproducing an analysis run against an earlier release; expect posteriors to differ otherwise.
 
 ## Example
 

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -1,0 +1,162 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the ``auto_scale_sigma`` feature of :class:`SyntheticControl`.
+
+The feature replaces ``WeightedSumFitter``'s default ``sigma ~ HalfNormal(1)``
+prior with ``sigma ~ Exponential(2/s)``, where *s* is the pre-treatment standard
+deviation of the treated data, computed *per treated unit*.
+
+These assertions inspect the model's ``y_hat`` prior, which ``algorithm()`` sets
+before fitting, so they rely on ``mock_pymc_sample`` and never need real MCMC.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+from pymc_extras.prior import Prior
+
+import causalpy as cp
+from causalpy.pymc_models import WeightedSumFitter
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
+
+
+def _make_data(treated_scales, n=60, treatment_time=45, seed=42):
+    """Build a synthetic-control dataset with one treated column per entry in
+    ``treated_scales``.
+
+    A bespoke builder is used here (rather than ``cp.load_data("sc")``) because
+    these tests need treated units on deliberately different scales, and a
+    constant pre-treatment series — cases the canned ``sc`` dataset cannot
+    express. Each treated unit is the control mean scaled by its factor, so
+    units can be placed orders of magnitude apart on demand.
+    """
+    rng = np.random.default_rng(seed)
+    controls = {
+        c: rng.normal(10, 2, n).cumsum() / 10 + rng.normal(0, 1, n)
+        for c in ["a", "b", "c"]
+    }
+    df = pd.DataFrame(controls)
+    base = df[["a", "b", "c"]].mean(axis=1)
+    treated_units = []
+    for i, scale in enumerate(treated_scales):
+        name = f"treated_{i}"
+        df[name] = scale * base + rng.normal(0, scale, n)
+        treated_units.append(name)
+    return df, treatment_time, treated_units
+
+
+def _sigma_prior(result):
+    """Return the inner ``sigma`` Prior of the model's ``y_hat`` prior."""
+    return result.model.priors["y_hat"].parameters["sigma"]
+
+
+def _fitter():
+    return WeightedSumFitter(sample_kwargs={**sample_kwargs, "random_seed": 1})
+
+
+def _expected_lam(df, treatment_time, treated_units):
+    """Independently compute 2/s per unit with pandas over the pre-treatment
+    rows (``index < treatment_time``), to cross-check the xarray-based impl."""
+    pre = df[df.index < treatment_time][treated_units]
+    return (2 / pre.std(ddof=1)).values
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_auto_scale_sets_exponential_prior_matching_2_over_s(mock_pymc_sample):
+    """After fit, the y_hat sigma prior is Exponential with lam = 2/s."""
+    df, tt, treated = _make_data([1.0])
+    result = cp.SyntheticControl(
+        df, tt, control_units=["a", "b", "c"], treated_units=treated, model=_fitter()
+    )
+    sigma = _sigma_prior(result)
+    assert sigma.distribution == "Exponential"
+    np.testing.assert_allclose(
+        np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample):
+    """auto_scale_sigma=False leaves the HalfNormal(1) default untouched."""
+    df, tt, treated = _make_data([1.0])
+    result = cp.SyntheticControl(
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(),
+        auto_scale_sigma=False,
+    )
+    sigma = _sigma_prior(result)
+    assert sigma.distribution == "HalfNormal"
+    assert sigma.parameters["sigma"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample):
+    """An explicit y_hat prior disables auto-scaling (guard not triggered)."""
+    df, tt, treated = _make_data([1.0])
+    custom = Prior(
+        "Normal",
+        sigma=Prior("HalfNormal", sigma=42, dims=["treated_units"]),
+        dims=["obs_ind", "treated_units"],
+    )
+    model = WeightedSumFitter(
+        sample_kwargs={**sample_kwargs, "random_seed": 1}, priors={"y_hat": custom}
+    )
+    result = cp.SyntheticControl(
+        df, tt, control_units=["a", "b", "c"], treated_units=treated, model=model
+    )
+    sigma = _sigma_prior(result)
+    # Untouched: still the user's HalfNormal(42), not the auto Exponential.
+    assert sigma.distribution == "HalfNormal"
+    assert sigma.parameters["sigma"] == 42
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_multiple_treated_units_get_per_unit_lam(mock_pymc_sample):
+    """With multiple treated units on different scales, lam is a per-unit vector
+    of 2/s_i — not a single broadcast scalar."""
+    df, tt, treated = _make_data([1.0, 100.0])  # two units, ~100x apart in scale
+    result = cp.SyntheticControl(
+        df, tt, control_units=["a", "b", "c"], treated_units=treated, model=_fitter()
+    )
+    lam = np.asarray(_sigma_prior(result).parameters["lam"])
+    assert lam.shape == (2,)
+    np.testing.assert_allclose(lam, _expected_lam(df, tt, treated))
+    # The two rates must genuinely differ; a shared scalar would fail this.
+    assert not np.isclose(lam[0], lam[1])
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_constant_pre_treatment_series_raises(mock_pymc_sample):
+    """A zero/undefined per-unit std raises a clear error rather than producing
+    an infinite Exponential rate."""
+    df, tt, treated = _make_data([1.0, 1.0])
+    df["treated_0"] = 5.0  # constant pre-treatment -> std == 0 for this unit
+    with pytest.raises(ValueError, match="auto-scale the sigma prior"):
+        cp.SyntheticControl(
+            df,
+            tt,
+            control_units=["a", "b", "c"],
+            treated_units=treated,
+            model=_fitter(),
+        )

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -27,9 +27,13 @@ import pytest
 from pymc_extras.prior import Prior
 
 import causalpy as cp
-from causalpy.pymc_models import WeightedSumFitter
+from causalpy.pymc_models import SoftmaxWeightedSumFitter, WeightedSumFitter
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
+
+# Both weighted-sum fitters share the same per-treated-unit ``y_hat`` sigma prior,
+# so auto-scaling must behave identically for each.
+FITTERS = [WeightedSumFitter, SoftmaxWeightedSumFitter]
 
 
 def _make_data(treated_scales, n=60, treatment_time=45, seed=42):
@@ -62,8 +66,8 @@ def _sigma_prior(result):
     return result.model.priors["y_hat"].parameters["sigma"]
 
 
-def _fitter():
-    return WeightedSumFitter(sample_kwargs={**sample_kwargs, "random_seed": 1})
+def _fitter(cls=WeightedSumFitter, **kwargs):
+    return cls(sample_kwargs={**sample_kwargs, "random_seed": 1}, **kwargs)
 
 
 def _expected_lam(df, treatment_time, treated_units):
@@ -75,11 +79,18 @@ def _expected_lam(df, treatment_time, treated_units):
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_auto_scale_sets_exponential_prior_matching_2_over_s(mock_pymc_sample):
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_auto_scale_sets_exponential_prior_matching_2_over_s(
+    mock_pymc_sample, fitter_cls
+):
     """After fit, the y_hat sigma prior is Exponential with lam = 2/s."""
     df, tt, treated = _make_data([1.0])
     result = cp.SyntheticControl(
-        df, tt, control_units=["a", "b", "c"], treated_units=treated, model=_fitter()
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(fitter_cls),
     )
     sigma = _sigma_prior(result)
     assert sigma.distribution == "Exponential"
@@ -90,7 +101,8 @@ def test_auto_scale_sets_exponential_prior_matching_2_over_s(mock_pymc_sample):
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample):
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample, fitter_cls):
     """auto_scale_sigma=False leaves the HalfNormal(1) default untouched."""
     df, tt, treated = _make_data([1.0])
     result = cp.SyntheticControl(
@@ -98,7 +110,7 @@ def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample):
         tt,
         control_units=["a", "b", "c"],
         treated_units=treated,
-        model=_fitter(),
+        model=_fitter(fitter_cls),
         auto_scale_sigma=False,
     )
     sigma = _sigma_prior(result)
@@ -108,7 +120,8 @@ def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample):
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample):
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample, fitter_cls):
     """An explicit y_hat prior disables auto-scaling (guard not triggered)."""
     df, tt, treated = _make_data([1.0])
     custom = Prior(
@@ -116,9 +129,7 @@ def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample):
         sigma=Prior("HalfNormal", sigma=42, dims=["treated_units"]),
         dims=["obs_ind", "treated_units"],
     )
-    model = WeightedSumFitter(
-        sample_kwargs={**sample_kwargs, "random_seed": 1}, priors={"y_hat": custom}
-    )
+    model = _fitter(fitter_cls, priors={"y_hat": custom})
     result = cp.SyntheticControl(
         df, tt, control_units=["a", "b", "c"], treated_units=treated, model=model
     )
@@ -130,12 +141,17 @@ def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample):
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
-def test_multiple_treated_units_get_per_unit_lam(mock_pymc_sample):
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_multiple_treated_units_get_per_unit_lam(mock_pymc_sample, fitter_cls):
     """With multiple treated units on different scales, lam is a per-unit vector
     of 2/s_i — not a single broadcast scalar."""
     df, tt, treated = _make_data([1.0, 100.0])  # two units, ~100x apart in scale
     result = cp.SyntheticControl(
-        df, tt, control_units=["a", "b", "c"], treated_units=treated, model=_fitter()
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(fitter_cls),
     )
     lam = np.asarray(_sigma_prior(result).parameters["lam"])
     assert lam.shape == (2,)
@@ -147,7 +163,8 @@ def test_multiple_treated_units_get_per_unit_lam(mock_pymc_sample):
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
-def test_constant_pre_treatment_series_raises(mock_pymc_sample):
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_constant_pre_treatment_series_raises(mock_pymc_sample, fitter_cls):
     """A zero/undefined per-unit std raises a clear error rather than producing
     an infinite Exponential rate."""
     df, tt, treated = _make_data([1.0, 1.0])
@@ -158,5 +175,5 @@ def test_constant_pre_treatment_series_raises(mock_pymc_sample):
             tt,
             control_units=["a", "b", "c"],
             treated_units=treated,
-            model=_fitter(),
+            model=_fitter(fitter_cls),
         )

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -15,7 +15,9 @@
 
 The feature replaces the stock fitters' ``sigma ~ HalfNormal(1)`` likelihood
 prior with ``sigma ~ Exponential(2/s)``, where *s* is the pre-treatment
-standard deviation of the treated data, computed *per treated unit*.
+standard deviation of the treated data, computed *per treated unit*. A unit whose
+spread cannot be estimated falls back to ``s = 1`` with a warning, so data that
+fitted under the legacy default keeps fitting.
 
 The tests use ``mock_pymc_sample`` where model construction is needed and never
 run real MCMC.
@@ -181,8 +183,8 @@ def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample, fitter_
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("fitter_cls", FITTERS)
-def test_auto_scale_false_skips_invalid_default_scale(mock_pymc_sample, fitter_cls):
-    """The legacy opt-out does not reject a constant treated pre-period."""
+def test_auto_scale_false_skips_scale_estimation(mock_pymc_sample, fitter_cls):
+    """The legacy opt-out never inspects a constant treated pre-period."""
     df, tt, treated = _make_data([1.0])
     df["treated_0"] = 5.0
     result = cp.SyntheticControl(
@@ -196,6 +198,27 @@ def test_auto_scale_false_skips_invalid_default_scale(mock_pymc_sample, fitter_c
     sigma = _sigma_prior(result)
     assert sigma.distribution == "HalfNormal"
     assert sigma.parameters["sigma"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_constant_treated_series_still_fits_with_auto_scaling(
+    mock_pymc_sample, fitter_cls
+):
+    """A constant treated pre-period fits as it did before data scaling."""
+    df, tt, treated = _make_data([1.0])
+    df["treated_0"] = 5.0
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment"):
+        result = cp.SyntheticControl(
+            df,
+            tt,
+            control_units=["a", "b", "c"],
+            treated_units=treated,
+            model=_fitter(fitter_cls),
+        )
+    sigma = _sigma_prior(result)
+    assert sigma.distribution == "Exponential"
+    assert np.asarray(sigma.parameters["lam"]) == 2.0
 
 
 @pytest.mark.integration
@@ -309,40 +332,49 @@ def test_reused_model_recomputes_the_auto_scale(mock_pymc_sample, fitter_cls):
 
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
-@pytest.mark.parametrize(
-    "invalid_kind",
-    ["constant", "single_observation", "nan", "infinite"],
-)
-def test_invalid_treated_outcome_scales_raise_actionable_error(
-    fitter_cls, invalid_kind
-):
-    """Every non-finite or non-positive per-unit scale is rejected before fit."""
-    if invalid_kind == "single_observation":
-        df, tt, treated = _make_data([1.0], n=2, treatment_time=1)
-    else:
-        df, tt, treated = _make_data([1.0, 10.0])
-        if invalid_kind == "constant":
-            df["treated_0"] = 5.0
-        elif invalid_kind == "nan":
-            df.loc[0, "treated_0"] = np.nan
-        else:
-            df.loc[0, "treated_0"] = np.inf
+@pytest.mark.parametrize("invalid_kind", ["nan", "infinite"])
+def test_non_finite_treated_outcome_raises_actionable_error(fitter_cls, invalid_kind):
+    """A non-finite treated outcome is a data error and is rejected before fit."""
+    df, tt, treated = _make_data([1.0, 10.0])
+    df.loc[0, "treated_0"] = np.nan if invalid_kind == "nan" else np.inf
     X, y = _pre_treatment_design(df, tt, treated)
-    with pytest.raises(ValueError, match="finite and positive") as error:
+    with pytest.raises(ValueError, match="non-finite values") as error:
         _fitter(fitter_cls).priors_from_data(X, y)
     assert "treated_1" not in str(error.value)
     assert "treated_0" in str(error.value)
 
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
-def test_dimension_only_invalid_scale_uses_index_label(fitter_cls):
+@pytest.mark.parametrize("degenerate_kind", ["constant", "single_observation"])
+def test_unestimable_scale_warns_and_falls_back_per_unit(fitter_cls, degenerate_kind):
+    """A unit with no estimable spread keeps the legacy scale; others do not."""
+    if degenerate_kind == "single_observation":
+        df, tt, treated = _make_data([1.0], n=2, treatment_time=1)
+    else:
+        df, tt, treated = _make_data([1.0, 10.0])
+        df["treated_0"] = 5.0
+    X, y = _pre_treatment_design(df, tt, treated)
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment") as record:
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    message = str(record[0].message)
+    assert "treated_0" in message
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    assert lam[0] == 2.0
+    if degenerate_kind == "constant":
+        # The healthy unit keeps its own data-derived rate.
+        assert "treated_1" not in message
+        np.testing.assert_allclose(lam[1], _expected_lam(df, tt, treated)[1])
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_dimension_only_degenerate_scale_uses_index_label(fitter_cls):
     """Dimension-only outcomes report their generated treated-unit index."""
     df, tt, treated = _make_data([1.0])
     X, y = _pre_treatment_design(df, tt, treated)
     y = xr.DataArray(np.ones_like(y.values), dims=["obs_ind", "treated_units"])
-    with pytest.raises(ValueError, match="finite and positive") as error:
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment") as record:
         _fitter(fitter_cls).priors_from_data(X, y)
-    assert "'0'" in str(error.value)
+    assert "'0'" in str(record[0].message)
 
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
@@ -381,16 +413,16 @@ def test_subclass_default_y_hat_prior_is_not_auto_overridden(fitter_cls):
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
 @pytest.mark.parametrize(
-    ("scale", "raises"),
+    ("scale", "falls_back"),
     [
         (np.finfo(float).tiny / 2, True),
         (np.finfo(float).max, False),
     ],
 )
 def test_finite_scale_rate_boundaries_are_checked(
-    monkeypatch, fitter_cls, scale, raises
+    monkeypatch, fitter_cls, scale, falls_back
 ):
-    """Rate overflow is rejected while the smallest finite rate remains valid."""
+    """A subnormal spread overflows its rate and falls back; a huge one does not."""
     df, tt, treated = _make_data([1.0])
     X, y = _pre_treatment_design(df, tt, treated)
     monkeypatch.setattr(
@@ -398,9 +430,10 @@ def test_finite_scale_rate_boundaries_are_checked(
         "std",
         lambda *_args, **_kwargs: np.array([scale]),
     )
-    if raises:
-        with pytest.raises(ValueError, match="finite and positive"):
-            _fitter(fitter_cls).priors_from_data(X, y)
+    if falls_back:
+        with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment"):
+            priors = _fitter(fitter_cls).priors_from_data(X, y)
+        assert np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"]) == 2.0
     else:
         sigma = _fitter(fitter_cls).priors_from_data(X, y)["y_hat"].parameters["sigma"]
         rate = np.asarray(sigma.parameters["lam"])

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -30,7 +30,6 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
-from causalpy.experiments.model_adapter import PyMCModelAdapter
 from causalpy.pymc_models import SoftmaxWeightedSumFitter, WeightedSumFitter
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
@@ -394,7 +393,7 @@ def test_user_y_hat_prior_bypasses_invalid_scale_calculation(fitter_cls):
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
 def test_subclass_default_y_hat_prior_is_not_auto_overridden(fitter_cls):
-    """Only stock fitter defaults are eligible for automatic scaling."""
+    """A subclass that declares its own noise default has already chosen one."""
     df, tt, treated = _make_data([1.0])
     X, y = _pre_treatment_design(df, tt, treated)
     custom = Prior(
@@ -409,6 +408,19 @@ def test_subclass_default_y_hat_prior_is_not_auto_overridden(fitter_cls):
     )
     priors = custom_fitter().priors_from_data(X, y)
     assert "y_hat" not in priors
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_subclass_inheriting_the_stock_default_is_auto_scaled(fitter_cls):
+    """A subclass that leaves the noise default alone is still scaled."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    subclass = type("SubclassedFitter", (fitter_cls,), {})
+    sigma = subclass().priors_from_data(X, y)["y_hat"].parameters["sigma"]
+    assert sigma.distribution == "Exponential"
+    np.testing.assert_allclose(
+        np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
+    )
 
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
@@ -441,37 +453,43 @@ def test_finite_scale_rate_boundaries_are_checked(
         assert np.all(rate > 0)
 
 
+@pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("fitter_cls", FITTERS)
-def test_opt_out_cleans_fit_local_policy_after_fit_error(monkeypatch, fitter_cls):
-    """A failed opt-out fit leaves no private policy on either model instance."""
+def test_opt_out_survives_refit_and_cloning(mock_pymc_sample, fitter_cls):
+    """The opt-out is carried by the model, so later fits keep the legacy prior."""
+    df, tt, treated = _make_data([1.0])
+    result = cp.SyntheticControl(
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(fitter_cls),
+        auto_scale_sigma=False,
+    )
+    X, y = _pre_treatment_design(*_make_data([100.0]))
+    refitted = result.model._clone()
+    refitted.fit(X, y)
+    sigma = refitted.priors["y_hat"].parameters["sigma"]
+    assert sigma.distribution == "HalfNormal"
+    assert sigma.parameters["sigma"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_opt_out_leaves_the_callers_model_untouched(mock_pymc_sample, fitter_cls):
+    """Opting out fits a copy, so the caller's own instance is not reconfigured."""
     df, tt, treated = _make_data([1.0])
     source_model = _fitter(fitter_cls)
-    clones = []
-    original_clone = fitter_cls._clone
-
-    def capture_clone(self):
-        clone = original_clone(self)
-        clones.append(clone)
-        return clone
-
-    def fail_fit(self, X, y, *, coords=None):
-        raise RuntimeError("fit failed")
-
-    monkeypatch.setattr(fitter_cls, "_clone", capture_clone)
-    monkeypatch.setattr(PyMCModelAdapter, "fit", fail_fit)
-    with pytest.raises(RuntimeError, match="fit failed"):
-        cp.SyntheticControl(
-            df,
-            tt,
-            control_units=["a", "b", "c"],
-            treated_units=treated,
-            model=source_model,
-            auto_scale_sigma=False,
-        )
-    assert len(clones) == 1
-    assert "_auto_scale_sigma" not in clones[0].__dict__
-    assert "_auto_scale_sigma" not in source_model.__dict__
-    assert source_model.priors["y_hat"].parameters["sigma"].distribution == (
-        "HalfNormal"
+    result = cp.SyntheticControl(
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=source_model,
+        auto_scale_sigma=False,
     )
+    assert result.model is not source_model
+    assert source_model._user_priors is None
+    assert source_model.idata is None

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -13,20 +13,22 @@
 #   limitations under the License.
 """Tests for the ``auto_scale_sigma`` feature of :class:`SyntheticControl`.
 
-The feature replaces ``WeightedSumFitter``'s default ``sigma ~ HalfNormal(1)``
-prior with ``sigma ~ Exponential(2/s)``, where *s* is the pre-treatment standard
-deviation of the treated data, computed *per treated unit*.
+The feature replaces the stock fitters' ``sigma ~ HalfNormal(1)`` likelihood
+prior with ``sigma ~ Exponential(2/s)``, where *s* is the pre-treatment
+standard deviation of the treated data, computed *per treated unit*.
 
-These assertions inspect the model's ``y_hat`` prior, which ``algorithm()`` sets
-before fitting, so they rely on ``mock_pymc_sample`` and never need real MCMC.
+The tests use ``mock_pymc_sample`` where model construction is needed and never
+run real MCMC.
 """
 
 import numpy as np
 import pandas as pd
 import pytest
+import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
+from causalpy.experiments.model_adapter import PyMCModelAdapter
 from causalpy.pymc_models import SoftmaxWeightedSumFitter, WeightedSumFitter
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
@@ -77,6 +79,22 @@ def _expected_lam(df, treatment_time, treated_units):
     return (2 / pre.std(ddof=1)).values
 
 
+def _pre_treatment_design(df, treatment_time, treated_units):
+    """Return labeled pre-treatment control and treated arrays."""
+    pre = df[df.index < treatment_time]
+    X = xr.DataArray(
+        pre[["a", "b", "c"]].to_numpy(),
+        dims=["obs_ind", "coeffs"],
+        coords={"obs_ind": pre.index, "coeffs": ["a", "b", "c"]},
+    )
+    y = xr.DataArray(
+        pre[treated_units].to_numpy(),
+        dims=["obs_ind", "treated_units"],
+        coords={"obs_ind": pre.index, "treated_units": treated_units},
+    )
+    return X, y
+
+
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
 @pytest.mark.parametrize("fitter_cls", FITTERS)
@@ -85,19 +103,62 @@ def test_auto_scale_sets_exponential_prior_matching_2_over_s(
 ):
     """After fit, the y_hat sigma prior is Exponential with lam = 2/s."""
     df, tt, treated = _make_data([1.0])
+    model = _fitter(fitter_cls)
     result = cp.SyntheticControl(
         df,
         tt,
         control_units=["a", "b", "c"],
         treated_units=treated,
-        model=_fitter(fitter_cls),
+        model=model,
     )
     sigma = _sigma_prior(result)
     assert sigma.distribution == "Exponential"
     np.testing.assert_allclose(
         np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
     )
+    assert result.model is model
 
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_direct_fit_consumes_data_scaled_prior(mock_pymc_sample, fitter_cls):
+    """The fitter-level prior is used when a stock fitter is fit directly."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    model = _fitter(fitter_cls)
+    model.fit(
+        X,
+        y,
+        coords={
+            "obs_ind": X.obs_ind.values,
+            "coeffs": X.coeffs.values,
+            "treated_units": y.treated_units.values,
+        },
+    )
+    sigma = model.priors["y_hat"].parameters["sigma"]
+    assert sigma.distribution == "Exponential"
+    np.testing.assert_allclose(
+        np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
+    )
+
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_direct_fit_accepts_dimension_only_treated_outcomes(
+    mock_pymc_sample, fitter_cls
+):
+    """Direct fitting supports a treated-units dimension without labels."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    y = xr.DataArray(y.values, dims=["obs_ind", "treated_units"])
+    model = _fitter(fitter_cls)
+    model.fit(X, y)
+    sigma = model.priors["y_hat"].parameters["sigma"]
+    np.testing.assert_allclose(
+        np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
+    )
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -105,6 +166,26 @@ def test_auto_scale_sets_exponential_prior_matching_2_over_s(
 def test_auto_scale_false_preserves_halfnormal_default(mock_pymc_sample, fitter_cls):
     """auto_scale_sigma=False leaves the HalfNormal(1) default untouched."""
     df, tt, treated = _make_data([1.0])
+    result = cp.SyntheticControl(
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(fitter_cls),
+        auto_scale_sigma=False,
+    )
+    sigma = _sigma_prior(result)
+    assert sigma.distribution == "HalfNormal"
+    assert sigma.parameters["sigma"] == 1
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_auto_scale_false_skips_invalid_default_scale(mock_pymc_sample, fitter_cls):
+    """The legacy opt-out does not reject a constant treated pre-period."""
+    df, tt, treated = _make_data([1.0])
+    df["treated_0"] = 5.0
     result = cp.SyntheticControl(
         df,
         tt,
@@ -137,6 +218,9 @@ def test_user_supplied_y_hat_prior_is_respected(mock_pymc_sample, fitter_cls):
     # Untouched: still the user's HalfNormal(42), not the auto Exponential.
     assert sigma.distribution == "HalfNormal"
     assert sigma.parameters["sigma"] == 42
+    assert model.priors["y_hat"] is custom
+    assert result.model._user_priors == {"y_hat": custom}
+    assert result.model is model
 
 
 @pytest.mark.integration
@@ -162,18 +246,202 @@ def test_multiple_treated_units_get_per_unit_lam(mock_pymc_sample, fitter_cls):
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
-@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 @pytest.mark.parametrize("fitter_cls", FITTERS)
-def test_constant_pre_treatment_series_raises(mock_pymc_sample, fitter_cls):
-    """A zero/undefined per-unit std raises a clear error rather than producing
-    an infinite Exponential rate."""
-    df, tt, treated = _make_data([1.0, 1.0])
-    df["treated_0"] = 5.0  # constant pre-treatment -> std == 0 for this unit
-    with pytest.raises(ValueError, match="auto-scale the sigma prior"):
+def test_reused_model_does_not_carry_auto_scaled_prior_into_opt_out(
+    mock_pymc_sample, fitter_cls
+):
+    """A scaled fit cannot turn a later opt-out fit into an Exponential prior."""
+    first_df, tt, treated = _make_data([1.0])
+    source_model = _fitter(fitter_cls)
+    first = cp.SyntheticControl(
+        first_df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=source_model,
+    )
+    second_df, _, _ = _make_data([100.0])
+    second = cp.SyntheticControl(
+        second_df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=first.model,
+        auto_scale_sigma=False,
+    )
+    second_sigma = _sigma_prior(second)
+    assert second_sigma.distribution == "HalfNormal"
+    assert second_sigma.parameters["sigma"] == 1
+    assert first.model is source_model
+    assert source_model.priors["y_hat"].parameters["sigma"].distribution == (
+        "Exponential"
+    )
+    assert second.model is not source_model
+    assert source_model._clone().priors["y_hat"].parameters["sigma"].distribution == (
+        "HalfNormal"
+    )
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_reused_model_recomputes_the_auto_scale(mock_pymc_sample, fitter_cls):
+    """A cloned model derives its next prior from the next treated outcome."""
+    first_df, tt, treated = _make_data([1.0])
+    first = cp.SyntheticControl(
+        first_df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=_fitter(fitter_cls),
+    )
+    second_df, _, _ = _make_data([100.0])
+    second = cp.SyntheticControl(
+        second_df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=first.model._clone(),
+    )
+    first_lam = np.asarray(_sigma_prior(first).parameters["lam"])
+    second_lam = np.asarray(_sigma_prior(second).parameters["lam"])
+    np.testing.assert_allclose(second_lam, _expected_lam(second_df, tt, treated))
+    assert not np.isclose(first_lam[0], second_lam[0])
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+@pytest.mark.parametrize(
+    "invalid_kind",
+    ["constant", "single_observation", "nan", "infinite"],
+)
+def test_invalid_treated_outcome_scales_raise_actionable_error(
+    fitter_cls, invalid_kind
+):
+    """Every non-finite or non-positive per-unit scale is rejected before fit."""
+    if invalid_kind == "single_observation":
+        df, tt, treated = _make_data([1.0], n=2, treatment_time=1)
+    else:
+        df, tt, treated = _make_data([1.0, 10.0])
+        if invalid_kind == "constant":
+            df["treated_0"] = 5.0
+        elif invalid_kind == "nan":
+            df.loc[0, "treated_0"] = np.nan
+        else:
+            df.loc[0, "treated_0"] = np.inf
+    X, y = _pre_treatment_design(df, tt, treated)
+    with pytest.raises(ValueError, match="finite and positive") as error:
+        _fitter(fitter_cls).priors_from_data(X, y)
+    assert "treated_1" not in str(error.value)
+    assert "treated_0" in str(error.value)
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_dimension_only_invalid_scale_uses_index_label(fitter_cls):
+    """Dimension-only outcomes report their generated treated-unit index."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    y = xr.DataArray(np.ones_like(y.values), dims=["obs_ind", "treated_units"])
+    with pytest.raises(ValueError, match="finite and positive") as error:
+        _fitter(fitter_cls).priors_from_data(X, y)
+    assert "'0'" in str(error.value)
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_user_y_hat_prior_bypasses_invalid_scale_calculation(fitter_cls):
+    """An explicit likelihood prior wins before invalid default scales are read."""
+    df, tt, treated = _make_data([1.0])
+    df["treated_0"] = 5.0
+    X, y = _pre_treatment_design(df, tt, treated)
+    custom = Prior(
+        "Normal",
+        sigma=Prior("HalfNormal", sigma=42, dims=["treated_units"]),
+        dims=["obs_ind", "treated_units"],
+    )
+    priors = _fitter(fitter_cls, priors={"y_hat": custom}).priors_from_data(X, y)
+    assert "y_hat" not in priors
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_subclass_default_y_hat_prior_is_not_auto_overridden(fitter_cls):
+    """Only stock fitter defaults are eligible for automatic scaling."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    custom = Prior(
+        "Normal",
+        sigma=Prior("HalfNormal", sigma=42, dims=["treated_units"]),
+        dims=["obs_ind", "treated_units"],
+    )
+    custom_fitter = type(
+        "CustomFitter",
+        (fitter_cls,),
+        {"default_priors": {"y_hat": custom}},
+    )
+    priors = custom_fitter().priors_from_data(X, y)
+    assert "y_hat" not in priors
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+@pytest.mark.parametrize(
+    ("scale", "raises"),
+    [
+        (np.finfo(float).tiny / 2, True),
+        (np.finfo(float).max, False),
+    ],
+)
+def test_finite_scale_rate_boundaries_are_checked(
+    monkeypatch, fitter_cls, scale, raises
+):
+    """Rate overflow is rejected while the smallest finite rate remains valid."""
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    monkeypatch.setattr(
+        np,
+        "std",
+        lambda *_args, **_kwargs: np.array([scale]),
+    )
+    if raises:
+        with pytest.raises(ValueError, match="finite and positive"):
+            _fitter(fitter_cls).priors_from_data(X, y)
+    else:
+        sigma = _fitter(fitter_cls).priors_from_data(X, y)["y_hat"].parameters[
+            "sigma"
+        ]
+        rate = np.asarray(sigma.parameters["lam"])
+        assert np.all(np.isfinite(rate))
+        assert np.all(rate > 0)
+
+
+@pytest.mark.filterwarnings("ignore::UserWarning")
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_opt_out_cleans_fit_local_policy_after_fit_error(monkeypatch, fitter_cls):
+    """A failed opt-out fit leaves no private policy on either model instance."""
+    df, tt, treated = _make_data([1.0])
+    source_model = _fitter(fitter_cls)
+    clones = []
+    original_clone = fitter_cls._clone
+
+    def capture_clone(self):
+        clone = original_clone(self)
+        clones.append(clone)
+        return clone
+
+    def fail_fit(self, X, y, *, coords=None):
+        raise RuntimeError("fit failed")
+
+    monkeypatch.setattr(fitter_cls, "_clone", capture_clone)
+    monkeypatch.setattr(PyMCModelAdapter, "fit", fail_fit)
+    with pytest.raises(RuntimeError, match="fit failed"):
         cp.SyntheticControl(
             df,
             tt,
             control_units=["a", "b", "c"],
             treated_units=treated,
-            model=_fitter(fitter_cls),
+            model=source_model,
+            auto_scale_sigma=False,
         )
+    assert len(clones) == 1
+    assert "_auto_scale_sigma" not in clones[0].__dict__
+    assert "_auto_scale_sigma" not in source_model.__dict__
+    assert source_model.priors["y_hat"].parameters["sigma"].distribution == (
+        "HalfNormal"
+    )

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -119,7 +119,6 @@ def test_auto_scale_sets_exponential_prior_matching_2_over_s(
     assert result.model is model
 
 
-
 @pytest.mark.integration
 @pytest.mark.parametrize("fitter_cls", FITTERS)
 def test_direct_fit_consumes_data_scaled_prior(mock_pymc_sample, fitter_cls):
@@ -143,7 +142,6 @@ def test_direct_fit_consumes_data_scaled_prior(mock_pymc_sample, fitter_cls):
     )
 
 
-
 @pytest.mark.integration
 @pytest.mark.parametrize("fitter_cls", FITTERS)
 def test_direct_fit_accepts_dimension_only_treated_outcomes(
@@ -159,6 +157,7 @@ def test_direct_fit_accepts_dimension_only_treated_outcomes(
     np.testing.assert_allclose(
         np.asarray(sigma.parameters["lam"]), _expected_lam(df, tt, treated)
     )
+
 
 @pytest.mark.integration
 @pytest.mark.filterwarnings("ignore::UserWarning")
@@ -403,9 +402,7 @@ def test_finite_scale_rate_boundaries_are_checked(
         with pytest.raises(ValueError, match="finite and positive"):
             _fitter(fitter_cls).priors_from_data(X, y)
     else:
-        sigma = _fitter(fitter_cls).priors_from_data(X, y)["y_hat"].parameters[
-            "sigma"
-        ]
+        sigma = _fitter(fitter_cls).priors_from_data(X, y)["y_hat"].parameters["sigma"]
         rate = np.asarray(sigma.parameters["lam"])
         assert np.all(np.isfinite(rate))
         assert np.all(rate > 0)


### PR DESCRIPTION
## Summary
- Derive each stock `WeightedSumFitter` and `SoftmaxWeightedSumFitter` `y_hat` noise prior from its treated outcome's pre-treatment sample standard deviation: `Exponential(lam=2/s_i)`.
- Rebuild effective priors on every fit in strict `default -> data-derived -> user` order, preserving explicit `y_hat` overrides and preventing derived-prior reuse.
- Keep `SyntheticControl(auto_scale_sigma=False)` as a fit-local legacy `HalfNormal(1)` opt-out; reject non-finite, zero, or rate-invalid scales with treated-unit diagnostics.
- Add focused no-MCMC behavioral coverage for both fitters, direct fitting, multiple treated units, overrides, opt-out, cloning/reuse, invalid and dimension-only inputs, rate boundaries, and failure cleanup.

## Contributor attribution and replacement
This same-repository PR supersedes, but does **not** close or modify, contributor PR #976 from @szego. It preserves @szego's authored implementation commits (`76bd144`, `f9efa02`, `5e8858e`, and `8b67dea`) as rebased/cherry-picked commits with original authorship.

## Notebook decision
The three large notebook-output diffs from #976 are intentionally excluded. They were generated before the transition's PyMC 6 / ArviZ 1 notebook refresh and are not authoritative against this base. No MCMC notebooks were executed here; coordinator final QA should re-execute affected stock-fitter notebooks serially after source validation.

Closes #887.