### PR TITLE
fix: sigma auto-scaling near-zero-variance gap and _clone() opt-out bypass

### DIFF
--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -323,10 +323,12 @@ class SyntheticControl(BaseExperiment):
         user_priors = model._user_priors or {}
         if "y_hat" in user_priors:
             return
-        pinned = type(model)(
-            sample_kwargs=dict(model.sample_kwargs),
-            priors={**user_priors, "y_hat": _LEGACY_Y_HAT_PRIOR},
-        )
+        # Route the opt-out through ``_clone`` rather than ``type(model)(...)``:
+        # subclasses with extra ``__init__`` parameters carry them through their
+        # ``_clone`` override, so a direct reconstruction here would silently
+        # drop that configuration. ``_clone`` takes the pinned prior set as an
+        # override, keeping the sole re-instantiation site inside ``_clone``.
+        pinned = model._clone(priors={**user_priors, "y_hat": _LEGACY_Y_HAT_PRIOR})
         self.model = pinned
         self._model_backend = PyMCModelAdapter(pinned)
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -696,8 +696,10 @@ def _data_scaled_y_hat_prior(y: xr.DataArray) -> Prior:
 
     Each treated unit's rate is ``2 / s_i``, giving ``sigma_i`` a prior mean of
     ``s_i / 2``, where ``s_i`` is that unit's sample standard deviation. Units
-    whose spread is not estimable fall back to ``s_i = 1`` with a warning;
-    non-finite outcomes are a data error and are rejected.
+    whose spread is not estimable -- constant, varying only below the outcome's
+    floating-point resolution, or with fewer than two observations -- fall back
+    to ``s_i = 1`` with a warning; non-finite outcomes are a data error and are
+    rejected.
     """
     y_values = np.asarray(
         y.transpose("obs_ind", "treated_units").values,
@@ -715,20 +717,34 @@ def _data_scaled_y_hat_prior(y: xr.DataArray) -> Prior:
         )
     if y_values.shape[0] < 2:
         scales = np.zeros(y_values.shape[1])
+        magnitudes = np.zeros(y_values.shape[1])
     else:
         scales = np.std(y_values, axis=0, ddof=1)
+        magnitudes = np.max(np.abs(y_values), axis=0)
     with np.errstate(divide="ignore", over="ignore"):
         rates = 2 / scales
-    # A zero (or subnormal) spread carries no scale information, so there is
-    # nothing to calibrate against and the fallback scale is used instead.
-    degenerate = ~np.isfinite(rates) | (rates <= 0)
+    # A spread carries no usable scale information in two cases. First, when it
+    # is zero or subnormal, ``2 / s`` overflows to non-finite or is non-positive.
+    # Second -- and this is the case the plain finite/positive test above misses
+    # -- when it is finite but negligible *relative to the outcome's own
+    # magnitude*. ``eps * |y|`` is the width of one representable float64 step at
+    # that magnitude, so a spread at or below it is indistinguishable from
+    # rounding noise; ``2 / s`` would mint that noise into an absurdly tight yet
+    # finite prior (a near-constant series -- e.g. a broken data pull -- is
+    # exactly this). The threshold is deliberately the resolution floor and no
+    # larger: above it the spread is genuine signal, however small in absolute
+    # terms, and the scale-equivariant ``Exponential(2 / s)`` prior is already
+    # calibrated to it. Both degenerate cases fall back to the default scale.
+    resolution = np.finfo(y_values.dtype).eps * magnitudes
+    degenerate = ~np.isfinite(rates) | (rates <= 0) | (scales <= resolution)
     if np.any(degenerate):
         warnings.warn(
             "Cannot estimate the pre-treatment outcome scale for treated unit(s) "
             f"{_format_treated_units(treated_units[degenerate])}; the series is "
-            "constant or has fewer than two observations. Falling back to an "
-            f"observation-noise scale of {_DEGENERATE_OUTCOME_SCALE} for those "
-            "units. Pass a custom y_hat prior to control this explicitly.",
+            "constant, varies only below its floating-point resolution, or has "
+            "fewer than two observations. Falling back to an observation-noise "
+            f"scale of {_DEGENERATE_OUTCOME_SCALE} for those units. Pass a custom "
+            "y_hat prior to control this explicitly.",
             UserWarning,
             stacklevel=2,
         )

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -258,16 +258,24 @@ class PyMCModel(pm.Model):
 
         self.priors = {**self.default_priors, **(priors or {})}
 
-    def _clone(self) -> "PyMCModel":
+    def _clone(self, priors: dict[str, Any] | None = None) -> "PyMCModel":
         """Create a fresh, unfitted copy with the same configuration.
 
         ``copy.deepcopy`` of a ``pm.Model`` subclass loses its class
         identity, so this method constructs a new instance from the
         stored init parameters instead.
