### PR TITLE
fix: doctest sampling leak — apply the mock at its root cause, guard the cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,13 @@ jobs:
               )
           PY
       - name: Run doctests
-        run: pytest --doctest-modules --ignore=causalpy/tests/ causalpy/ --config-file=causalpy/tests/conftest.py --no-cov
+        # -p causalpy.tests.doctest_sampling loads the plugin that mocks
+        # pm.sample for doctests (an autouse fixture in causalpy/tests/conftest.py
+        # cannot reach doctests collected from causalpy/*.py) and that fails the
+        # leg fast if a doctest ever reaches the real MCMC sampler. The old
+        # --config-file=causalpy/tests/conftest.py pointed pytest's rootdir at
+        # causalpy/tests (a .py file carries no ini config), so it is dropped.
+        run: pytest --doctest-modules -p causalpy.tests.doctest_sampling --ignore=causalpy/tests/ causalpy/ --no-cov
       - name: Run extra tests
         run: pytest docs/source/.codespell/test_notebook_to_markdown.py --no-cov
       - name: Run statistical correctness tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }}, pandas ${{ matrix.pandas-version }})
     runs-on: ubuntu-latest
+    # Guard (issue #1117): a wedged run fails as `failure` in minutes instead of
+    # being `cancelled` at GitHub's 6h ceiling. Headroom over the observed ~21 min
+    # max for this job (incl. cold micromamba-cache solves); tune if legitimately
+    # slower runs appear.
+    timeout-minutes: 30
     permissions:
       contents: read
     defaults:

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ check-architecture: ## Verify ARCHITECTURE.md experiment inventory matches code
 	python scripts/check_architecture_inventory.py --check
 
 doctest: ## Run doctests for the causalpy module
-	python -m pytest --doctest-modules --ignore=causalpy/tests/ causalpy/ --config-file=causalpy/tests/conftest.py
+	python -m pytest --doctest-modules -p causalpy.tests.doctest_sampling --ignore=causalpy/tests/ causalpy/
 
 test: ## Run default tests with pytest
 	python -m pytest

