### PR TITLE
docs: PyMC 6 migration breaking-change release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Alternatively, if you want the very latest version of the package you can instal
 pip install git+https://github.com/pymc-labs/CausalPy.git
 ```
 
+## Runtime notes
+
+As of the PyMC 6 release, CausalPy runs on PyMC 6 / PyTensor 3 / ArviZ 1.x and requires Python 3.12+. A few runtime behaviours are worth knowing about:
+
+- **numba is now a (transitive) hard dependency and the default backend.** PyTensor 3 compiles models with numba by default, so the *first* sample from a freshly defined model incurs a noticeable one-off compilation delay before sampling starts. Subsequent samples reuse the compiled function.
+- **Native crashes can replace Python tracebacks.** When a numba-compiled sampler worker dies, the failure may surface as a native crash or a stalled worker rather than a Python traceback — so a wedged worker can present as a silent hang rather than an exception.
+- **Installing `nutpie` changes sampling defaults.** If a recent enough `nutpie` is installed, PyMC uses it as the default NUTS sampler unless you pass an explicit `nuts_sampler=`, and nutpie applies its own number of tuning steps rather than PyMC's built-in default of 1000. Merely installing nutpie is therefore enough to change how `pm.sample()` behaves; pass `nuts_sampler="pymc"` if you need the built-in sampler.
+
+For the full list of breaking changes in this release, see the [release notes](https://causalpy.readthedocs.io/en/latest/release_notes.html).
+
 ## AI Agent Skills
 
 CausalPy includes agent skills that teach AI coding assistants how to use the library for causal inference. Skills are available via [Decision AI Hub](https://hub.decision.ai) and live in `causalpy/skills/` in the source tree.

--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -14,4 +14,5 @@
 knowledgebase/index
 api/index
 notebooks/index
+release_notes
 :::

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -23,9 +23,10 @@ upgrading; several public signatures and default behaviours changed.
   `pymc-marketing` v1.0.0 caps `pymc<6.1`, so environments that include it
   resolve to an older 6.x. Do not rely on a specific patch version.
 - **pytensor `>=3,<4`**.
-- **arviz `>=1.1,<2`** — the ArviZ 0.x → 1.x jump. `arviz.InferenceData` no
-  longer exists as a class; importing it emits a `MigrationWarning`, and ArviZ
-  now uses xarray's `DataTree` for the same role.
+- **arviz `>=1.1,<2`** — the ArviZ 0.x → 1.x jump. `arviz.InferenceData` is no
+  longer available as a usable class — accessing it emits a `MigrationWarning`
+  (`"arviz.InferenceData is no longer available on the arviz package"`) — and
+  ArviZ now uses xarray's `DataTree` for the same role.
 - **pandas `>=2.3,<4`** — pandas 2.3 through the 3.x line are supported and are
   exercised as separate CI legs.
 - **pymc-extras `>=0.3.0`**.

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -132,12 +132,15 @@ older release — pass `SyntheticControl(..., auto_scale_sigma=False)`.
 #### `InstrumentalVariable` samples with `cores=1`
 
 The instrumental-variable model (an `MvNormal` with an `LKJCholeskyCov` prior)
-can crash under multiprocess sampling on the numba backend (a native worker
-death rather than a Python exception). To keep it usable, CausalPy forces
-`cores=1` for this model when `cores` is not otherwise specified
-(`causalpy/pymc_models.py`). This is a mitigation pending an upstream fix
-(tracked in issue #1067); IV sampling therefore does not parallelise across
-cores by default.
+can crash under multiprocess ("fork") sampling on an affected platform/version
+combination (observed on macOS arm64 with Python 3.14 and PyMC 6.0.1–6.2.0) —
+the worker dies natively rather than raising a Python exception. To keep the
+model usable, CausalPy forces `cores=1` for it when `cores` is not otherwise
+specified (`causalpy/pymc_models.py:1330-1332`). IV sampling therefore does not
+parallelise across cores by default. This is a temporary mitigation: the
+upstream bug is tracked at
+[pymc-devs/pymc#8377](https://github.com/pymc-devs/pymc/issues/8377), and
+removal of the workaround is tracked in CausalPy issue #1067.
 
 ### Behaviour that intentionally did *not* change
 

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -1,0 +1,185 @@
+# Release notes
+
+This page records user-visible changes, with an emphasis on anything that can
+break existing code. The auto-generated, commit-level history for each tagged
+release lives on the
+[GitHub releases](https://github.com/pymc-labs/CausalPy/releases) page; this
+page is the curated, human-written companion to it.
+
+## 1.0.0 (unreleased) — PyMC 6 migration
+
+This is a **major, breaking release**. It migrates CausalPy off the PyMC 5
+stack and onto PyMC 6 / PyTensor 3 / ArviZ 1.x (compatible with
+`pymc-marketing` v1.0.0). Read the breaking-change section below before
+upgrading; several public signatures and default behaviours changed.
+
+### Supported versions and dependencies
+
+- **Python `>=3.12`** (raised from 3.11). The dependency stack currently
+  resolves on Python 3.12–3.14 (PyTensor caps Python `<3.15`). CI exercises
+  3.12 and 3.14.
+- **pymc `>=6.0.1,<7`** (previously the PyMC 5 series). The exact patch the
+  resolver selects depends on what else is installed — for example
+  `pymc-marketing` v1.0.0 caps `pymc<6.1`, so environments that include it
+  resolve to an older 6.x. Do not rely on a specific patch version.
+- **pytensor `>=3,<4`**.
+- **arviz `>=1.1,<2`** — the ArviZ 0.x → 1.x jump. `arviz.InferenceData` no
+  longer exists as a class; importing it emits a `MigrationWarning`, and ArviZ
+  now uses xarray's `DataTree` for the same role.
+- **pandas `>=2.3,<4`** — pandas 2.3 through the 3.x line are supported and are
+  exercised as separate CI legs.
+- **pymc-extras `>=0.3.0`**.
+- **numba is now effectively a hard (transitive) dependency.** It is
+  PyTensor 3's default compilation backend and is pulled in through the
+  PyTensor/PyMC dependency chain. See [Runtime characteristics](#runtime-characteristics).
+
+These floors are declared in `pyproject.toml`.
+
+### Breaking changes
+
+#### Inference results are now `xarray.DataTree`, not `arviz.InferenceData`
+
+Under ArviZ 1.x, `pm.sample()` — and therefore the `.idata` attribute on
+CausalPy's PyMC models and experiments — is an `xarray.DataTree` rather than an
+`arviz.InferenceData`. CausalPy's own type annotations reflect this (for
+example `causalpy/pymc_forecast_models.py` annotates `self.idata: xr.DataTree
+| None`).
+
+If you wrote code against the old `InferenceData` object you may need to update
+it. In particular:
+
+- `InferenceData.extend()` no longer exists; groups are combined with
+  `DataTree` operations instead.
+- Constructing results via `az.InferenceData(group=ds)` no longer works.
+- Accessing a group returns a `DataTree` node, which does not expose the
+  group-level `.assign_coords` / `.rename` shortcuts that `InferenceData`
+  groups had.
+
+These are ArviZ/PyMC-level changes; they surface through any CausalPy object
+that exposes an `idata`.
+
+#### Public method signatures were narrowed (no more silent `**kwargs`)
+
+Public methods across the experiment classes had their `*args` / `**kwargs`
+catch-alls removed so that the supported keyword arguments are explicit
+(PR #1107). A call that passes a keyword the method does not declare now raises
+`TypeError`, where previously the argument was silently accepted and ignored.
+This narrowing is enforced in CI (`scripts/audit_public_signatures.py` and
+`causalpy/tests/test_public_signatures.py`). The two most user-visible
+consequences are `get_plot_data` and `effect_summary`, below.
+
+#### `get_plot_data` is now keyword-only, and absent on several experiments
+
+`get_plot_data` used to be defined generically on `BaseExperiment` (as
+`get_plot_data(self, *args, **kwargs)`, which raised `NotImplementedError` for
+experiments that did not override it). That generic method was removed. As a
+result:
+
+- On the four experiments that implement it with an `hdi_prob` argument,
+  `get_plot_data` is now **keyword-only**:
+  - `InterruptedTimeSeries` (`causalpy/experiments/interrupted_time_series.py`)
+  - `PiecewiseITS` (`causalpy/experiments/piecewise_its.py`)
+  - `StaggeredDifferenceInDifferences` (`causalpy/experiments/staggered_did.py`)
+  - `SyntheticControl` (`causalpy/experiments/synthetic_control.py`)
+
+  These previously accepted `hdi_prob` positionally, so a call such as
+  `experiment.get_plot_data(0.9)` now raises `TypeError`. Use the keyword form,
+  `experiment.get_plot_data(hdi_prob=0.9)`.
+- On `PanelRegression` (`causalpy/experiments/panel_regression.py`),
+  `get_plot_data` is now **argument-less**. It previously accepted `**kwargs`
+  (which were ignored), so passing any argument now raises `TypeError`. A bare
+  `experiment.get_plot_data()` call still works.
+- Because there is no longer a `BaseExperiment.get_plot_data`, calling
+  `get_plot_data` on an experiment that does not define it now raises
+  `AttributeError` (previously it raised `NotImplementedError`). The seven
+  experiments in this situation are:
+  1. `DifferenceInDifferences`
+  2. `InstrumentalVariable`
+  3. `InversePropensityWeighting`
+  4. `PrePostNEGD`
+  5. `RegressionKink`
+  6. `RegressionDiscontinuity`
+  7. `SyntheticDifferenceInDifferences`
+
+  (This split — five experiments implement `get_plot_data`, seven do not — is
+  pinned by `causalpy/tests/test_public_signatures.py`.)
+
+#### `effect_summary(alpha=...)` raises `TypeError` instead of `NotImplementedError`
+
+On the three experiments that do not implement a unified effect summary —
+`PanelRegression` (`causalpy/experiments/panel_regression.py`),
+`InstrumentalVariable` (`causalpy/experiments/instrumental_variable.py`), and
+`InversePropensityWeighting`
+(`causalpy/experiments/inverse_propensity_weighting.py`) — `effect_summary` is
+now defined as `def effect_summary(self) -> NoReturn` with no parameters. A
+bare `experiment.effect_summary()` call still raises `NotImplementedError` as
+before. But because the method no longer declares an `alpha` (or any other)
+parameter, a call such as `experiment.effect_summary(alpha=0.05)` now raises
+`TypeError` *before* the body runs, whereas previously the same call reached
+the body and raised `NotImplementedError`. The operation remains unsupported on
+these three experiments; only the exception type for the `alpha=` form changed.
+
+#### `SyntheticControl` default prior changed
+
+`SyntheticControl` now derives its observation-noise `sigma` prior from each
+treated unit's pre-treatment spread (a data-scaled prior), controlled by the
+new `auto_scale_sigma` argument, which defaults to `True`
+(`causalpy/experiments/synthetic_control.py`; PR #1106). This changes the
+default posterior relative to earlier releases. To restore the previous fixed
+`HalfNormal(1)` prior — for example when reproducing an analysis run against an
+older release — pass `SyntheticControl(..., auto_scale_sigma=False)`.
+
+#### `InstrumentalVariable` samples with `cores=1`
+
+The instrumental-variable model (an `MvNormal` with an `LKJCholeskyCov` prior)
+can crash under multiprocess sampling on the numba backend (a native worker
+death rather than a Python exception). To keep it usable, CausalPy forces
+`cores=1` for this model when `cores` is not otherwise specified
+(`causalpy/pymc_models.py`). This is a mitigation pending an upstream fix
+(tracked in issue #1067); IV sampling therefore does not parallelise across
+cores by default.
+
+### Behaviour that intentionally did *not* change
+
+#### The ArviZ default-interval change is a no-op for CausalPy
+
+ArviZ 1.x changed *its own* default summary interval from a 0.94 highest-density
+interval (HDI) to a 0.89 equal-tailed interval (ETI). This does **not** change
+any CausalPy output. CausalPy always passes an explicit interval probability
+when it calls ArviZ — its HDI helper calls `az.hdi(..., prob=HDI_PROB)`, with
+the project-wide `HDI_PROB = 0.94` defined in `causalpy/constants.py` — so
+nothing falls through to ArviZ's new default. Interval widths in effect
+summaries, plots, and `get_plot_data` are identical to the previous release.
+(This is separate from the fact that different reports use different nominal
+levels — some effect summaries report a 95% interval, and
+`PanelRegression.get_plot_data` reports 95% quantile bounds — none of which
+changed in this release.)
+
+### Runtime characteristics
+
+See also the [runtime notes in the README](https://github.com/pymc-labs/CausalPy#runtime-notes).
+
+- **numba first-compile latency.** Because numba is PyTensor 3's default
+  backend, the first sample from a freshly defined model incurs a noticeable
+  compilation delay before sampling begins.
+- **Native worker crashes replace Python tracebacks.** When a numba-compiled
+  sampler worker fails, the failure can present as a native crash (or a stalled
+  worker) rather than a Python traceback. A wedged worker can therefore look
+  like a silent hang.
+- **nutpie changes sampling defaults if installed.** If a recent enough
+  `nutpie` is installed, PyMC selects it as the default NUTS sampler unless you
+  pass an explicit `nuts_sampler` — so *installing* nutpie is itself enough to
+  change how `pm.sample()` behaves. nutpie also applies its own tuning-step
+  default rather than PyMC's built-in NUTS default of 1000 tune steps (with
+  `tune=None`, PyMC forwards the request straight to nutpie rather than
+  resolving it to 1000). The migration investigation reported nutpie's default
+  as 400 tune steps; that exact number was not re-verified for this release
+  (nutpie is optional and was not installed in the release environment), so
+  treat 400 as indicative and confirm against your installed nutpie version if
+  it matters for your run.
+
+### Version
+
+This release is intended to be **1.0.0** (the migration is
+backwards-incompatible, so the major version increments). The version is
+single-sourced from `causalpy/version.py`.


### PR DESCRIPTION
Part of #1048.

## What this PR does

Adds the **breaking-change release notes** for the PyMC 6 / PyTensor 3 /
ArviZ 1.x migration, plus a runtime-behaviour note, as requested by the last
open item on #1048. Documentation only — no library code is touched.

- **`docs/source/release_notes.md`** (new): a curated `1.0.0 (unreleased)`
  breaking-change section, wired into the docs `toctree` in
  `docs/source/index.md`.
- **`README.md`**: a new `## Runtime notes` section (numba first-compile
  latency and native worker crashes; nutpie changing sampling defaults when
  installed). The docs landing page includes the README from the
  `<!-- docs-start -->` marker to EOF, so this note renders on the docs index
  automatically — it is deliberately **not** duplicated into `index.md`.