+
+        ``priors`` overrides the stored user priors on the copy. It is the sole
+        supported way to re-instantiate a model with a different prior set (used
+        by the ``auto_scale_sigma=False`` opt-out to pin the legacy noise prior),
+        so that no ``type(model)(...)`` reconstruction that could silently drop
+        subclass ``__init__`` configuration exists outside ``_clone``. Omitting
+        it (the ``clone_model`` sensitivity-check path) preserves the stored
+        priors unchanged.
         """
         return type(self)(
             sample_kwargs=dict(self.sample_kwargs),
-            priors=self._user_priors,
+            priors=self._user_priors if priors is None else priors,
         )
 
     def build_model(
@@ -1967,8 +1975,12 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
         self._seasonality_component = None
         self._validate_and_initialize_components()
 
-    def _clone(self) -> "PyMCModel":
-        """Create a fresh, unfitted copy with the same configuration."""
+    def _clone(self, priors: dict[str, Any] | None = None) -> "PyMCModel":
+        """Create a fresh, unfitted copy with the same configuration.
+
+        ``priors`` overrides the stored user priors on the copy; omitting it
+        preserves them. See :meth:`PyMCModel._clone`.
+        """
         return type(self)(
             n_order=self.n_order,
             n_changepoints_trend=self.n_changepoints_trend,
@@ -1976,7 +1988,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
             trend_component=self._custom_trend_component,
             seasonality_component=self._custom_seasonality_component,
             sample_kwargs=dict(self.sample_kwargs),
-            priors=self._user_priors,
+            priors=self._user_priors if priors is None else priors,
         )
 
     def _validate_and_initialize_components(self):
@@ -2451,8 +2463,12 @@ class StateSpaceTimeSeries(PyMCModel):
         self.second_model: pm.Model | None = None  # Created in build_model()
         self._validate_and_initialize_components()
 
-    def _clone(self) -> "PyMCModel":
-        """Create a fresh, unfitted copy with the same configuration."""
+    def _clone(self, priors: dict[str, Any] | None = None) -> "PyMCModel":
+        """Create a fresh, unfitted copy with the same configuration.
+
+        ``priors`` overrides the stored user priors on the copy; omitting it
+        preserves them. See :meth:`PyMCModel._clone`.
+        """
         return type(self)(
             level_order=self.level_order,
             seasonal_length=self.seasonal_length,
@@ -2460,7 +2476,7 @@ class StateSpaceTimeSeries(PyMCModel):
             seasonality_component=self._custom_seasonality_component,
             sample_kwargs=dict(self.sample_kwargs),
             mode=self.mode,
-            priors=self._user_priors,
+            priors=self._user_priors if priors is None else priors,
         )
 
     def _validate_and_initialize_components(self):

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -693,9 +693,10 @@ def _uses_stock_y_hat_default(model: "PyMCModel") -> bool:
 
 
 #: Fallback outcome scale used when a treated unit's pre-treatment spread cannot
-#: be estimated (a constant series, or fewer than two observations). Keeping the
-#: scale at 1 reproduces the legacy ``HalfNormal(1)`` order of magnitude for
-#: those degenerate units instead of failing a fit that used to work.
+#: be estimated (a constant or sub-resolution series, or fewer than two
+#: observations). Keeping the scale at 1 reproduces the legacy ``HalfNormal(1)``
+#: order of magnitude for those degenerate units instead of failing a fit that
+#: used to work.
 _DEGENERATE_OUTCOME_SCALE = 1.0
 
 

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -484,6 +484,32 @@ def test_near_constant_series_falls_back_like_a_constant_one(fitter_cls):
 
 
 @pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_near_constant_unit_falls_back_only_for_that_unit(fitter_cls):
+    """The relative-resolution guard is per treated unit, not global.
+
+    One near-constant unit (a sub-resolution spread, caught only by the new
+    ``scales <= eps * |y|`` term) mixed with a healthy one: only the degenerate
+    unit falls back and is named in the warning; the healthy unit keeps its data
+    rate. A regression collapsing the per-unit magnitude to a single global
+    scalar (dropping ``axis=0``) would break this.
+    """
+    df, tt, treated = _make_data([1.0, 10.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    values = y.values.copy()
+    level = 5.0
+    values[:, 0] = level
+    values[-1, 0] = np.nextafter(level, np.inf)  # unit 0 near-constant
+    y = xr.DataArray(values, dims=y.dims, coords=y.coords)
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment") as record:
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    message = str(record[0].message)
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    assert lam[0] == 2.0  # degenerate unit -> fallback
+    assert "treated_0" in message and "treated_1" not in message
+    np.testing.assert_allclose(lam[1], 2 / np.std(values[:, 1], ddof=1))
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
 def test_finite_but_sub_resolution_scale_falls_back(monkeypatch, fitter_cls):
     """A finite sd negligible against the data magnitude falls back, not ~2e200.
 

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -32,7 +32,11 @@ import xarray as xr
 from pymc_extras.prior import Prior
 
 import causalpy as cp