--- a/causalpy/tests/conftest.py
+++ b/causalpy/tests/conftest.py
@@ -42,11 +42,10 @@ from causalpy.data.simulate_data import (
 
 # Try to use PyMC's testing helpers if available; otherwise, fall back to no-op fixtures
 try:  # pragma: no cover - conditional import for compatibility across PyMC versions
-    from pymc.testing import mock_sample, mock_sample_setup_and_teardown  # type: ignore
+    from pymc.testing import mock_sample_setup_and_teardown  # type: ignore
 
     _HAVE_PYMC_TESTING = True
 except Exception:  # pragma: no cover
-    mock_sample = None  # type: ignore
     mock_sample_setup_and_teardown = None  # type: ignore
     _HAVE_PYMC_TESTING = False
 
@@ -66,18 +65,6 @@ else:
     def mock_pymc_sample():  # pragma: no cover - compatibility no-op
         # No-op fixture to satisfy tests when PyMC testing helpers are unavailable
         yield
-
-
-@pytest.fixture(autouse=True)
-def mock_sample_for_doctest(request):
-    if not request.config.getoption("--doctest-modules", default=False):
-        return
-
-    if not _HAVE_PYMC_TESTING or mock_sample is None:
-        return
-    import pymc as pm
-
-    pm.sample = mock_sample
 
 
 @pytest.fixture(scope="session")

--- a/causalpy/tests/doctest_sampling.py
+++ b/causalpy/tests/doctest_sampling.py
@@ -29,7 +29,7 @@ the doctests.
 Why here and not a package-root ``causalpy/conftest.py``
 --------------------------------------------------------
 This module lives under ``causalpy/tests/``, which is excluded from the built
-wheel by ``[tool.setuptools.packages.find] exclude = ["causalpy.test*"]``. No
+wheel by ``[tool.setuptools.packages.find] exclude = ["causalpy.test*", "docs*"]``. No
 test-only sampling shim ships to users. Excluding a single ``conftest.py``
 *module* from a setuptools wheel, by contrast, is not cleanly expressible
 (``packages.find`` excludes packages, and ``MANIFEST.in`` only shapes the

--- a/causalpy/tests/doctest_sampling.py
+++ b/causalpy/tests/doctest_sampling.py
@@ -69,7 +69,7 @@ _guard_originals: dict = {}
 
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Install the doctest sampling mock and arm the real-sampler guard.
+    """Install the doctest sampling mock when running ``--doctest-modules``.
 
     Parameters
     ----------
@@ -77,10 +77,32 @@ def pytest_configure(config: pytest.Config) -> None:
         The active pytest configuration; used only to detect
         ``--doctest-modules``.
     """
-    if not config.getoption("--doctest-modules", default=False):
+    if config.getoption("--doctest-modules", default=False):
+        _install_doctest_mock()
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Undo whatever :func:`pytest_configure` installed.
+
+    Parameters
+    ----------
+    config : pytest.Config
+        The active pytest configuration (unused; required by the hook
+        signature).
+    """
+    _restore_doctest_mock()
+
+
+def _install_doctest_mock() -> None:
+    """Swap in the mock sampler and arm the real-sampler guard, process-wide."""
+    global _mock_gen
+    # Keep configure/unconfigure symmetric: a second install would capture the
+    # already-mocked state as its "original" and a single restore would then
+    # leak the mock. In practice a ``-p`` plugin configures once, but guard
+    # against double registration.
+    if _mock_gen is not None:
         return
 
-    global _mock_gen
     from pymc.sampling import mcmc
     from pymc.testing import mock_sample_setup_and_teardown
 
@@ -104,15 +126,8 @@ def pytest_configure(config: pytest.Config) -> None:
         setattr(mcmc, name, _forbidden)
 
 
-def pytest_unconfigure(config: pytest.Config) -> None:
-    """Restore ``pm.sample`` and the guarded MCMC entry points.
-
-    Parameters
-    ----------
-    config : pytest.Config
-        The active pytest configuration (unused; required by the hook
-        signature).
-    """
+def _restore_doctest_mock() -> None:
+    """Restore ``pm.sample``/``Flat``/``HalfFlat`` and the guarded entry points."""
     global _mock_gen
     if _mock_gen is None:
         return

--- a/causalpy/tests/doctest_sampling.py
+++ b/causalpy/tests/doctest_sampling.py
@@ -1,0 +1,87 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Pytest plugin that neutralises real MCMC sampling in the doctest leg.
+
+Loaded explicitly from the doctest CI/Make command via
+``-p causalpy.tests.doctest_sampling``.
+
+Why a plugin and not a conftest fixture
+---------------------------------------
+An autouse fixture defined in ``causalpy/tests/conftest.py`` only applies to
+items collected *under that conftest's own directory*. The doctests are
+collected from ``causalpy/*.py`` -- outside ``causalpy/tests/`` -- so such a
+fixture can never reach them, and every model-fitting doctest sampled for real
+(multi-core by default). A plugin loaded with ``-p`` registers its hooks
+globally, independent of the collection tree, so the mock actually applies to
+the doctests.
+
+Why here and not a package-root ``causalpy/conftest.py``
+--------------------------------------------------------
+This module lives under ``causalpy/tests/``, which is excluded from the built
+wheel by ``[tool.setuptools.packages.find] exclude = ["causalpy.test*"]``. No
+test-only sampling shim ships to users. Excluding a single ``conftest.py``
+*module* from a setuptools wheel, by contrast, is not cleanly expressible
+(``packages.find`` excludes packages, and ``MANIFEST.in`` only shapes the
+sdist).
+
+What it does
+------------
+When ``--doctest-modules`` is active it replaces :func:`pymc.sample` with
+:func:`pymc.testing.mock_sample` (fast prior-predictive stand-in), and it
+booby-traps the real MCMC entry points so that if a doctest *ever* reaches the
+real sampler -- i.e. the mock stops applying for any reason -- the run fails
+loudly and immediately instead of sampling for real and wedging the job.
+"""
+
+import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Install the doctest sampling mock and the real-sampler guard.
+
+    Parameters
+    ----------
+    config : pytest.Config
+        The active pytest configuration; used only to detect
+        ``--doctest-modules``.
+    """
+    if not config.getoption("--doctest-modules", default=False):
+        return
+
+    import pymc as pm
+    from pymc.sampling import mcmc
+    from pymc.testing import mock_sample
+
+    # The fix: doctests that call ``pm.sample`` get the fast prior-predictive
+    # stand-in instead of real MCMC.
+    pm.sample = mock_sample
+
+    # The proof: ``mock_sample`` routes through ``pm.sample_prior_predictive``
+    # (in ``pymc.sampling.forward``) and never touches these MCMC entry points.
+    # Real sampling always does. Patching them to raise turns "a doctest reached
+    # the real sampler" into an immediate, unambiguous failure rather than a
+    # six-hour hang.
+    def _forbidden(*_args, **_kwargs):
+        raise RuntimeError(
+            "A doctest reached the real MCMC sampler: the doctest sampling mock "
+            "is not in force. See causalpy/tests/doctest_sampling.py."
+        )
+
+    for _name in (
+        "_sample_many",
+        "_mp_sample",
+        "_sample_population",
+        "_sample_external_nuts",
+    ):
+        setattr(mcmc, _name, _forbidden)

--- a/causalpy/tests/doctest_sampling.py
+++ b/causalpy/tests/doctest_sampling.py
@@ -37,18 +37,39 @@ sdist).
 
 What it does
 ------------
-When ``--doctest-modules`` is active it replaces :func:`pymc.sample` with
-:func:`pymc.testing.mock_sample` (fast prior-predictive stand-in), and it
-booby-traps the real MCMC entry points so that if a doctest *ever* reaches the
-real sampler -- i.e. the mock stops applying for any reason -- the run fails
-loudly and immediately instead of sampling for real and wedging the job.
+When ``--doctest-modules`` is active it drives PyMC's own
+:func:`pymc.testing.mock_sample_setup_and_teardown` -- the *same* setup/teardown
+that backs the normal suite's ``mock_pymc_sample`` fixture, so the mock is
+defined in exactly one place. That swaps :func:`pymc.sample` for a fast
+prior-predictive stand-in and swaps ``Flat``/``HalfFlat`` for proper priors that
+prior-predictive can actually draw. On top of that it booby-traps the real MCMC
+entry points so that if a doctest *ever* reaches the real sampler -- i.e. the
+mock stops applying for any reason -- the run fails loudly and immediately
+instead of sampling for real and wedging the job.
 """
 
 import pytest
 
+#: Real MCMC entry points in ``pymc.sampling.mcmc`` that ``pymc.sample`` dispatches
+#: to. ``mock_sample`` routes through ``sample_prior_predictive`` (in
+#: ``pymc.sampling.forward``) and never calls any of these, so guarding them
+#: cannot false-fire on the mock.
+_FORBIDDEN_MCMC_ENTRY_POINTS = (
+    "_sample_many",
+    "_mp_sample",
+    "_sample_population",
+    "_sample_external_nuts",
+)
+
+# Session state stashed between configure and unconfigure. Restored on teardown
+# so the process-global patches do not leak, even though in practice the doctest
+# leg runs in a throwaway process of its own.
+_mock_gen = None
+_guard_originals: dict = {}
+
 
 def pytest_configure(config: pytest.Config) -> None:
-    """Install the doctest sampling mock and the real-sampler guard.
+    """Install the doctest sampling mock and arm the real-sampler guard.
 
     Parameters
     ----------
@@ -59,29 +80,47 @@ def pytest_configure(config: pytest.Config) -> None:
     if not config.getoption("--doctest-modules", default=False):
         return
 
-    import pymc as pm
+    global _mock_gen
     from pymc.sampling import mcmc
-    from pymc.testing import mock_sample
+    from pymc.testing import mock_sample_setup_and_teardown
 
-    # The fix: doctests that call ``pm.sample`` get the fast prior-predictive
-    # stand-in instead of real MCMC.
-    pm.sample = mock_sample
+    # The fix. A bare import (no try/except) is deliberate: if PyMC's mock helper
+    # is unavailable we must fail loudly here, never silently fall through to
+    # real sampling.
+    _mock_gen = mock_sample_setup_and_teardown()
+    next(_mock_gen)  # run setup: swap pm.sample, pm.Flat, pm.HalfFlat
 
-    # The proof: ``mock_sample`` routes through ``pm.sample_prior_predictive``
-    # (in ``pymc.sampling.forward``) and never touches these MCMC entry points.
-    # Real sampling always does. Patching them to raise turns "a doctest reached
-    # the real sampler" into an immediate, unambiguous failure rather than a
-    # six-hour hang.
+    # The proof. ``getattr`` first so an upstream rename fails loudly *here*
+    # (AttributeError at configure time) rather than ``setattr`` silently
+    # attaching a dead attribute and leaving the real sampler unguarded.
     def _forbidden(*_args, **_kwargs):
         raise RuntimeError(
             "A doctest reached the real MCMC sampler: the doctest sampling mock "
             "is not in force. See causalpy/tests/doctest_sampling.py."
         )
 
-    for _name in (
-        "_sample_many",
-        "_mp_sample",
-        "_sample_population",
-        "_sample_external_nuts",
-    ):
-        setattr(mcmc, _name, _forbidden)
+    for name in _FORBIDDEN_MCMC_ENTRY_POINTS:
+        _guard_originals[name] = getattr(mcmc, name)
+        setattr(mcmc, name, _forbidden)
+
+
+def pytest_unconfigure(config: pytest.Config) -> None:
+    """Restore ``pm.sample`` and the guarded MCMC entry points.
+
+    Parameters
+    ----------
+    config : pytest.Config
+        The active pytest configuration (unused; required by the hook
+        signature).
+    """
+    global _mock_gen
+    if _mock_gen is None:
+        return
+
+    from pymc.sampling import mcmc
+
+    next(_mock_gen, None)  # run teardown: restore pm.sample, pm.Flat, pm.HalfFlat
+    _mock_gen = None
+    while _guard_originals:
+        name, original = _guard_originals.popitem()
+        setattr(mcmc, name, original)

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -201,16 +201,88 @@ class _FakeConfig:
         return self._doctest_modules
 
 
+def _sentinel(qualified_name):
+    """Build a unique, identifiable stand-in for one patched global.
+
+    Parameters
+    ----------
+    qualified_name : str
+        Name the sentinel stands in for, used in ``__name__`` and in the error
+        raised if anything actually calls it.
+
+    Returns
+    -------
+    callable
+        A fresh function object, distinct from every other object in the
+        process.
+    """
+
+    def _never_call(*_args, **_kwargs):
+        raise AssertionError(
+            f"the sentinel standing in for {qualified_name} was called"
+        )
+
+    _never_call.__name__ = f"sentinel_{qualified_name.replace('.', '_')}"
+    return _never_call
+
+
+def _pin_sampling_globals(monkeypatch):
+    """Pin every global the plugin patches to a unique sentinel, for one test.
+
+    The in-process hook tests assert that install *replaces* these globals and
+    that restore puts back *exactly* what was there. Read against whatever the
+    live values happen to be, both halves of that are order-dependent and can
+    pass vacuously: ``mock_pymc_sample`` in ``causalpy/tests/conftest.py`` is
+    session-scoped, so the first test file that uses it leaves ``pm.sample`` set
+    to ``mock_sample`` for the rest of the session. A test that then asserted
+    ``pm.sample.__name__ != "mock_sample"`` after restore would fail even though
+    the plugin behaved perfectly -- it restored the mock it was correctly handed
+    as the original.
+
+    Sentinels remove the coupling. Each is a fresh object that cannot collide
+    with ``mock_sample`` or with the real PyMC callables, so "install swapped
+    it" and "restore returned this exact object" are both decidable no matter
+    what ran earlier. ``monkeypatch`` reverts the pinning at teardown.
+
+    Parameters
+    ----------
+    monkeypatch : pytest.MonkeyPatch
+        Fixture used to install and later revert the sentinels.
+
+    Returns
+    -------
+    dict
+        Maps ``"pm.sample"``, ``"pm.Flat"``, ``"pm.HalfFlat"`` and each name in
+        ``_FORBIDDEN_MCMC_ENTRY_POINTS`` to the sentinel now bound there.
+    """
+    import pymc as pm
+
+    pinned = {}
+    for name in ("sample", "Flat", "HalfFlat"):
+        sentinel = _sentinel(f"pm.{name}")
+        monkeypatch.setattr(pm, name, sentinel)
+        pinned[f"pm.{name}"] = sentinel
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        sentinel = _sentinel(f"mcmc.{name}")
+        monkeypatch.setattr(mcmc, name, sentinel)
+        pinned[name] = sentinel
+    return pinned
+
+
 def test_configure_is_noop_without_doctest_modules(monkeypatch):
     """Outside the doctest leg the plugin must not touch global sampling state."""
     import pymc as pm
 
-    original_sample = pm.sample
-    monkeypatch.setattr(pm, "sample", original_sample)
+    pinned = _pin_sampling_globals(monkeypatch)
 
     doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=False))
 