## Every behavioural claim is backed by code I read

Declared breaking changes:
- **`idata` is now `xarray.DataTree`** — arviz 1.x removed `InferenceData`
  (import emits a `MigrationWarning`); CausalPy annotates `self.idata:
  xr.DataTree | None` (`causalpy/pymc_forecast_models.py:194`) and combines
  groups via `_extend_datatree_left` / `_assign_group_coords`
  (`causalpy/pymc_models.py:73,81`).
- **Dependency floors** (`pyproject.toml:24,52-72`): Python `>=3.12`,
  `pymc>=6.0.1,<7`, `pytensor>=3,<4`, `arviz>=1.1,<2`, `pandas>=2.3,<4`,
  `pymc-extras>=0.3.0`. numba is a transitive dep (PyTensor 3 default backend);
  it is not a direct pyproject entry, so the notes phrase it as "effectively a
  hard transitive dependency".
- **numba / nutpie runtime behaviour** — verified against pymc 6.2.0 source:
  `pm.sample()` auto-selects nutpie when installed
  (`pymc/sampling/mcmc.py:931-956`, docstring :691); for the external nutpie
  path pymc forwards `tune=None` straight to `nutpie.sample`
  (`_sample_external_nuts`, mcmc.py:471) and does **not** call
  `get_default_tune_steps` (→1000, mcmc.py:127,1058), which is the
  pymc-internal path only. **The "400 tune steps" figure could not be verified
  here** (nutpie is not installed), so the notes label it "reported, indicative,
  confirm against your nutpie".