-from causalpy.pymc_models import SoftmaxWeightedSumFitter, WeightedSumFitter
+from causalpy.pymc_models import (
+    SoftmaxWeightedSumFitter,
+    WeightedSumFitter,
+    _uses_stock_y_hat_default,
+)
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2, "progressbar": False}
 
@@ -543,6 +547,64 @@ def test_small_but_resolvable_relative_variation_is_not_degenerate(fitter_cls):
         priors = _fitter(fitter_cls).priors_from_data(X, y)
     lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
     np.testing.assert_allclose(lam, 2 / np.std(values, axis=0, ddof=1))
+
+
+class _ExtraArgWeightedSumFitter(WeightedSumFitter):
+    """A weighted-sum subclass that, like the real time-series fitters, carries
+    an extra ``__init__`` parameter and a matching ``_clone`` override.
+
+    It inherits ``default_priors = {"y_hat": _LEGACY_Y_HAT_PRIOR}`` from
+    ``WeightedSumFitter``, so -- unlike ``BayesianBasisExpansionTimeSeries``,
+    whose ``default_priors`` is empty -- the ``auto_scale_sigma=False`` opt-out
+    actually fires for it, exercising the clone path with real extra config.
+    """
+
+    def __init__(self, marker="default", **kwargs):
+        super().__init__(**kwargs)
+        self.marker = marker
+
+    def _clone(self, priors=None):
+        return type(self)(
+            marker=self.marker,
+            sample_kwargs=dict(self.sample_kwargs),
+            priors=self._user_priors if priors is None else priors,
+        )
+
+
+@pytest.mark.integration
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_opt_out_preserves_subclass_init_config_through_clone(mock_pymc_sample):
+    """auto_scale_sigma=False on a subclass with extra __init__ args keeps them.
+
+    The opt-out re-instantiates the model to pin the legacy prior. Routing that
+    through ``_clone`` (not ``type(model)(...)``) means the subclass's extra
+    ``marker`` config survives; the direct reconstruction on the base branch
+    reset it to the default. This reproduces the
+    ``BayesianBasisExpansionTimeSeries`` pattern -- extra init args plus a
+    ``_clone`` override -- on a fitter that actually reaches the opt-out.
+    """
+    df, tt, treated = _make_data([1.0])
+    model = _ExtraArgWeightedSumFitter(
+        marker="preserved", sample_kwargs={**sample_kwargs, "random_seed": 1}
+    )
+    # Precondition: this subclass really does reach the pin path. A silent no-op
+    # would let the assertions below pass for the wrong reason.
+    assert _uses_stock_y_hat_default(model)
+    result = cp.SyntheticControl(
+        df,
+        tt,
+        control_units=["a", "b", "c"],
+        treated_units=treated,
+        model=model,
+        auto_scale_sigma=False,
+    )
+    pinned = result.model
+    assert pinned is not model  # the opt-out fit a fresh copy
+    assert isinstance(pinned, _ExtraArgWeightedSumFitter)
+    assert pinned.marker == "preserved"  # dropped by type(model)(...) on base
+    sigma = pinned.priors["y_hat"].parameters["sigma"]
+    assert sigma.distribution == "HalfNormal"
+    assert sigma.parameters["sigma"] == 1
 
 
 @pytest.mark.integration

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -23,6 +23,8 @@ The tests use ``mock_pymc_sample`` where model construction is needed and never
 run real MCMC.
 """
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pytest
@@ -451,6 +453,96 @@ def test_finite_scale_rate_boundaries_are_checked(
         rate = np.asarray(sigma.parameters["lam"])
         assert np.all(np.isfinite(rate))
         assert np.all(rate > 0)
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_near_constant_series_falls_back_like_a_constant_one(fitter_cls):
+    """A spread below the outcome's float resolution is treated as degenerate.
+
+    A near-constant pre-period -- a broken data pull, say -- has a finite but
+    negligible sd, so ``2 / s`` is enormous yet finite and slips past the plain
+    zero/subnormal guard, minting a ~1e16 rate with no warning. Relative to the
+    outcome's own magnitude the spread is below one representable float64 step,
+    so it must fall back to the default scale rather than that absurd rate.
+    """
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    level = 5.0
+    values = np.full(y.shape, level)
+    # A single row perturbed by one unit in the last place: a genuine, finite,
+    # sub-resolution spread that the old ``~isfinite | rate <= 0`` guard misses.
+    values[-1, 0] = np.nextafter(level, np.inf)
+    y = xr.DataArray(values, dims=y.dims, coords=y.coords)
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment"):
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    assert lam[0] == 2.0  # 2 / _DEGENERATE_OUTCOME_SCALE, not 2 / sd ~ 1e16
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_finite_but_sub_resolution_scale_falls_back(monkeypatch, fitter_cls):
+    """A finite sd negligible against the data magnitude falls back, not ~2e200.
+
+    ``np.std`` is forced to a tiny-but-finite ``1e-200`` while the outcome stays
+    at unit magnitude, so ``2 / s = 2e200`` is finite and positive and escapes
+    the zero/subnormal guard. The degeneracy decision reads the magnitude from
+    ``np.max`` on the *real* data (not from the patched ``np.std``), so the
+    relative test still fires and the rate falls back to 2.0 -- if the guard
+    ever derived the magnitude from ``np.std`` this test would be circular.
+    """
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    monkeypatch.setattr(np, "std", lambda *_a, **_k: np.array([1e-200]))
+    with pytest.warns(UserWarning, match="Cannot estimate the pre-treatment"):
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    assert lam[0] == 2.0
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_genuinely_small_scale_outcome_keeps_its_data_rate(fitter_cls):
+    """The guard is relative, not absolute: a legitimately tiny-scale outcome
+    keeps its data-derived rate.
+
+    Rescaling the outcome to magnitude ~1e-100 while preserving its relative
+    spread must NOT be flagged: ``Exponential(2 / s)`` is scale-equivariant, so
+    a genuinely tiny scale deserves a genuinely large rate, not the fallback.
+    This is the guardrail against an over-aggressive absolute threshold.
+    (Magnitude ~1e-100 keeps ``std`` computable -- around ~1e-200 the squared
+    deviations underflow to zero, which is a genuine float64 limit, not signal.)
+    """
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    tiny = 1e-100 * (y.values / np.max(np.abs(y.values)))
+    y = xr.DataArray(tiny, dims=y.dims, coords=y.coords)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)  # any degeneracy warning fails
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    np.testing.assert_allclose(lam, 2 / np.std(tiny, axis=0, ddof=1), rtol=1e-6)
+    assert lam[0] > 1e50  # tiny scale -> large finite data rate, not fallback 2.0
+
+
+@pytest.mark.parametrize("fitter_cls", FITTERS)
+def test_small_but_resolvable_relative_variation_is_not_degenerate(fitter_cls):
+    """Healthy low-variance data is left untouched -- the guard sits at eps.
+
+    A relative spread of ~1e-6 is far above the float64 resolution floor
+    (~1e-16), so it is real signal: no warning fires and the rate is the
+    data-derived ``2 / s``. This pins the threshold to the resolution scale and
+    protects the healthy-data behaviour the parameter-recovery tests depend on.
+    """
+    df, tt, treated = _make_data([1.0])
+    X, y = _pre_treatment_design(df, tt, treated)
+    rng = np.random.default_rng(0)
+    level = 100.0
+    values = level + rng.normal(0, level * 1e-6, size=y.shape)  # rel. sd ~1e-6
+    y = xr.DataArray(values, dims=y.dims, coords=y.coords)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        priors = _fitter(fitter_cls).priors_from_data(X, y)
+    lam = np.asarray(priors["y_hat"].parameters["sigma"].parameters["lam"])
+    np.testing.assert_allclose(lam, 2 / np.std(values, axis=0, ddof=1))
 
 
 @pytest.mark.integration

--- a/causalpy/tests/test_auto_scale_sigma.py
+++ b/causalpy/tests/test_auto_scale_sigma.py
@@ -598,7 +598,6 @@ class _ExtraArgWeightedSumFitter(WeightedSumFitter):
 
 
 @pytest.mark.integration
-@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_opt_out_preserves_subclass_init_config_through_clone(mock_pymc_sample):
     """auto_scale_sigma=False on a subclass with extra __init__ args keeps them.
 