-    assert pm.sample is original_sample
+    assert pm.sample is pinned["pm.sample"]
+    assert pm.Flat is pinned["pm.Flat"]
+    assert pm.HalfFlat is pinned["pm.HalfFlat"]
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        assert getattr(mcmc, name) is pinned[name]
+    assert doctest_sampling._mock_gen is None
 
 
 def test_hooks_install_and_restore_inside_the_doctest_leg(monkeypatch):
@@ -219,23 +291,34 @@ def test_hooks_install_and_restore_inside_the_doctest_leg(monkeypatch):
     ``test_install_and_restore_round_trip`` covers the private helpers; this
     covers the wiring from ``pytest_configure``/``pytest_unconfigure`` to them,
     which otherwise only runs in the subprocess tests' child process.
+
+    The contract asserted here is a *round trip* -- restore hands back the exact
+    objects install was given -- not "``pm.sample`` is unmocked afterwards". The
+    latter is not the plugin's to promise: whatever ``pm.sample`` happened to be
+    at install time is what restore must reinstate, mock or not. See
+    ``_pin_sampling_globals`` for why that distinction decides whether this test
+    is order-dependent.
     """
     import pymc as pm
 
-    monkeypatch.setattr(pm, "sample", pm.sample)
-    monkeypatch.setattr(pm, "Flat", pm.Flat)
-    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
-    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
-        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+    pinned = _pin_sampling_globals(monkeypatch)
 
     doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=True))
     try:
         assert pm.sample.__name__ == "mock_sample"
+        assert pm.Flat is pm.Normal
+        assert pm.HalfFlat is pm.HalfNormal
     finally:
         doctest_sampling.pytest_unconfigure(_FakeConfig(doctest_modules=True))
 
     assert doctest_sampling._mock_gen is None
-    assert pm.sample.__name__ != "mock_sample"
+    # Restore must hand back the exact objects install was given, not merely
+    # "something that isn't the mock".
+    assert pm.sample is pinned["pm.sample"]
+    assert pm.Flat is pinned["pm.Flat"]
+    assert pm.HalfFlat is pinned["pm.HalfFlat"]
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        assert getattr(mcmc, name) is pinned[name]
 
 
 def test_install_is_idempotent(monkeypatch):
@@ -246,14 +329,7 @@ def test_install_is_idempotent(monkeypatch):
     """
     import pymc as pm
 
