### PR TITLE
fix: PlaceboInTime single-fold tau degeneracy (spurious SUPPORTED)

### DIFF
--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -81,6 +81,16 @@ _DEFAULT_SAMPLE_KWARGS: dict[str, Any] = {
 }
 
 
+class _NullModelUnidentifiedError(ValueError):
+    """Raised when the hierarchical null's between-fold spread is unidentified.
+
+    A subclass of :class:`ValueError` so existing ``except ValueError`` callers
+    keep working.  :meth:`PlaceboInTime.run` catches it and abstains
+    (INCONCLUSIVE) rather than building a scale-free null that could report a
+    spurious verdict.
+    """
+
+
 def _is_non_positive_length(length: Any) -> bool:
     """Return whether a window length is orderable against zero and not positive.
 
@@ -814,11 +824,11 @@ class PlaceboInTime:
 
         Raises
         ------
-        ValueError
+        _NullModelUnidentifiedError
             If the between-fold spread is unidentified, i.e.
             ``np.nanstd(fold_means)`` is not positive and finite. Building the
             null in that case would collapse it to a prior-driven width and
-            could report a spurious verdict.
+            could report a spurious verdict. A subclass of ``ValueError``.
         """
         n_folds = len(fold_means)
         fold_sds = np.where(fold_sds < 1e-6, 1e-6, fold_sds)
@@ -835,7 +845,7 @@ class PlaceboInTime:
         # complete; this guards the residual case of >= 2 folds whose
         # cumulative impacts coincide (e.g. an almost-constant series).
         if not np.isfinite(prior_mu_scale) or prior_mu_scale <= 0.0:
-            raise ValueError(
+            raise _NullModelUnidentifiedError(
                 "Cannot identify the hierarchical status-quo null: the "
                 f"{n_folds} completed placebo fold(s) have no between-fold "
                 "spread in their cumulative impacts (np.nanstd(fold_means) is "
@@ -1348,28 +1358,56 @@ class PlaceboInTime:
         n_completed = len(fold_results)
         n_skipped = len(skipped_folds)
 
-        if n_completed < MIN_USABLE_FOLDS:
-            if n_completed == 0:
-                summary = (
-                    f"Placebo-in-time analysis: 0 folds completed "
-                    f"({n_skipped} skipped)."
+        # A verdict requires a hierarchical null whose between-fold spread is
+        # identified.  It is not when fewer than ``MIN_USABLE_FOLDS`` folds
+        # complete (``np.nanstd`` of one fold is 0), nor when the completed
+        # folds have coincident cumulative impacts (``np.nanstd`` still 0).  In
+        # both cases the null loses all data scaling and collapses to a
+        # prior-driven width, which can flip the verdict to a spurious
+        # SUPPORTED.  Abstain (INCONCLUSIVE) instead — mirroring PlaceboInSpace,
+        # which returns ``passed=None`` when it lacks enough units to
+        # characterise its null.  The count is checked here; the coincident-fold
+        # case is detected inside ``_build_status_quo_model`` (which raises) so
+        # that monkeypatched builds and direct callers stay consistent.
+        fold_means = np.array([fr.fold_mean for fr in fold_results])
+        fold_sds = np.array([fr.fold_sd for fr in fold_results])
+
+        inconclusive: tuple[str, str] | None = None
+        idata = None
+        theta_new_samples = None
+        if n_completed == 0:
+            inconclusive = (
+                f"Placebo-in-time analysis: 0 folds completed ({n_skipped} skipped).",
+                "INCONCLUSIVE — no folds completed.",
+            )
+        elif n_completed < MIN_USABLE_FOLDS:
+            inconclusive = (
+                f"Placebo-in-time analysis: {n_completed} of {self.n_folds} "
+                f"folds completed ({n_skipped} skipped).",
+                f"INCONCLUSIVE — only {n_completed} usable fold; at least "
+                f"{MIN_USABLE_FOLDS} are required to identify the between-fold "
+                "status-quo spread. A single fold leaves the null distribution "
+                "unidentified, so no verdict is issued.",
+            )
+
+        if inconclusive is None:
+            try:
+                idata, theta_new_samples = self._build_status_quo_model(
+                    fold_means, fold_sds
                 )
-                verdict = "INCONCLUSIVE — no folds completed."
-            else:
-                # A single usable fold cannot identify the between-fold null
-                # spread, so the hierarchical null model is degenerate and any
-                # verdict would be driven by prior width rather than evidence.
-                # Abstain instead of building it (never surface as SUPPORTED).
-                summary = (
+            except _NullModelUnidentifiedError:
+                inconclusive = (
                     f"Placebo-in-time analysis: {n_completed} of "
-                    f"{self.n_folds} folds completed ({n_skipped} skipped)."
+                    f"{self.n_folds} folds completed ({n_skipped} skipped).",
+                    f"INCONCLUSIVE — the {n_completed} usable folds have "
+                    "coincident cumulative impacts, so the between-fold "
+                    "status-quo spread is unidentified. Building a null from it "
+                    "would collapse to a prior-driven width, so no verdict is "
+                    "issued.",
                 )
-                verdict = (
-                    f"INCONCLUSIVE — only {n_completed} usable fold; at least "
-                    f"{MIN_USABLE_FOLDS} are required to identify the "
-                    "between-fold status-quo spread. A single fold leaves the "
-                    "null distribution unidentified, so no verdict is issued."
-                )
+
+        if inconclusive is not None:
+            summary, verdict = inconclusive
             parts = [summary, verdict]
             parts.extend(fold_summaries)
             return CheckResult(
@@ -1390,10 +1428,8 @@ class PlaceboInTime:
                 },
             )
 
-        fold_means = np.array([fr.fold_mean for fr in fold_results])
-        fold_sds = np.array([fr.fold_sd for fr in fold_results])
-
-        idata, theta_new_samples = self._build_status_quo_model(fold_means, fold_sds)
+        # Reaching here means the null model was built successfully.
+        assert idata is not None and theta_new_samples is not None
 
         p_outside = float(
             (np.abs(actual_cumulative_mean) > np.abs(theta_new_samples)).mean()

--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -811,14 +811,37 @@ class PlaceboInTime:
             ``(idata, theta_new_samples)`` where ``theta_new_samples``
             are draws from the posterior predictive for a new null
             period.
+
+        Raises
+        ------
+        ValueError
+            If the between-fold spread is unidentified, i.e.
+            ``np.nanstd(fold_means)`` is not positive and finite. Building the
+            null in that case would collapse it to a prior-driven width and
+            could report a spurious verdict.
         """
         n_folds = len(fold_means)
         fold_sds = np.where(fold_sds < 1e-6, 1e-6, fold_sds)
 
         prior_mu_center = float(np.nanmean(fold_means))
         prior_mu_scale = float(np.nanstd(fold_means))
-        if prior_mu_scale <= 0.0:
-            prior_mu_scale = 1.0
+        # A non-positive (or non-finite) between-fold spread means the null's
+        # scale is unidentified from these folds. Silently substituting a bare
+        # ``1.0`` here strips all data scaling from the ``mu`` and ``tau``
+        # priors and collapses the null to a prior-driven O(1) width, which on
+        # a large-scale series flips the verdict to a spurious SUPPORTED. Fail
+        # loudly instead. ``run`` already abstains (INCONCLUSIVE) before
+        # reaching this point when fewer than ``MIN_USABLE_FOLDS`` folds
+        # complete; this guards the residual case of >= 2 folds whose
+        # cumulative impacts coincide (e.g. an almost-constant series).
+        if not np.isfinite(prior_mu_scale) or prior_mu_scale <= 0.0:
+            raise ValueError(
+                "Cannot identify the hierarchical status-quo null: the "
+                f"{n_folds} completed placebo fold(s) have no between-fold "
+                "spread in their cumulative impacts (np.nanstd(fold_means) is "
+                "not positive). Use more folds or a longer pre-intervention "
+                "span so the placebo windows differ."
+            )
 
         scale = self.prior_scale
         coords = {"fold": np.arange(n_folds)}

--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -57,6 +57,15 @@ logger = logging.getLogger(__name__)
 MIN_FOLD_OBSERVATIONS = 3
 MAX_RANDOM_SELECTION_RETRIES = 16
 
+# The hierarchical status-quo (null) model estimates the between-fold spread
+# ``tau_status_quo`` from the completed folds.  That spread is unidentified from
+# a single fold: ``prior_mu_scale = np.nanstd([x]) == 0.0`` falls back to
+# ``1.0``, stripping all data scaling from both the ``mu`` and ``tau`` priors
+# and collapsing the null distribution to a prior-driven O(1) width.  On a
+# large-scale series that flips the verdict to a spurious SUPPORTED, so at least
+# this many usable folds are required before a verdict is issued.
+MIN_USABLE_FOLDS = 2
+
 # Placebo windows are half-open (``[t, t + intervention_length)``) while the
 # actual effect is summarised over the whole post-intervention period.  With
 # the derived default ``intervention_length`` those two spans differ by at most
@@ -1316,11 +1325,29 @@ class PlaceboInTime:
         n_completed = len(fold_results)
         n_skipped = len(skipped_folds)
 
-        if n_completed < 1:
-            parts = [
-                f"Placebo-in-time analysis: 0 folds completed ({n_skipped} skipped).",
-                "INCONCLUSIVE — no folds completed.",
-            ]
+        if n_completed < MIN_USABLE_FOLDS:
+            if n_completed == 0:
+                summary = (
+                    f"Placebo-in-time analysis: 0 folds completed "
+                    f"({n_skipped} skipped)."
+                )
+                verdict = "INCONCLUSIVE — no folds completed."
+            else:
+                # A single usable fold cannot identify the between-fold null
+                # spread, so the hierarchical null model is degenerate and any
+                # verdict would be driven by prior width rather than evidence.
+                # Abstain instead of building it (never surface as SUPPORTED).
+                summary = (
+                    f"Placebo-in-time analysis: {n_completed} of "
+                    f"{self.n_folds} folds completed ({n_skipped} skipped)."
+                )
+                verdict = (
+                    f"INCONCLUSIVE — only {n_completed} usable fold; at least "
+                    f"{MIN_USABLE_FOLDS} are required to identify the "
+                    "between-fold status-quo spread. A single fold leaves the "
+                    "null distribution unidentified, so no verdict is issued."
+                )
+            parts = [summary, verdict]
             parts.extend(fold_summaries)
             return CheckResult(
                 check_name="PlaceboInTime",

--- a/causalpy/tests/test_placebo_in_time.py
+++ b/causalpy/tests/test_placebo_in_time.py
@@ -929,9 +929,7 @@ def _make_scaled_fake_experiment(
     totals = rng.normal(cumulative_mean, cumulative_sd, size=n_draws)
     per_obs = (totals / n_post).reshape(1, n_draws, 1, 1)
     post = np.broadcast_to(per_obs, (1, n_draws, n_post, 1)).copy()
-    post_impact = xr.DataArray(
-        post, dims=("chain", "draw", "obs_ind", "treated_units")
-    )
+    post_impact = xr.DataArray(post, dims=("chain", "draw", "obs_ind", "treated_units"))
     return SimpleNamespace(
         data=data,
         treatment_time=treatment_time,
@@ -1021,9 +1019,7 @@ def test_skips_down_to_single_fold_does_not_report_supported_on_large_scale():
         random_seed=42,
     )
 
-    with pytest.warns(
-        UserWarning, match="shorter than one full intervention window"
-    ):
+    with pytest.warns(UserWarning, match="shorter than one full intervention window"):
         result = check.run(experiment)
 
     assert result.metadata["n_folds_requested"] == 2

--- a/causalpy/tests/test_placebo_in_time.py
+++ b/causalpy/tests/test_placebo_in_time.py
@@ -979,7 +979,6 @@ def test_single_fold_directly_does_not_report_supported_on_large_scale():
     # A single usable fold cannot characterise the null distribution, so the
     # verdict must abstain rather than (spuriously) claim the effect is real.
     assert result.passed is None
-    assert result.passed is not True
     assert "SUPPORTED" not in result.text
     assert "INCONCLUSIVE" in result.text
     # No degenerate null was built.
@@ -1025,11 +1024,66 @@ def test_skips_down_to_single_fold_does_not_report_supported_on_large_scale():
     assert result.metadata["n_folds_requested"] == 2
     assert result.metadata["n_folds_completed"] == 1
     assert result.passed is None
-    assert result.passed is not True
     assert "SUPPORTED" not in result.text
     assert "INCONCLUSIVE" in result.text
     assert "null_samples" not in result.metadata
     assert "p_effect_outside_null" not in result.metadata
+
+
+def test_build_status_quo_model_raises_when_between_fold_spread_unidentified():
+    """>=2 folds with identical means must not fabricate a scale-free null.
+
+    The single-fold routes are abstained in :meth:`PlaceboInTime.run` before
+    the model is built.  This guards the residual root cause directly: when the
+    completed folds have no between-fold spread (``np.nanstd(fold_means) == 0``,
+    e.g. an almost-constant series with >= 2 folds), the old ``prior_mu_scale``
+    fallback to ``1.0`` stripped all data scaling and collapsed the null to an
+    O(1) width, flipping the verdict to a spurious SUPPORTED.  It must now fail
+    loudly rather than build that null.
+    """
+    check = PlaceboInTime(sample_kwargs=_FAST_HIERARCHICAL_KWARGS)
+    with pytest.raises(ValueError, match="Cannot identify the hierarchical"):
+        check._build_status_quo_model(
+            np.array([5000.0, 5000.0]),
+            np.array([300.0, 300.0]),
+        )
+
+
+def test_identical_folds_do_not_report_supported_end_to_end():
+    """A near-constant large-scale series must never surface as SUPPORTED.
+
+    Two folds complete (so the single-fold count guard does not apply) but with
+    identical cumulative impacts, so the between-fold null spread is
+    unidentified.  ``run`` must not return a verdict for such a degenerate
+    configuration.
+    """
+    data = pd.DataFrame({"y": np.zeros(120)}, index=np.arange(120))
+    experiment = _make_scaled_fake_experiment(
+        data,
+        treatment_time=90,
+        cumulative_mean=5150.0,
+        cumulative_sd=0.0,
+    )
+
+    def factory(fold_data, treatment_time):
+        return _make_scaled_fake_experiment(
+            fold_data,
+            treatment_time,
+            cumulative_mean=5000.0,
+            cumulative_sd=0.0,
+            seed=1,
+        )
+
+    check = PlaceboInTime(
+        n_folds=2,
+        intervention_length=30,
+        experiment_factory=factory,
+        sample_kwargs=_FAST_HIERARCHICAL_KWARGS,
+        random_seed=42,
+    )
+
+    with pytest.raises(ValueError, match="Cannot identify the hierarchical"):
+        check.run(experiment)
 
 
 def test_random_run_is_inconclusive_with_no_feasible_folds():

--- a/causalpy/tests/test_placebo_in_time.py
+++ b/causalpy/tests/test_placebo_in_time.py
@@ -904,6 +904,138 @@ def test_run_is_inconclusive_when_no_fold_has_enough_pre_period():
     assert "p_effect_outside_null" not in result.metadata
 
 
+# ===========================================================================
+# Single usable fold degeneracy (regression for the tau-scale collapse)
+# ===========================================================================
+
+
+def _make_scaled_fake_experiment(
+    data: pd.DataFrame,
+    treatment_time: int,
+    cumulative_mean: float,
+    cumulative_sd: float,
+    n_draws: int = 400,
+    seed: int = 0,
+) -> SimpleNamespace:
+    """Create a fake Bayesian experiment with a controlled cumulative impact.
+
+    The returned ``post_impact`` sums (over ``obs_ind``) to a draw-level
+    cumulative impact with the requested mean and standard deviation, so the
+    downstream hierarchical null and verdict are exercised on a series whose
+    scale we choose deterministically.
+    """
+    rng = np.random.default_rng(seed)
+    n_post = max(int((data.index >= treatment_time).sum()), 1)
+    totals = rng.normal(cumulative_mean, cumulative_sd, size=n_draws)
+    per_obs = (totals / n_post).reshape(1, n_draws, 1, 1)
+    post = np.broadcast_to(per_obs, (1, n_draws, n_post, 1)).copy()
+    post_impact = xr.DataArray(
+        post, dims=("chain", "draw", "obs_ind", "treated_units")
+    )
+    return SimpleNamespace(
+        data=data,
+        treatment_time=treatment_time,
+        _model_backend=SimpleNamespace(supports_idata=True),
+        model=SimpleNamespace(),
+        post_impact=post_impact,
+    )
+
+
+def test_single_fold_directly_does_not_report_supported_on_large_scale():
+    """A large-scale series with ``n_folds=1`` must not fabricate SUPPORTED.
+
+    Route 1 to a single usable fold: ``n_folds=1`` requested directly.  With a
+    single fold the between-fold spread ``tau_status_quo`` is unidentified and
+    collapses to its prior width (~O(1)), so the null distribution loses all
+    data scaling.  An actual effect that is well within the fold's own noise at
+    the data scale must therefore never be declared "outside the null".
+    """
+    data = pd.DataFrame({"y": np.zeros(90)}, index=np.arange(90))
+    experiment = _make_scaled_fake_experiment(
+        data,
+        treatment_time=60,
+        cumulative_mean=5150.0,
+        cumulative_sd=0.0,
+    )
+
+    def factory(fold_data, treatment_time):
+        return _make_scaled_fake_experiment(
+            fold_data,
+            treatment_time,
+            cumulative_mean=5000.0,
+            cumulative_sd=300.0,
+            seed=1,
+        )
+
+    check = PlaceboInTime(
+        n_folds=1,
+        intervention_length=30,
+        experiment_factory=factory,
+        sample_kwargs=_FAST_HIERARCHICAL_KWARGS,
+        random_seed=42,
+    )
+
+    result = check.run(experiment)
+
+    assert result.metadata["n_folds_completed"] == 1
+    # A single usable fold cannot characterise the null distribution, so the
+    # verdict must abstain rather than (spuriously) claim the effect is real.
+    assert result.passed is None
+    assert result.passed is not True
+    assert "SUPPORTED" not in result.text
+    assert "INCONCLUSIVE" in result.text
+    # No degenerate null was built.
+    assert "null_samples" not in result.metadata
+    assert "p_effect_outside_null" not in result.metadata
+
+
+def test_skips_down_to_single_fold_does_not_report_supported_on_large_scale():
+    """Skips reducing ``n_folds>1`` to one usable fold must not report SUPPORTED.
+
+    Route 2 to a single usable fold: ``n_folds=2`` requested, but the earlier
+    fold is skipped for insufficient pre-period, leaving exactly one usable
+    fold.  This must reach the same abstention as the direct ``n_folds=1``
+    route rather than build a degenerate single-fold null.
+    """
+    data = pd.DataFrame({"y": np.zeros(100)}, index=np.arange(100))
+    experiment = _make_scaled_fake_experiment(
+        data,
+        treatment_time=70,
+        cumulative_mean=5150.0,
+        cumulative_sd=0.0,
+    )
+
+    def factory(fold_data, treatment_time):
+        return _make_scaled_fake_experiment(
+            fold_data,
+            treatment_time,
+            cumulative_mean=5000.0,
+            cumulative_sd=300.0,
+            seed=1,
+        )
+
+    check = PlaceboInTime(
+        n_folds=2,
+        experiment_factory=factory,
+        sample_kwargs=_FAST_HIERARCHICAL_KWARGS,
+        random_seed=42,
+    )
+
+    with pytest.warns(
+        UserWarning, match="shorter than one full intervention window"
+    ):
+        result = check.run(experiment)
+
+    assert result.metadata["n_folds_requested"] == 2
+    assert result.metadata["n_folds_completed"] == 1
+    assert result.passed is None
+    assert result.passed is not True
+    assert "SUPPORTED" not in result.text
+    assert "INCONCLUSIVE" in result.text
+    assert "null_samples" not in result.metadata
+    assert "p_effect_outside_null" not in result.metadata
+
+
 def test_random_run_is_inconclusive_with_no_feasible_folds():
     """A zero-candidate random selection cannot fabricate a null."""
     data = pd.DataFrame({"y": np.zeros(100)}, index=np.arange(100))

--- a/causalpy/tests/test_placebo_in_time.py
+++ b/causalpy/tests/test_placebo_in_time.py
@@ -1049,13 +1049,14 @@ def test_build_status_quo_model_raises_when_between_fold_spread_unidentified():
         )
 
 
-def test_identical_folds_do_not_report_supported_end_to_end():
+def test_identical_folds_are_inconclusive_end_to_end():
     """A near-constant large-scale series must never surface as SUPPORTED.
 
     Two folds complete (so the single-fold count guard does not apply) but with
     identical cumulative impacts, so the between-fold null spread is
-    unidentified.  ``run`` must not return a verdict for such a degenerate
-    configuration.
+    unidentified.  ``run`` must abstain (INCONCLUSIVE) — mirroring the
+    single-fold routes and PlaceboInSpace — rather than build a degenerate null
+    or crash the caller.
     """
     data = pd.DataFrame({"y": np.zeros(120)}, index=np.arange(120))
     experiment = _make_scaled_fake_experiment(
@@ -1082,8 +1083,58 @@ def test_identical_folds_do_not_report_supported_end_to_end():
         random_seed=42,
     )
 
-    with pytest.raises(ValueError, match="Cannot identify the hierarchical"):
-        check.run(experiment)
+    result = check.run(experiment)
+
+    assert result.metadata["n_folds_completed"] == 2
+    assert result.passed is None
+    assert "SUPPORTED" not in result.text
+    assert "INCONCLUSIVE" in result.text
+    assert "null_samples" not in result.metadata
+    assert "p_effect_outside_null" not in result.metadata
+
+
+def test_two_folds_with_distinct_means_still_produce_a_verdict():
+    """The degeneracy guards must not over-fire on a healthy multi-fold run.
+
+    Two folds complete with *distinct* cumulative impacts, so the between-fold
+    spread is identified.  ``run`` must build the null and return a boolean
+    verdict rather than abstaining — this pins that the abstention path is
+    reached only for genuinely degenerate configurations.
+    """
+    data = pd.DataFrame({"y": np.zeros(120)}, index=np.arange(120))
+    experiment = _make_scaled_fake_experiment(
+        data,
+        treatment_time=90,
+        cumulative_mean=5000.0,
+        cumulative_sd=0.0,
+    )
+
+    def factory(fold_data, treatment_time):
+        # Distinct per-fold means (folds sit at pseudo tt 30 and 60), so
+        # np.nanstd(fold_means) > 0 and the null is identified.
+        return _make_scaled_fake_experiment(
+            fold_data,
+            treatment_time,
+            cumulative_mean=5000.0 + 2.0 * treatment_time,
+            cumulative_sd=300.0,
+            seed=1,
+        )
+
+    check = PlaceboInTime(
+        n_folds=2,
+        intervention_length=30,
+        experiment_factory=factory,
+        sample_kwargs=_FAST_HIERARCHICAL_KWARGS,
+        random_seed=42,
+    )
+
+    result = check.run(experiment)
+
+    assert result.metadata["n_folds_completed"] == 2
+    assert result.passed is not None
+    assert "INCONCLUSIVE" not in result.text
+    assert "null_samples" in result.metadata
+    assert "p_effect_outside_null" in result.metadata
 
 
 def test_random_run_is_inconclusive_with_no_feasible_folds():


### PR DESCRIPTION
Part of #1048.

## Problem

`causalpy/checks/placebo_in_time.py` accepts `n_folds >= 1`. The hierarchical
status-quo (null) model derives its scale from the between-fold spread of the
placebo folds:

```python
prior_mu_scale = np.nanstd(fold_means)
if prior_mu_scale <= 0.0:
    prior_mu_scale = 1.0
```

When that spread is **unidentified**, `prior_mu_scale` falls back to a bare
`1.0`, stripping all data scaling from both the `mu_status_quo` prior
(`sigma = 5·scale·prior_mu_scale`) and the `tau_status_quo` prior
(`sigma = 2·scale·prior_mu_scale`). On a large-scale series the null `theta_new`
then collapses to a prior-driven O(1) width, so almost any actual effect reads
as "outside the null" and the verdict flips to a spurious **SUPPORTED**
(`p_effect_outside_null = 1.0`) — driven by prior width, not evidence.

The spread is unidentified in two ways:

1. **A single usable fold** — `np.nanstd([x]) == 0`. Reached either via
   `n_folds=1` directly, or via `n_folds>1` reduced to one usable fold by fold
   skips (insufficient pre-period, too few observations, fit failure).
2. **≥2 completed folds whose cumulative impacts coincide** (e.g. an
   almost-constant series) — `np.nanstd([c, c, …]) == 0`.

This is a **false-negative in a diagnostic**: a user runs a placebo check
specifically to catch a bad design, and a spuriously SUPPORTED verdict tells
them the design is sound when it is not.

## Fix

Both degenerate cases now abstain with an explicit **INCONCLUSIVE**
(`passed=None`) — mirroring the sibling `PlaceboInSpace`, which returns
`passed=None` when it lacks enough control units to characterise its null.
(Semantics choice discussed in the maintainer-decision comment below.)

1. **`run()` abstains (INCONCLUSIVE) when fewer than `MIN_USABLE_FOLDS = 2`
   folds complete**, instead of building the degenerate single-fold null.
   Covers both routes to a single usable fold with one code path.
2. **`_build_status_quo_model()` raises a private
   `_NullModelUnidentifiedError` (a `ValueError` subclass) when the between-fold
   spread is non-positive or non-finite**, removing the scale-stripping `1.0`
   fallback. This closes the residual ≥2-coincident-fold case (and all-NaN fold
   means) at the root. `run()` catches it and returns the same unified
   INCONCLUSIVE `CheckResult`, so all three degenerate cases (0 folds, 1 fold,
   ≥2 coincident folds) share one `passed=None` contract and metadata shape.

A degenerate configuration can therefore no longer surface as SUPPORTED.

## Reproduction / tests

- `test_single_fold_directly_does_not_report_supported_on_large_scale`
  (`n_folds=1`) — fails on base (`passed=True`, `p=1.0`), passes after.
- `test_skips_down_to_single_fold_does_not_report_supported_on_large_scale`
  (`n_folds=2` reduced to one usable fold by an insufficient-pre-period skip) —
  fails on base, passes after.
- `test_build_status_quo_model_raises_when_between_fold_spread_unidentified`
  and `test_identical_folds_are_inconclusive_end_to_end` — cover the residual
  ≥2-coincident-fold case.
- `test_two_folds_with_distinct_means_still_produce_a_verdict` — positive path:
  a healthy multi-fold run still builds the null and returns a boolean verdict,
  so the abstention guards cannot silently over-fire.

The status-quo MCMC is exercised by the real code path on base (not
monkeypatched); after the fix the abstention paths return before sampling, so
the single-fold tests are deterministic.

## Known residual

The identifiability guard is `np.nanstd(fold_means) > 0` (and finite), which
closes the *exact* degeneracy. A *tiny-but-positive* between-fold spread on a
large-scale series is not closed and needs a relative criterion or an
option-(b) tau prior — a modeling choice flagged for maintainers in the review
comment, not guessed here.

## User-visible semantics change

A single-usable-fold (or ≥2-coincident-fold) placebo check that previously
returned a (spurious) SUPPORTED/NOT-SUPPORTED verdict now returns INCONCLUSIVE.
Flagged here for the release-notes unit.

## Deliberately out of scope

- The #1106 sigma findings (near-zero variance, `_clone()` bypass) in
  `pymc_models.py` / `synthetic_control.py` — owned by a sibling unit. This PR
  keeps its diff to the placebo path.
- Release notes — owned by another unit (see the semantics note above).
- A fold that *completes* but yields a partly-NaN posterior (mixed
  finite/NaN `fold_means`, e.g. `[c, NaN, d]`) is a separate fold-validity
  concern. The new guard rejects the all-NaN case; the mixed case is noted for
  a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)