--- a/causalpy/tests/test_timeseries_model_coverage.py
+++ b/causalpy/tests/test_timeseries_model_coverage.py
@@ -760,6 +760,34 @@ class TestTimeSeriesModelClonePreservesPriors:
         assert cloned._user_priors == override
         assert cloned.level_order == 1
 
+    def test_all_shipped_pymc_model_clones_accept_priors_override(self):
+        """Every shipped ``PyMCModel._clone`` must accept the ``priors`` override.
+
+        The ``auto_scale_sigma=False`` opt-out pins the legacy prior via
+        ``_clone(priors=...)``; a subclass whose override dropped the parameter
+        would silently lose the pin. Since the design threads ``priors`` per
+        override rather than through a single template method, this guards the
+        exact drift that would reintroduce the bug one inheritance level up.
+        """
+        import inspect
+
+        from causalpy.pymc_models import PyMCModel
+
+        def _subclasses(cls):
+            for sub in cls.__subclasses__():
+                yield sub
+                yield from _subclasses(sub)
+
+        shipped = [
+            cls
+            for cls in _subclasses(PyMCModel)
+            if cls.__module__ == "causalpy.pymc_models"
+        ]
+        assert shipped  # sanity: the subclasses were discovered
+        for cls in shipped:
+            params = inspect.signature(cls._clone).parameters
+            assert "priors" in params, f"{cls.__name__}._clone drops priors override"
+
 
 class TestTimeSeriesModelCloneIsUnfitted:
     """Regression tests: ``_clone()`` returns a fresh model with no fitted state.

--- a/causalpy/tests/test_timeseries_model_coverage.py
+++ b/causalpy/tests/test_timeseries_model_coverage.py
@@ -721,6 +721,45 @@ class TestTimeSeriesModelClonePreservesPriors:
         assert cloned._user_priors == custom_priors
         assert cloned._user_priors is not None
 
+    def test_bayesian_basis_expansion_clone_accepts_priors_override(self):
+        """BSTS._clone(priors=...) overrides priors and keeps extra init args.
+
+        The ``auto_scale_sigma=False`` opt-out pins the legacy prior by cloning
+        with a ``priors`` override; the subclass override must accept it and
+        still carry ``n_order`` and friends, or the base and override signatures
+        drift apart.
+        """
+        pytest.importorskip(
+            "pymc_marketing",
+            reason="pymc-marketing optional for default BSTS components",
+        )
+        original = cp.pymc_models.BayesianBasisExpansionTimeSeries(
+            n_order=7,
+            sample_kwargs={"draws": 10, "tune": 10, "progressbar": False},
+            priors={"sentinel": "value"},
+        )
+        override = {"y_hat": "pinned"}
+        cloned = original._clone(priors=override)
+        assert cloned._user_priors == override  # override applied
+        assert cloned.n_order == 7  # extra init arg preserved through the clone
+
+    def test_state_space_clone_accepts_priors_override(self):
+        """StateSpaceTimeSeries._clone(priors=...) overrides priors, keeps args."""
+        pytest.importorskip(
+            "pymc_extras",
+            reason="pymc-extras optional for state-space model",
+        )
+        original = cp.pymc_models.StateSpaceTimeSeries(
+            level_order=1,
+            seasonal_length=7,
+            sample_kwargs={"draws": 10, "tune": 10, "chains": 1, "progressbar": False},
+            priors={"sentinel": "value"},
+        )
+        override = {"y_hat": "pinned"}
+        cloned = original._clone(priors=override)
+        assert cloned._user_priors == override
+        assert cloned.level_order == 1
+
 
 class TestTimeSeriesModelCloneIsUnfitted:
     """Regression tests: ``_clone()`` returns a fresh model with no fitted state.