-    monkeypatch.setattr(pm, "sample", pm.sample)
-    monkeypatch.setattr(pm, "Flat", pm.Flat)
-    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
-    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
-        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
-    originals = {
-        n: getattr(mcmc, n) for n in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS
-    }
+    pinned = _pin_sampling_globals(monkeypatch)
 
     doctest_sampling._install_doctest_mock()
     try:
@@ -263,8 +339,10 @@ def test_install_is_idempotent(monkeypatch):
     finally:
         doctest_sampling._restore_doctest_mock()
 
-    for name, original in originals.items():
-        assert getattr(mcmc, name) is original
+    # The single restore matching the two installs must leave nothing mocked.
+    assert pm.sample is pinned["pm.sample"]
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        assert getattr(mcmc, name) is pinned[name]
 
 
 def test_restore_without_install_is_a_noop():
@@ -287,18 +365,13 @@ def test_install_and_restore_round_trip(monkeypatch):
     """
     import pymc as pm
 
-    monkeypatch.setattr(pm, "sample", pm.sample)
-    monkeypatch.setattr(pm, "Flat", pm.Flat)
-    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
-    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
-        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
-    originals = {
-        n: getattr(mcmc, n) for n in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS
-    }
+    pinned = _pin_sampling_globals(monkeypatch)
 
     doctest_sampling._install_doctest_mock()
     try:
         assert pm.sample.__name__ == "mock_sample"
+        assert pm.Flat is pm.Normal
+        assert pm.HalfFlat is pm.HalfNormal
         for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
             with pytest.raises(RuntimeError, match="real MCMC sampler"):
                 getattr(mcmc, name)()
@@ -306,8 +379,11 @@ def test_install_and_restore_round_trip(monkeypatch):
         doctest_sampling._restore_doctest_mock()
 
     # Teardown restored every patched name to the exact original object.
-    for name, original in originals.items():
-        assert getattr(mcmc, name) is original
+    assert pm.sample is pinned["pm.sample"]
+    assert pm.Flat is pinned["pm.Flat"]
+    assert pm.HalfFlat is pinned["pm.HalfFlat"]
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        assert getattr(mcmc, name) is pinned[name]
     assert doctest_sampling._mock_gen is None
 
 

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -13,78 +13,174 @@
 #   limitations under the License.
 """Tests for the doctest sampling plugin (``causalpy/tests/doctest_sampling.py``).
 
-These guard the mechanism that keeps the ``--doctest-modules`` CI leg from
-running real MCMC: that the plugin (a) swaps ``pm.sample`` for the fast mock and
-(b) booby-traps the real MCMC entry points so a regression fails loudly instead
-of sampling for real. The guard is only useful if it targets functions that
-still exist and actually raises, so both are asserted here.
+The plugin keeps the ``--doctest-modules`` CI leg from running real MCMC. The
+acceptance criterion is not "the leg is green" (it was green while broken) but
+"a check that would fail if a doctest ever reached the real sampler". That check
+has to exercise the *real* pytest option plumbing and the real ``-p`` load, so
+the core proofs here run pytest in a subprocess against a throwaway probe module
+rather than calling the hook with a hand-rolled fake config. Two cheap in-process
+checks (an upstream-rename catcher and the no-op-outside-the-leg guarantee)
+round it out.
 """
 
-import pymc as pm
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
 import pytest
 from pymc.sampling import mcmc
-from pymc.testing import mock_sample
 
 from causalpy.tests import doctest_sampling
 
-# The real MCMC entry points the plugin forbids during the doctest leg. Kept in
-# one place so the "these names still exist" check and the "these actually
-# raise" check cannot drift apart.
-GUARDED_ENTRY_POINTS = (
-    "_sample_many",
-    "_mp_sample",
-    "_sample_population",
-    "_sample_external_nuts",
+# Repo root: this file is <root>/causalpy/tests/test_doctest_sampling.py.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_PLUGIN_ARG = "causalpy.tests.doctest_sampling"
+
+# A probe whose doctest asserts the mock is installed. Under the plugin it prints
+# ``mock_sample``; without it, the real ``sample``.
+_MOCK_PROBE = textwrap.dedent(
+    '''\
+    """Throwaway probe module."""
+
+
+    def probe():
+        """
+        >>> import pymc as pm
+        >>> print(pm.sample.__name__)
+        mock_sample
+        """
+    '''
+)
+
+# A probe whose doctest reaches a real MCMC entry point directly. Under the
+# plugin the guard raises; without it, calling the real internal with no
+# arguments raises some *other* error, so the expected RuntimeError is the
+# specific signal that the guard is armed.
+_GUARD_PROBE = textwrap.dedent(
+    '''\
+    """Throwaway probe module."""
+
+
+    def probe():
+        """
+        >>> from pymc.sampling import mcmc
+        >>> mcmc._mp_sample()
+        Traceback (most recent call last):
+        ...
+        RuntimeError: A doctest reached the real MCMC sampler: ...
+        """
+    '''
 )
 
 
-class _FakeConfig:
-    """Minimal stand-in for ``pytest.Config`` exposing only ``getoption``."""
+def _run_doctest(tmp_path, source, *, load_plugin):
+    """Run ``pytest --doctest-modules`` on a probe module in a subprocess.
 