- **arviz 0.94 HDI → 0.89 ETI** is a **no-op** — CausalPy always passes an
  explicit `prob` to arviz (`az.hdi(..., prob=HDI_PROB)`,
  `causalpy/_arviz_compat.py:161`; `HDI_PROB = 0.94`, `causalpy/constants.py:23`),
  so nothing falls through to arviz's new default. The notes deliberately do
  **not** claim "every interval is 0.94 HDI" (some effect summaries are 95%, and
  `PanelRegression.get_plot_data` reports 95% quantile bounds,
  `panel_regression.py:641-647`) — only that the arviz upgrade changes nothing.
- **`InstrumentalVariable` `cores=1`** — forced when unset
  (`causalpy/pymc_models.py:1331-1332`); tracked for removal in issue #1067.

Undeclared breaking changes (verified before/after against `git show
8f5d755a~1` vs current, the pre/post-#1107 states):
- **`get_plot_data` keyword-only** on `InterruptedTimeSeries`
  (`interrupted_time_series.py:875`), `PiecewiseITS` (`piecewise_its.py:649`),
  `StaggeredDifferenceInDifferences` (`staggered_did.py:1367`),
  `SyntheticControl` (`synthetic_control.py:759`) — these took `hdi_prob`
  positionally before #1107. **Argument-less** on `PanelRegression`
  (`panel_regression.py:621`, was `**kwargs`). Removed from `base.py` (was
  `get_plot_data(self, *args, **kwargs)` → `NotImplementedError`), so the
  **seven** experiments that don't define it now raise `AttributeError`:
  DifferenceInDifferences, InstrumentalVariable, InversePropensityWeighting,
  PrePostNEGD, RegressionKink, RegressionDiscontinuity,
  SyntheticDifferenceInDifferences. This 5-define / 7-don't split is pinned by
  `causalpy/tests/test_public_signatures.py:360-398`.
- **`effect_summary(alpha=...)` → `TypeError`** on `PanelRegression`
  (`panel_regression.py:468`), `InstrumentalVariable`
  (`instrumental_variable.py:361`), `InversePropensityWeighting`
  (`inverse_propensity_weighting.py:881`). All three are now
  `def effect_summary(self) -> NoReturn`; they accepted `alpha`/`**kwargs`
  before #1107, so `alpha=` now raises `TypeError` before the
  `NotImplementedError` body. A bare `effect_summary()` still raises
  `NotImplementedError` — the notes scope the change to the `alpha=` form only.
- **`SyntheticControl` data-scaled sigma prior** (`auto_scale_sigma=True`
  default, `synthetic_control.py:128,140-141`; PR #1106).
- **pandas 2.3–3.x** supported and exercised as separate CI legs
  (`.github/workflows/ci.yml:79-89`; PR #1101).
- **#1107** removed `*args`/`**kwargs` from public methods broadly; a user
  passing an unexpected keyword now gets `TypeError` (enforced by
  `scripts/audit_public_signatures.py` + `test_public_signatures.py`).

## Version bump — recommended, not performed

Recommend **1.0.0** (backwards-incompatible → major bump; matches the 1.0.0
milestone). I did **not** perform it. Note: #850 (dynamic versioning) is now
**merged**, and this base already single-sources the version from
`causalpy/version.py` (`pyproject.toml` uses `dynamic = ["version"]`), so the
"two sources of truth" concern is resolved — the bump is now a one-line change
to `causalpy/version.py`. I left it to the maintainers to time alongside the
final release-to-`main` PR.

## Where the notes live — maintainer decision (see PR comment)

There was no `CHANGELOG.md` and no docs release-notes page. I chose a docs page
wired into the toctree; a comment below lays out the options and the one
reconciliation point (`pyproject.toml`'s `Changelog =` metadata points at
GitHub Releases) so a maintainer can redirect cheaply.

## Deliberately not done / observations for other units

- No library code changed (this unit is docs-only). The 95% vs 94% interval
  nuance and `PanelRegression.get_plot_data`'s hardcoded 95% ETI are documented
  as-is, not "fixed".
- The classifiers advertise Python 3.13 but CI only runs 3.12 and 3.14; and
  `requires-python` has no upper cap although PyTensor caps `<3.15`. Flagging
  for a maintainer/CI unit, not fixing here.

## Beehive gates

Ran EXPLORE → PLAN → 4-lens adversarial plan review (bugs / edge-cases /
architecture / test-quality) in parallel; every claim above was re-verified at
file/line and corrected against their findings before this push (the biggest
correction: reframing the HDI section from "everything is 0.94 HDI" to "the
arviz default change is a no-op"). Implementation review + fact-check +
supervisor pass to follow on this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