### PR DESCRIPTION
Part of #1048.

Fixes two post-merge issues in the synthetic-control sigma auto-scaling
(`auto_scale_sigma`, from #1106) that CI did not catch. They are independent —
different code paths, **not** a shared root cause — so they are fixed
separately, one commit each (plus a third commit adding review-driven coverage).

## Finding 1 — near-zero-but-finite variance silently produces an absurd prior

`_data_scaled_y_hat_prior` sets `sigma_i ~ Exponential(2 / s_i)` from each
treated unit's pre-treatment spread `s_i`. The degeneracy guard was
`~isfinite(rates) | (rates <= 0)`, which only catches a zero or subnormal
spread. A near-constant series — what a broken data pull looks like — has a
finite but tiny `s_i`, so `2 / s_i` is finite and enormous (~1e16) and slipped
through, minting a silently over-confident prior with **no warning**.

**Fix.** Add a relative-magnitude guard: a spread at or below `eps * |y|` — the
width of one representable float64 step at the outcome's own magnitude — is
indistinguishable from rounding noise, so it is treated as degenerate and falls
back to the documented default scale (rate `2 / 1.0`) with the existing warning.

The threshold is deliberately the float64 **resolution floor and no larger**,
and justified in terms of the data scale rather than an arbitrary epsilon:
`Exponential(2 / s)` is scale-equivariant, so a genuinely small *but resolvable*
spread is real signal the prior is already calibrated to and is left untouched.
This is why a merely "practically constant" multi-ULP spread is intentionally
**not** flagged — there is no principled cutoff between that and legitimate
low-variance data, whereas the resolution floor is exactly where a computed std
stops being distinguishable from rounding of the data's own magnitude.

## Finding 2 — the `auto_scale_sigma=False` opt-out bypassed `_clone()`

`_pin_legacy_sigma_prior` re-instantiated the model with
`type(model)(sample_kwargs=..., priors=...)`, dropping any subclass `__init__`
configuration — exactly the arguments the `_clone` overrides on
`BayesianBasisExpansionTimeSeries` and `StateSpaceTimeSeries` exist to carry.

**Fix (structural, not at the one call site).** `_clone` gains an optional
`priors` override (falling back to the stored user priors when omitted, so the
arg-less `clone_model` sensitivity-check path is unchanged), and the opt-out
routes through `model._clone(priors={..., "y_hat": _LEGACY_Y_HAT_PRIOR})`. No
`type(model)(...)` reconstruction that could drop subclass config remains
outside `_clone`. `priors` is a value override, not a behaviour flag.

**Honest reachability note.** The two named subclasses inherit an empty
`default_priors`, so `_uses_stock_y_hat_default` is False for them and the
opt-out never fires — it currently fires only for `WeightedSumFitter` /
`SoftmaxWeightedSumFitter`, which take no extra init args. So this is structural
hardening against a plausible `WeightedSumFitter` subclass, **not** a live
regression in any shipped class. The added test reproduces the pattern on a
subclass that does reach the opt-out.

## Tests

**Regression catchers — fail on base, pass here:**

- `test_near_constant_series_falls_back_like_a_constant_one` — 1-ULP series → warns + fallback rate 2.0 (would mint ~1e16 on base).
- `test_near_constant_unit_falls_back_only_for_that_unit` — one sub-resolution + one healthy unit → per-unit fallback; guards the `axis=0` per-unit resolution against a global-scalar regression.
- `test_finite_but_sub_resolution_scale_falls_back` — finite ~1e-200 scale → fallback, not ~2e200.
- `test_opt_out_preserves_subclass_init_config_through_clone` — extra-init-arg subclass survives the opt-out clone (base drops the config).
- `test_state_space_clone_accepts_priors_override` (+ `bayesian_basis_expansion` twin, import-gated) — real subclass `_clone(priors=...)` forwards the override and keeps init args; raises `TypeError` on the old no-arg `_clone`.
- `test_all_shipped_pymc_model_clones_accept_priors_override` — structural guard that every shipped `PyMCModel._clone` accepts the override.

**Inertness guardrails — pass on base *and* here, by design** (they assert the
change did not over-fire; they defend the threshold, they do not catch the
original bug):

- `test_genuinely_small_scale_outcome_keeps_its_data_rate` — ~1e-100 magnitude keeps its large data rate (scale-equivariance).
- `test_small_but_resolvable_relative_variation_is_not_degenerate` — ~1e-6 relative sd is untouched, pinning the threshold at the eps scale.

The change is inert for all healthy data (`cp.load_data("sc")` has
sd/magnitude ≈ 0.2 ≫ eps), so it must not move the #1108 parameter-recovery
tests; if it does, that is signal to investigate, not to widen tolerance.

## Deliberately not done / overlap

- **Not touched:** the #1105 placebo `tau` degeneracy (sibling unit), `_plot`'s
  `**kwargs`, and the `pymc_models.py` doctest `cores` kwargs (#1110). The diff
  is confined to the sigma path.
- **Considered and deferred:** a template-method `_clone` (base owns the single
  `type(self)(...)` and a `_clone_init_kwargs()` hook) would remove the
  "future subclass author forgets to thread priors" hazard entirely, but it
  rewrites the two timeseries `_clone` overrides. The current per-override
  `priors` param keeps the diff tight and the protocol consistent (and
  `test_all_shipped_pymc_model_clones_accept_priors_override` guards the drift);
  the template-method refactor is a better fit to land alongside #1110.

## Environment note

The fleet's shared interpreter has `pymc_extras` installed but not
`pymc_marketing`. So the `StateSpaceTimeSeries` clone-override test (gated on
`pymc_extras`) runs locally, while the `BayesianBasisExpansionTimeSeries` twin
(gated on `pymc_marketing`) is `importorskip`-skipped locally; both run in CI,
which has the full dependency set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