-    def __init__(self, doctest_modules: bool):
-        self._doctest_modules = doctest_modules
+    Parameters
+    ----------
+    tmp_path : pathlib.Path
+        Directory to write the probe into and run from. Running from a tmp dir
+        (no ``pyproject.toml``) keeps pytest's config clean -- no coverage gate,
+        no repo ``addopts``.
+    source : str
+        Source of the probe module.
+    load_plugin : bool
+        Whether to pass ``-p causalpy.tests.doctest_sampling``.
 
-    def getoption(self, name, default=False):
-        if name == "--doctest-modules":
-            return self._doctest_modules
-        return default
+    Returns
+    -------
+    subprocess.CompletedProcess
+        The finished pytest invocation.
+    """
+    (tmp_path / "probe.py").write_text(source)
+    args = [
+        sys.executable,
+        "-m",
+        "pytest",
+        "--doctest-modules",
+        "-o",
+        "doctest_optionflags=ELLIPSIS",
+        "-p",
+        "no:cacheprovider",
+    ]
+    if load_plugin:
+        args += ["-p", _PLUGIN_ARG]
+    args.append("probe.py")
+    return subprocess.run(
+        args, cwd=tmp_path, capture_output=True, text=True, timeout=120, check=False
+    )
+
+
+def test_mock_applied_in_real_doctest_leg(tmp_path):
+    """With the plugin loaded, ``pm.sample`` is the mock for the doctests.
+
+    Exercises the real ``--doctest-modules`` detection and ``-p`` load, which the
+    in-process fake-config approach cannot.
+    """
+    result = _run_doctest(tmp_path, _MOCK_PROBE, load_plugin=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_plugin_is_load_bearing(tmp_path):
+    """Without the plugin the mock is absent -- proving ``-p`` is load-bearing.
+
+    This is the regression that would let the doctest leg sample for real again
+    if the ``-p`` flag were dropped from the CI/Make command.
+    """
+    result = _run_doctest(tmp_path, _MOCK_PROBE, load_plugin=False)
+    assert result.returncode != 0, result.stdout + result.stderr
+
+
+def test_guard_fires_on_real_sampler_in_real_doctest_leg(tmp_path):
+    """A doctest that reaches a real MCMC entry point fails loudly, not slowly.
+
+    This is the acceptance-criterion check: it would fail (here, by *not*
+    raising the expected RuntimeError) if the guard were not armed during an
+    actual ``--doctest-modules`` run.
+    """
+    result = _run_doctest(tmp_path, _GUARD_PROBE, load_plugin=True)
+    assert result.returncode == 0, result.stdout + result.stderr
 
 
 def test_guarded_entry_points_still_exist():
     """The plugin can only guard functions that exist; a rename must be caught.
 
-    If PyMC renames one of these internals the plugin would silently guard
-    nothing and doctests would sample for real again, so pin the names down.
+    If PyMC renames one of these internals the plugin's ``getattr`` would raise
+    at configure time (fail loud), but this cheap check flags the drift directly
+    without needing to run the doctest leg.
     """
-    for name in GUARDED_ENTRY_POINTS:
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
         assert hasattr(mcmc, name), f"pymc.sampling.mcmc.{name} no longer exists"
 
 
-def test_plugin_is_noop_without_doctest_modules(monkeypatch):
+def test_configure_is_noop_without_doctest_modules(monkeypatch):
     """Outside the doctest leg the plugin must not touch global sampling state."""
+    import pymc as pm
+
     original_sample = pm.sample
     monkeypatch.setattr(pm, "sample", original_sample)
 
-    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=False))
+    class _FakeConfig:
+        def getoption(self, name, default=False):
+            return default  # --doctest-modules not set
+
+    doctest_sampling.pytest_configure(_FakeConfig())
 
     assert pm.sample is original_sample
 
 
-def test_plugin_installs_mock_and_arms_guard(monkeypatch):
-    """Under ``--doctest-modules`` the mock is installed and the guard is armed."""
-    # Register the originals with monkeypatch so its teardown restores the
-    # process-wide state the plugin mutates, keeping the rest of the suite clean.
-    monkeypatch.setattr(pm, "sample", pm.sample)
-    for name in GUARDED_ENTRY_POINTS:
-        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+@pytest.mark.parametrize("relpath", [".github/workflows/ci.yml", "Makefile"])
+def test_doctest_command_loads_the_plugin(relpath):
+    """The load-bearing ``-p`` flag must stay on the doctest command at source.
 
