### PR TITLE
chore: fix the diff-cover exclude pattern for test files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,10 @@ PACKAGE_DIR = causalpy
 
 DIFF_COVER_COMPARE_BRANCH ?= $(shell if git show-ref --verify --quiet refs/remotes/upstream/main; then printf "upstream/main"; else printf "origin/main"; fi)
 DIFF_COVER_FAIL_UNDER ?= 96
-DIFF_COVER_EXCLUDE ?= causalpy/tests/*
+# diff-cover (10.3.0, 10.4.1) matches exclude patterns against the basename
+# and then the absolute path, never the repo-relative path. The pattern goes
+# through fnmatch, so a checkout path containing [ ? or * disables it.
+DIFF_COVER_EXCLUDE ?= $(CURDIR)/$(PACKAGE_DIR)/tests/*
 
 init: ## Install the package in editable mode
 	python -m pip install -e . --no-deps


### PR DESCRIPTION
Closes #1115.

diff-cover matches an exclude pattern against the file basename and then the absolute path, never the repo-relative path (checked on 10.3.0 and 10.4.1, `diff_reporter.py`, `_is_path_excluded`). `causalpy/tests/*` matches neither, so `make test-patch-cov` has always counted test files, and the number it prints is not the one the Makefile says it computes. Test files usually pull it up, since they run end to end, so poorly covered source can pass the threshold. `CONTRIBUTING.md` and `AGENTS.md` both already describe the gate as excluding `causalpy/tests/*`, which this makes true.

`$(CURDIR)/$(PACKAGE_DIR)/tests/*` matches the absolute path exactly. A leading-wildcard form such as `*/causalpy/tests/*` also works in the normal case, but `fnmatch` lets `*` cross slashes, so it excludes the whole diff for any checkout sitting under a matching path, and diff-cover then prints "No lines with coverage information in this diff" and exits 0 under `--fail-under`. Anchoring at `CURDIR` rules that out, and `CURDIR` is the physical path even when the checkout is entered through a symlink, so it lines up with `os.path.abspath`.

The anchored form has one limit, noted in the comment: the pattern still goes through `fnmatch`, so a checkout path containing `[`, `?` or `*` disables the exclusion. That degrades to the current behavior on `main` rather than to a gate that measures nothing, which is why I kept the anchor.

Reproduction, throwaway repo with one source file and one test file changed and a matching `coverage.xml`:

```
--exclude 'causalpy/tests/*'        Total: 6 lines, Coverage: 83%  (test file counted)
--exclude "$PWD/causalpy/tests/*"   Total: 2 lines, Coverage: 50%  (source only)
```

No CI change, since no workflow calls this target.