-    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=True))
-
-    # (a) The fix: pm.sample is the fast prior-predictive stand-in.
-    assert pm.sample is mock_sample
-
-    # (b) The proof: every real MCMC entry point now refuses to run, so a
-    #     doctest that reaches the real sampler fails immediately.
-    for name in GUARDED_ENTRY_POINTS:
-        with pytest.raises(RuntimeError, match="real MCMC sampler"):
-            getattr(mcmc, name)()
+    ``test_plugin_is_load_bearing`` proves the flag matters; this proves the two
+    real invocations still carry it, so a hand-edit cannot silently remove it.
+    """
+    text = (_REPO_ROOT / relpath).read_text()
+    doctest_lines = [ln for ln in text.splitlines() if "--doctest-modules" in ln]
+    assert doctest_lines, f"no --doctest-modules command found in {relpath}"
+    for line in doctest_lines:
+        assert f"-p {_PLUGIN_ARG}" in line, (
+            f"doctest command in {relpath} does not load the plugin: {line!r}"
+        )

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -257,6 +257,16 @@ def _pin_sampling_globals(monkeypatch):
     """
     import pymc as pm
 
+    # The plugin's own bookkeeping is module-global too, so a sibling test that
+    # fails part-way (or a mutant that breaks restore) would otherwise hand the
+    # next test a half-installed plugin -- and the ``_mock_gen is not None``
+    # idempotence guard would silently turn its install into a no-op, letting
+    # the test pass without exercising anything. Pin it to the not-installed
+    # state so each test starts from a known plugin state as well as a known
+    # PyMC state.
+    monkeypatch.setattr(doctest_sampling, "_mock_gen", None)
+    monkeypatch.setattr(doctest_sampling, "_guard_originals", {})
+
     pinned = {}
     for name in ("sample", "Flat", "HalfFlat"):
         sentinel = _sentinel(f"pm.{name}")
@@ -345,13 +355,24 @@ def test_install_is_idempotent(monkeypatch):
         assert getattr(mcmc, name) is pinned[name]
 
 
-def test_restore_without_install_is_a_noop():
-    """``pytest_unconfigure`` also fires when configure never installed."""
-    assert doctest_sampling._mock_gen is None
+def test_restore_without_install_is_a_noop(monkeypatch):
+    """``pytest_unconfigure`` also fires when configure never installed.
+
+    The not-installed precondition is pinned rather than inherited from
+    whatever ran before, so this cannot fail as collateral from an unrelated
+    test leaving the plugin half-installed.
+    """
+    pinned = _pin_sampling_globals(monkeypatch)
 
     doctest_sampling._restore_doctest_mock()
 
     assert doctest_sampling._mock_gen is None
+    # A restore with nothing to undo must not touch the globals either.
+    import pymc as pm
+
+    assert pm.sample is pinned["pm.sample"]
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        assert getattr(mcmc, name) is pinned[name]
 
 
 def test_install_and_restore_round_trip(monkeypatch):

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -53,6 +53,26 @@ _MOCK_PROBE = textwrap.dedent(
     '''
 )
 
+# A probe whose doctest actually fits a model and calls ``pm.sample()``. Under
+# the plugin the mock returns fast and the guard stays silent -- the whole point
+# of the mechanism (model-fitting doctests run without real MCMC).
+_MODEL_PROBE = textwrap.dedent(
+    '''\
+    """Throwaway probe module."""
+
+
+    def probe():
+        """
+        >>> import pymc as pm
+        >>> with pm.Model():
+        ...     _ = pm.Normal("x", 0, 1)
+        ...     idata = pm.sample()
+        >>> "posterior" in idata
+        True
+        """
+    '''
+)
+
 # A probe whose doctest reaches a real MCMC entry point directly. Under the
 # plugin the guard raises; without it, calling the real internal with no
 # arguments raises some *other* error, so the expected RuntimeError is the
@@ -122,6 +142,18 @@ def test_mock_applied_in_real_doctest_leg(tmp_path):
     assert result.returncode == 0, result.stdout + result.stderr
 
 
+def test_model_fitting_doctest_runs_under_mock(tmp_path):
+    """A doctest that fits a model and calls ``pm.sample()`` passes under the mock.
+
+    The positive complement to ``test_guard_fires...``: it proves the mock and
+    the guard coexist -- real model-fitting doctests run fast without tripping
+    the guard -- and would catch a future PyMC change where ``mock_sample`` began
+    routing through a guarded internal.
+    """
+    result = _run_doctest(tmp_path, _MODEL_PROBE, load_plugin=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
 def test_plugin_is_load_bearing(tmp_path):
     """Without the plugin the mock is absent -- proving ``-p`` is load-bearing.
 
@@ -129,7 +161,11 @@ def test_plugin_is_load_bearing(tmp_path):
     if the ``-p`` flag were dropped from the CI/Make command.
     """
     result = _run_doctest(tmp_path, _MOCK_PROBE, load_plugin=False)
+    # Pin the *reason* for the failure to the doctest mismatch (real ``sample``
+    # where ``mock_sample`` was expected), so an unrelated import/collection
+    # error cannot make this pass for the wrong reason.
     assert result.returncode != 0, result.stdout + result.stderr
+    assert "mock_sample" in result.stdout, result.stdout + result.stderr
 
 
 def test_guard_fires_on_real_sampler_in_real_doctest_leg(tmp_path):
@@ -170,12 +206,50 @@ def test_configure_is_noop_without_doctest_modules(monkeypatch):
     assert pm.sample is original_sample
 
 
+def test_install_and_restore_round_trip(monkeypatch):
+    """In-process check that install arms mock+guard and restore undoes both.
+
+    The subprocess tests prove the mechanism through real pytest, but that logic
+    never runs in this (coverage-measured) process. This exercises
+    ``_install_doctest_mock``/``_restore_doctest_mock`` directly, and is the only
+    place teardown is asserted in-process. ``monkeypatch`` snapshots the globals
+    so state is restored even if an assertion fails mid-way.
+    """
+    import pymc as pm
+
+    monkeypatch.setattr(pm, "sample", pm.sample)
+    monkeypatch.setattr(pm, "Flat", pm.Flat)
+    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+    originals = {
+        n: getattr(mcmc, n) for n in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS
+    }
+
+    doctest_sampling._install_doctest_mock()
+    try:
+        assert pm.sample.__name__ == "mock_sample"
+        for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+            with pytest.raises(RuntimeError, match="real MCMC sampler"):
+                getattr(mcmc, name)()
+    finally:
+        doctest_sampling._restore_doctest_mock()
+
+    # Teardown restored every patched name to the exact original object.
+    for name, original in originals.items():
+        assert getattr(mcmc, name) is original
+    assert doctest_sampling._mock_gen is None
+
+
 @pytest.mark.parametrize("relpath", [".github/workflows/ci.yml", "Makefile"])
 def test_doctest_command_loads_the_plugin(relpath):
     """The load-bearing ``-p`` flag must stay on the doctest command at source.
 
     ``test_plugin_is_load_bearing`` proves the flag matters; this proves the two
     real invocations still carry it, so a hand-edit cannot silently remove it.
+
+    Assumes the doctest command stays on a single line (true for both files); a
+    future reformat splitting the flags across lines would need this updated.
     """
     text = (_REPO_ROOT / relpath).read_text()
     doctest_lines = [ln for ln in text.splitlines() if "--doctest-modules" in ln]

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -1,0 +1,90 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""Tests for the doctest sampling plugin (``causalpy/tests/doctest_sampling.py``).
+
+These guard the mechanism that keeps the ``--doctest-modules`` CI leg from
+running real MCMC: that the plugin (a) swaps ``pm.sample`` for the fast mock and
+(b) booby-traps the real MCMC entry points so a regression fails loudly instead
+of sampling for real. The guard is only useful if it targets functions that
+still exist and actually raises, so both are asserted here.
+"""
+
+import pymc as pm
+import pytest
+from pymc.sampling import mcmc
+from pymc.testing import mock_sample
+
+from causalpy.tests import doctest_sampling
+
+# The real MCMC entry points the plugin forbids during the doctest leg. Kept in
+# one place so the "these names still exist" check and the "these actually
+# raise" check cannot drift apart.
+GUARDED_ENTRY_POINTS = (
+    "_sample_many",
+    "_mp_sample",
+    "_sample_population",
+    "_sample_external_nuts",
+)
+
+
+class _FakeConfig:
+    """Minimal stand-in for ``pytest.Config`` exposing only ``getoption``."""
+
+    def __init__(self, doctest_modules: bool):
+        self._doctest_modules = doctest_modules
+
+    def getoption(self, name, default=False):
+        if name == "--doctest-modules":
+            return self._doctest_modules
+        return default
+
+
+def test_guarded_entry_points_still_exist():
+    """The plugin can only guard functions that exist; a rename must be caught.
+
+    If PyMC renames one of these internals the plugin would silently guard
+    nothing and doctests would sample for real again, so pin the names down.
+    """
+    for name in GUARDED_ENTRY_POINTS:
+        assert hasattr(mcmc, name), f"pymc.sampling.mcmc.{name} no longer exists"
+
+
+def test_plugin_is_noop_without_doctest_modules(monkeypatch):
+    """Outside the doctest leg the plugin must not touch global sampling state."""
+    original_sample = pm.sample
+    monkeypatch.setattr(pm, "sample", original_sample)
+
+    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=False))
+
+    assert pm.sample is original_sample
+
+
+def test_plugin_installs_mock_and_arms_guard(monkeypatch):
+    """Under ``--doctest-modules`` the mock is installed and the guard is armed."""
+    # Register the originals with monkeypatch so its teardown restores the
+    # process-wide state the plugin mutates, keeping the rest of the suite clean.
+    monkeypatch.setattr(pm, "sample", pm.sample)
+    for name in GUARDED_ENTRY_POINTS:
+        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+
+    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=True))
+
+    # (a) The fix: pm.sample is the fast prior-predictive stand-in.
+    assert pm.sample is mock_sample
+
+    # (b) The proof: every real MCMC entry point now refuses to run, so a
+    #     doctest that reaches the real sampler fails immediately.
+    for name in GUARDED_ENTRY_POINTS:
+        with pytest.raises(RuntimeError, match="real MCMC sampler"):
+            getattr(mcmc, name)()

--- a/causalpy/tests/test_doctest_sampling.py
+++ b/causalpy/tests/test_doctest_sampling.py
@@ -190,6 +190,17 @@ def test_guarded_entry_points_still_exist():
         assert hasattr(mcmc, name), f"pymc.sampling.mcmc.{name} no longer exists"
 
 
+class _FakeConfig:
+    """Minimal stand-in for ``pytest.Config``; the hooks read one option."""
+
+    def __init__(self, *, doctest_modules):
+        self._doctest_modules = doctest_modules
+
+    def getoption(self, name, default=False):
+        assert name == "--doctest-modules"
+        return self._doctest_modules
+
+
 def test_configure_is_noop_without_doctest_modules(monkeypatch):
     """Outside the doctest leg the plugin must not touch global sampling state."""
     import pymc as pm
@@ -197,13 +208,72 @@ def test_configure_is_noop_without_doctest_modules(monkeypatch):
     original_sample = pm.sample
     monkeypatch.setattr(pm, "sample", original_sample)
 
-    class _FakeConfig:
-        def getoption(self, name, default=False):
-            return default  # --doctest-modules not set
-
-    doctest_sampling.pytest_configure(_FakeConfig())
+    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=False))
 
     assert pm.sample is original_sample
+
+
+def test_hooks_install_and_restore_inside_the_doctest_leg(monkeypatch):
+    """The pytest entry points themselves arm and disarm the mock.
+
+    ``test_install_and_restore_round_trip`` covers the private helpers; this
+    covers the wiring from ``pytest_configure``/``pytest_unconfigure`` to them,
+    which otherwise only runs in the subprocess tests' child process.
+    """
+    import pymc as pm
+
+    monkeypatch.setattr(pm, "sample", pm.sample)
+    monkeypatch.setattr(pm, "Flat", pm.Flat)
+    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+
+    doctest_sampling.pytest_configure(_FakeConfig(doctest_modules=True))
+    try:
+        assert pm.sample.__name__ == "mock_sample"
+    finally:
+        doctest_sampling.pytest_unconfigure(_FakeConfig(doctest_modules=True))
+
+    assert doctest_sampling._mock_gen is None
+    assert pm.sample.__name__ != "mock_sample"
+
+
+def test_install_is_idempotent(monkeypatch):
+    """A second install must not capture the mocked state as its "original".
+
+    If it did, the single matching restore would leave the mock in place for
+    every later test in the process.
+    """
+    import pymc as pm
+
+    monkeypatch.setattr(pm, "sample", pm.sample)
+    monkeypatch.setattr(pm, "Flat", pm.Flat)
+    monkeypatch.setattr(pm, "HalfFlat", pm.HalfFlat)
+    for name in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS:
+        monkeypatch.setattr(mcmc, name, getattr(mcmc, name))
+    originals = {
+        n: getattr(mcmc, n) for n in doctest_sampling._FORBIDDEN_MCMC_ENTRY_POINTS
+    }
+
+    doctest_sampling._install_doctest_mock()
+    try:
+        first_gen = doctest_sampling._mock_gen
+        doctest_sampling._install_doctest_mock()
+        assert doctest_sampling._mock_gen is first_gen
+    finally:
+        doctest_sampling._restore_doctest_mock()
+
+    for name, original in originals.items():
+        assert getattr(mcmc, name) is original
+
+
+def test_restore_without_install_is_a_noop():
+    """``pytest_unconfigure`` also fires when configure never installed."""
+    assert doctest_sampling._mock_gen is None
+
+    doctest_sampling._restore_doctest_mock()
+
+    assert doctest_sampling._mock_gen is None
 
 
 def test_install_and_restore_round_trip(monkeypatch):


### PR DESCRIPTION
Part of #1048.

## What this fixes

The `--doctest-modules` CI leg (`.github/workflows/ci.yml`) ran **real MCMC
sampling**. Its mock never applied. The autouse fixture `mock_sample_for_doctest`
lived in `causalpy/tests/conftest.py`, and a conftest fixture only applies to
items collected **under its own directory**. The doctests are collected from
`causalpy/*.py` (outside `tests/`), so the fixture could never reach them: every
model-fitting doctest sampled for real, multi-core by default.

Verified empirically on pytest 9.1.1 with a probe doctest asserting
`pm.sample.__name__`: under the old command it read `sample` (the real sampler),
not `mock_sample`.

`--config-file=causalpy/tests/conftest.py` was **not** the cause — but it is not
a pure no-op either. A `.py` file carries no ini config, and its only effect was
to repoint pytest's rootdir at `causalpy/tests`. It is dropped.

## The change

- **The fix.** Move the mock into a pytest plugin
  (`causalpy/tests/doctest_sampling.py`) loaded explicitly with
  `-p causalpy.tests.doctest_sampling`. Plugin hooks register globally,
  independent of the collection tree, so `pm.sample` is mocked for the doctests.
- **The proof (a check that fails if a doctest reaches the real sampler).** The
  same plugin booby-traps the real MCMC entry points (`_sample_many`,
  `_mp_sample`, `_sample_population`, `_sample_external_nuts`) to raise. If the
  mock ever stops applying, the leg fails **loudly and immediately** instead of
  sampling for real. `mock_sample` routes through `sample_prior_predictive` and
  never touches those functions, so the guard never false-fires (confirmed: the
  full doctest suite passes green under it). `causalpy/tests/test_doctest_sampling.py`
  asserts both that the mock installs and that the guard actually raises, and
  pins the guarded names so an upstream rename can't silently disarm it.
- **The guard for #1117 (separate concern).** `timeout-minutes: 30` on the
  `test` job. A wedged run now fails as `failure` in minutes rather than being
  `cancelled` at GitHub's 6h ceiling. **This is a guard, not the fix** — the mock
  is what removes the wedge; the cap only bounds the worst case. Ordered after
  the fix so the timing improvement is measurable before the cap could mask it.
- Drop `--config-file` from the doctest command in CI and the `Makefile`; remove
  the now-dead `mock_sample_for_doctest` fixture.

## Evidence

**Mock now applies.** Probe doctest `print(pm.sample.__name__)` → `mock_sample`
under the new command (was `sample`).

**No real sampling.** Full doctest suite: `37 passed, 13 skipped` under the
plugin, with the real-sampler guard armed — nothing reached the guarded entry
points.

**Wall time (local, single core; CI runs multi-core so the absolute numbers
differ, the direction does not):**

| target | before (real) | after (mock) |
| --- | --- | --- |
| full doctest leg | 178 s | 44 s |
| `causalpy/pymc_models.py` | 64 s | 8 s |
| `causalpy/experiments/regression_discontinuity.py` | 7.6 s | 1.0 s |

**Not shipped in the wheel.** The plugin lives under `causalpy/tests/`, already
excluded by `[tool.setuptools.packages.find] exclude = ["causalpy.test*"]`.
`setuptools.find_packages(exclude=["causalpy.test*", "docs*"])` returns no
`causalpy.tests*` entry, so no file under `causalpy/tests/` (plugin included) is
packaged. (`build`/`wheel` are not installable in the shared fleet env, so this
is shown via the discovery API rather than a built wheel.)

## Intermittency

The 6-hour cancellations are intermittent (PRs #1087, #1110), consistent with
real sampling making the leg long enough to hit a race under py3.12's `fork`
default; 3.14 defaults to `forkserver` and is unaffected. This PR removes the
real sampling, so the race can no longer be triggered from the doctest leg; the
timeout is the backstop. No determinism is claimed for the original hang.

## Deliberately not done (left to maintainers)

- **No `"cores": 1` sprinkled across the remaining doctests.** It is redundant
  once the mock applies, and it would edit `causalpy/pymc_models.py`, which open
  PR #1110 rewrites. Left to a maintainer.
- **IV's `cores: 1` untouched** (issue #1067 is blocked upstream).
- **Placement decision posted as a PR comment** for maintainer override.

## Beehive gates

Explore → Plan → adversarial plan review (4 lenses) → implement → adversarial
implementation review (4 lenses) → fact-check → supervise. Details in-thread.
