### PR TITLE
migration: re-pin the baseline harness candidate to the integration-branch head

### DIFF
--- a/causalpy/tests/test_migration_baseline_harness.py
+++ b/causalpy/tests/test_migration_baseline_harness.py
@@ -483,17 +483,15 @@ def test_capture_rejects_an_unpinned_revision_before_import(
     superseded_commit = "1" * 40
     assert superseded_commit not in harness.STACK_COMMITS.values()
 
-    def fake_run_git(_repo_root: Path, *arguments: str) -> str:
-        if arguments == ("rev-parse", "HEAD"):
-            return superseded_commit
-        assert arguments == ("status", "--porcelain")
-        return ""
+    git_queries: list[tuple[str, ...]] = []
+    imported_roots: list[Path] = []
 
-    def unexpected_import(_repo_root: Path) -> None:
-        pytest.fail("an unpinned revision must be rejected before importing CausalPy")
+    def fake_run_git(_repo_root: Path, *arguments: str) -> str:
+        git_queries.append(arguments)
+        return superseded_commit
 
     monkeypatch.setattr(harness, "_run_git", fake_run_git)
-    monkeypatch.setattr(harness, "_import_capture_dependencies", unexpected_import)
+    monkeypatch.setattr(harness, "_import_capture_dependencies", imported_roots.append)
 
     with pytest.raises(harness.HarnessError, match="capture requires"):
         harness._capture_artifact(
@@ -502,6 +500,9 @@ def test_capture_rejects_an_unpinned_revision_before_import(
             batch_id="00000000-0000-4000-8000-000000000000",
             capture_role="candidate_first",
         )
+
+    assert git_queries == [("rev-parse", "HEAD")]
+    assert imported_roots == []
 
 
 def test_did_capture_fixture_passes_constructor_validation_without_mcmc() -> None:

--- a/causalpy/tests/test_migration_baseline_harness.py
+++ b/causalpy/tests/test_migration_baseline_harness.py
@@ -1218,13 +1218,13 @@ DOCUMENTED_PIN_QUOTES = (
         ("pymc6",),
     ),
     (
-        "REPORT_TEMPLATE.md",
+        "REPORT_TEMPLATE.md reference checkout",
         REPORT_TEMPLATE_PATH,
         r"- Reference checkout: `([0-9a-f]{40})`",
         ("pymc5",),
     ),
     (
-        "REPORT_TEMPLATE.md",
+        "REPORT_TEMPLATE.md candidate checkout",
         REPORT_TEMPLATE_PATH,
         r"- Candidate checkout: `([0-9a-f]{40})`",
         ("pymc6",),

--- a/causalpy/tests/test_migration_baseline_harness.py
+++ b/causalpy/tests/test_migration_baseline_harness.py
@@ -470,6 +470,40 @@ def test_capture_rejects_dirty_pinned_checkout_before_import(
         )
 
 
+def test_capture_rejects_an_unpinned_revision_before_import(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A clean checkout at the wrong revision is not migration evidence.
+
+    This is what makes re-pinning ``PYMC6_COMMIT`` safe: once the pin moves,
+    the superseded worktree can no longer be captured at all, so a stale tree
+    cannot be sampled and labelled as the migration candidate.
+    """
+    harness = _load_harness_module()
+    superseded_commit = "1" * 40
+    assert superseded_commit not in harness.STACK_COMMITS.values()
+
+    def fake_run_git(_repo_root: Path, *arguments: str) -> str:
+        if arguments == ("rev-parse", "HEAD"):
+            return superseded_commit
+        assert arguments == ("status", "--porcelain")
+        return ""
+
+    def unexpected_import(_repo_root: Path) -> None:
+        pytest.fail("an unpinned revision must be rejected before importing CausalPy")
+
+    monkeypatch.setattr(harness, "_run_git", fake_run_git)
+    monkeypatch.setattr(harness, "_import_capture_dependencies", unexpected_import)
+
+    with pytest.raises(harness.HarnessError, match="capture requires"):
+        harness._capture_artifact(
+            "pymc6",
+            tmp_path,
+            batch_id="00000000-0000-4000-8000-000000000000",
+            capture_role="candidate_first",
+        )
+
+
 def test_did_capture_fixture_passes_constructor_validation_without_mcmc() -> None:
     """The pinned DiD fixture reaches real constructor validation with OLS only."""
     harness = _load_harness_module()
@@ -850,6 +884,34 @@ def test_comparator_requires_the_executing_harness_commit(
         harness.compare_artifacts(*artifacts)
 
 
+@pytest.mark.parametrize(
+    ("provenance_key", "message"),
+    [
+        ("expected_commit", "unexpected registered commit"),
+        ("actual_commit", "differs from the pinned"),
+    ],
+)
+def test_comparator_rejects_an_artifact_from_a_superseded_pin(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    provenance_key: str,
+    message: str,
+) -> None:
+    """Evidence captured at a superseded pin cannot enter a new batch.
+
+    Re-pinning ``PYMC6_COMMIT`` is therefore strictly narrowing: artifacts
+    recorded against the previous candidate are refused rather than silently
+    compared against captures of a different tree.
+    """
+    harness = _load_harness_module()
+    artifacts = list(_valid_artifact_batch(harness, tmp_path))
+    artifacts[2]["provenance"][provenance_key] = "1" * 40
+    monkeypatch.setattr(harness, "_harness_identity", _fake_harness_identity)
+
+    with pytest.raises(harness.HarnessError, match=message):
+        harness.compare_artifacts(*artifacts)
+
+
 def test_comparator_requires_four_unique_role_bound_capture_ids(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -1202,19 +1264,21 @@ def test_harness_identity_binds_the_executing_file_to_its_committed_blob(
 # coordinator provisions its two worktrees from the README and transcribes the
 # attribution statement from REPORT_TEMPLATE, so a stale SHA in either document
 # sends a real capture at the wrong tree while the harness reports success.
+# The anchors tolerate reflowed whitespace: a rewrapped paragraph must not look
+# like pin drift, or the next author reflows the prose and deletes the test.
 DOCUMENTED_PIN_QUOTES = (
     (
         "README.md",
         README_PATH,
-        r"PyMC 5 reference `([0-9a-f]{40})` and PyMC 6 migration candidate "
-        r"`([0-9a-f]{40})`",
+        r"PyMC\s+5\s+reference\s+`([0-9a-f]{40})`\s+and\s+PyMC\s+6\s+migration"
+        r"\s+candidate\s+`([0-9a-f]{40})`",
         ("pymc5", "pymc6"),
     ),
     (
         "README.md coordinator procedure",
         README_PATH,
-        r"provision `PYMC6_ROOT` as a separate clean detached worktree at "
-        r"`([0-9a-f]{40})`",
+        r"provision\s+`PYMC6_ROOT`\s+as\s+a\s+separate\s+clean\s+detached"
+        r"\s+worktree\s+at\s+`([0-9a-f]{40})`",
         ("pymc6",),
     ),
     (
@@ -1232,8 +1296,8 @@ DOCUMENTED_PIN_QUOTES = (
 )
 
 
-def test_pinned_revisions_are_documented_consistently() -> None:
-    """Re-pinning must move the constant and both documents together."""
+def test_pinned_revisions_are_distinct_full_shas() -> None:
+    """Both stacks must pin one resolved, distinct revision."""
     harness = _load_harness_module()
     assert set(harness.STACK_COMMITS) == {"pymc5", "pymc6"}
     assert harness.PYMC5_COMMIT != harness.PYMC6_COMMIT
@@ -1242,13 +1306,37 @@ def test_pinned_revisions_are_documented_consistently() -> None:
             f"{stack} pin is not a full lowercase SHA-1: {commit!r}"
         )
 
-    for label, path, pattern, stacks in DOCUMENTED_PIN_QUOTES:
-        matches = re.findall(pattern, path.read_text(encoding="utf-8"))
-        assert len(matches) == 1, (
-            f"{label} must quote the pinned revisions exactly once via {pattern!r}"
-        )
-        quoted = matches[0] if isinstance(matches[0], tuple) else (matches[0],)
-        expected = tuple(harness.STACK_COMMITS[stack] for stack in stacks)
-        assert quoted == expected, (
-            f"{label} quotes {quoted}, but the harness pins {expected}"
-        )
+
+@pytest.mark.parametrize(
+    ("label", "path", "pattern", "stacks"),
+    DOCUMENTED_PIN_QUOTES,
+    ids=[quote[0] for quote in DOCUMENTED_PIN_QUOTES],
+)
+def test_pinned_revisions_are_documented_consistently(
+    label: str, path: Path, pattern: str, stacks: tuple[str, ...]
+) -> None:
+    """Re-pinning must move the constant and every document that quotes it."""
+    harness = _load_harness_module()
+    matches = re.findall(pattern, path.read_text(encoding="utf-8"))
+    assert len(matches) == 1, (
+        f"{label} must quote the pinned revisions exactly once via {pattern!r}"
+    )
+    quoted = matches[0] if isinstance(matches[0], tuple) else (matches[0],)
+    expected = tuple(harness.STACK_COMMITS[stack] for stack in stacks)
+    assert quoted == expected, (
+        f"{label} quotes {quoted}, but the harness pins {expected}"
+    )
+
+
+def test_superseded_pin_is_recorded_as_history_only() -> None:
+    """The re-pinning section must describe a predecessor, not the current pin."""
+    harness = _load_harness_module()
+    body = README_PATH.read_text(encoding="utf-8")
+    heading = "## Re-pinning the candidate revision"
+    assert heading in body, "the README must keep a re-pinning section"
+    section = body.split(heading, 1)[1].split("\n## ", 1)[0]
+    superseded = re.findall(r"`([0-9a-f]{40})`", section)
+    assert superseded, "the re-pinning section must name the superseded revision"
+    assert harness.PYMC6_COMMIT not in superseded, (
+        "the re-pinning section names the current pin as its own predecessor"
+    )

--- a/causalpy/tests/test_migration_baseline_harness.py
+++ b/causalpy/tests/test_migration_baseline_harness.py
@@ -20,6 +20,7 @@ import copy
 import importlib.util
 import json
 import math
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -32,6 +33,10 @@ import xarray as xr
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "migration_baseline" / "harness.py"
+README_PATH = REPO_ROOT / "scripts" / "migration_baseline" / "README.md"
+REPORT_TEMPLATE_PATH = (
+    REPO_ROOT / "scripts" / "migration_baseline" / "REPORT_TEMPLATE.md"
+)
 
 # The shared ``conftest`` registers ``mock_pymc_sample`` at *session* scope, so
 # once any earlier test in the run triggers it, ``pymc.sample`` (and
@@ -1191,3 +1196,59 @@ def test_harness_identity_binds_the_executing_file_to_its_committed_blob(
     copy_path.write_bytes(copy_path.read_bytes() + b"\n# uncommitted edit\n")
     with pytest.raises(harness.HarnessError, match="must be clean"):
         harness._harness_identity()
+
+
+# Every place a pinned revision is quoted outside ``STACK_COMMITS``. The
+# coordinator provisions its two worktrees from the README and transcribes the
+# attribution statement from REPORT_TEMPLATE, so a stale SHA in either document
+# sends a real capture at the wrong tree while the harness reports success.
+DOCUMENTED_PIN_QUOTES = (
+    (
+        "README.md",
+        README_PATH,
+        r"PyMC 5 reference `([0-9a-f]{40})` and PyMC 6 migration candidate "
+        r"`([0-9a-f]{40})`",
+        ("pymc5", "pymc6"),
+    ),
+    (
+        "README.md coordinator procedure",
+        README_PATH,
+        r"provision `PYMC6_ROOT` as a separate clean detached worktree at "
+        r"`([0-9a-f]{40})`",
+        ("pymc6",),
+    ),
+    (
+        "REPORT_TEMPLATE.md",
+        REPORT_TEMPLATE_PATH,
+        r"- Reference checkout: `([0-9a-f]{40})`",
+        ("pymc5",),
+    ),
+    (
+        "REPORT_TEMPLATE.md",
+        REPORT_TEMPLATE_PATH,
+        r"- Candidate checkout: `([0-9a-f]{40})`",
+        ("pymc6",),
+    ),
+)
+
+
+def test_pinned_revisions_are_documented_consistently() -> None:
+    """Re-pinning must move the constant and both documents together."""
+    harness = _load_harness_module()
+    assert set(harness.STACK_COMMITS) == {"pymc5", "pymc6"}
+    assert harness.PYMC5_COMMIT != harness.PYMC6_COMMIT
+    for stack, commit in harness.STACK_COMMITS.items():
+        assert harness._COMMIT_PATTERN.fullmatch(commit), (
+            f"{stack} pin is not a full lowercase SHA-1: {commit!r}"
+        )
+
+    for label, path, pattern, stacks in DOCUMENTED_PIN_QUOTES:
+        matches = re.findall(pattern, path.read_text(encoding="utf-8"))
+        assert len(matches) == 1, (
+            f"{label} must quote the pinned revisions exactly once via {pattern!r}"
+        )
+        quoted = matches[0] if isinstance(matches[0], tuple) else (matches[0],)
+        expected = tuple(harness.STACK_COMMITS[stack] for stack in stacks)
+        assert quoted == expected, (
+            f"{label} quotes {quoted}, but the harness pins {expected}"
+        )

--- a/scripts/migration_baseline/README.md
+++ b/scripts/migration_baseline/README.md
@@ -6,14 +6,6 @@ The candidate was the head of the `pymc6_and_pymcmarketing1_migration` integrati
 
 The tracked implementation is `scripts/migration_baseline/harness.py`; generated JSON and Markdown evidence belongs outside every Git checkout. The harness rejects destinations inside its own checkout or either sampled checkout, and creates evidence files without replacing an existing path.
 
-## Re-pinning the candidate revision
-
-`PYMC6_COMMIT` in `harness.py` moved once already, from `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (the merge of #1091) to the current value: 121 further commits merged into the integration branch afterwards, changing 60 files under `causalpy/`. Evidence captured at the superseded pin would have described a tree predating most of the migration.
-
-Move the pin again when behavioral change to `causalpy/` merges into the integration branch before a capture is run. Commits that change only this harness, its documentation or its tests do not make the pin stale, because they cannot change a sampled posterior — the harness is executed from its own checkout, not from the sampled candidate tree.
-
-Re-pin only by editing `PYMC6_COMMIT`, this document, and [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md) together in a reviewed commit; `test_pinned_revisions_are_documented_consistently` fails when they disagree. Re-pinning invalidates any capture taken at the previous pin: `capture` refuses a checkout whose `HEAD` is not the pinned revision, and `compare` refuses an artifact whose recorded `expected_commit` or `actual_commit` is not the currently pinned revision, so a stale artifact cannot be mixed into a new batch. Discard it and capture a fresh batch.
-
 ## Historical v1 result and v2 evidence requirement
 
 The prior schema-v1 coordinator run passed all registered gates. Its issue comment is [#1048 evidence comment](https://github.com/pymc-labs/CausalPy/issues/1048#issuecomment-5116536256), and its immutable evidence manifest is [gist revision `ac7db2676caf0eec0ae2da46ac52e48b3b00f86a`](https://gist.github.com/cetagostini/62d0ebf197c99fd7eef4336fb7de46a1/ac7db2676caf0eec0ae2da46ac52e48b3b00f86a).
@@ -57,18 +49,18 @@ The two repeat captures for one stack must have identical runtime provenance, po
 
 Run the four capture commands as independent processes from a clean, committed harness checkout. One coordinator-generated canonical UUID is required for the whole batch; each capture receives its fixed role and a fresh capture UUID is generated inside the harness. The outputs below are create-only: use a newly created evidence directory, not an existing directory or old v1 evidence.
 
-The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `7b3e257b4b006800f445bec6303a399ef7ec2ffc` and install it into its own editable-install prefix. Do not use the harness checkout (`MIGRATION_ROOT`) as `PYMC6_ROOT`: its `HEAD` intentionally differs from the migration candidate, so `capture` would reject it.
-
 ### Host requirements
 
 The protocol is not runnable on a small shared CI container or agent sandbox; it must be scheduled on a host that provides all of the following.
 
 - **Environment manager:** `mamba`, `micromamba` or `conda` on `PATH`, able to create two prefixes. `pip` alone is not sufficient: the two stacks need incompatible PyMC/PyTensor/ArviZ trees and their compiled dependencies.
 - **Two distinct prefixes:** `PYMC5_PREFIX` with PyMC 5 / PyTensor 2 / ArviZ 0, and `PYMC6_PREFIX` with PyMC 6 / PyTensor 3 / ArviZ 1, each with an editable CausalPy install whose `direct_url.json` target is exactly that stack's checkout. The two prefixes must agree on platform, machine, Python version/implementation and NumPy/pandas/xarray versions: `capture` never sees the other prefix, so this is checked at `compare` time by the cross-stack runtime gate, and a mismatch there fails the comparison rather than being reported as migration drift. Budget roughly 5–8 GB of disk for the two prefixes, the two worktrees and the PyTensor compile caches.
-- **Memory:** at least 8 GB of RAM available to the run. Each capture holds four chains of retained draws plus both models' posteriors in memory before serializing summaries, on top of a full PyTensor/NumPy toolchain and its C/numba compilation.
-- **CPU:** at least 4 cores. `cores=1` is a registered protocol constant, so the four chains of each model are sampled serially and extra cores do not shorten a capture; they are needed for the C/numba compilation steps and to keep the host from thrashing. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
-- **Wall time:** hours, not minutes. Four captures run sequentially, each sampling two models at four chains × (1,000 tune + 1,000 draws) with `target_accept=0.95`, i.e. 32 serial chain runs in total, preceded by a cold PyTensor compile in each prefix. Schedule it as a long uninterrupted job.
+- **Memory:** at least 8 GB of RAM available to the run. The serialized fixtures are tiny — 24 and 20 rows — so the posteriors themselves are megabytes; the requirement is set by solving and building two full scientific stacks and by PyTensor's C/numba compilation, not by the draws.
+- **CPU:** at least 4 cores. Sampling does not use them: `cores=1` is a registered protocol constant (see the runtime protocol above), so the four chains of each model run serially and more cores do not shorten a capture. They are for provisioning the two prefixes and compiling, and for headroom. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
+- **Wall time:** budget hours end to end and schedule it as one uninterrupted job. Sampling itself is the smaller part: 32 serial chain runs (4 captures × 2 models × 4 chains of 1,000 tune + 1,000 draws at `target_accept=0.95`) over small fixtures. The bulk of the wall time is creating the two prefixes and cold-compiling each stack.
 - **Isolation:** a clean host with no other memory-hungry work. The command block below points `PYTENSOR_FLAGS=compiledir=...` at a per-prefix directory so a PyTensor 2 and a PyTensor 3 stack never share a compile cache; the harness does not record or validate `compiledir`, so this one is on the coordinator.
+
+The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `7b3e257b4b006800f445bec6303a399ef7ec2ffc` and install it into its own editable-install prefix. Do not use the harness checkout (`MIGRATION_ROOT`) as `PYMC6_ROOT`: its `HEAD` intentionally differs from the migration candidate, so `capture` would reject it.
 
 Set the coordinator locations below to your own paths. `WORKTREES` is any
 directory outside every CausalPy checkout; `MAMBA` is whichever environment
@@ -116,6 +108,16 @@ PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" 
 The comparator requires four distinct paths, exact role order, one shared batch UUID, and four distinct capture UUIDs. It reads each JSON input once, hashes that exact byte buffer, and carries the buffer-derived hash into the report. It verifies exact raw-draw digests, posterior summaries, and sampling-quality evidence only within each stack; a mismatch makes the entire comparison fail as non-deterministic evidence. It never compares a PyMC 5 digest or raw draw with a PyMC 6 digest or raw draw.
 
 A failed numerical comparison writes its fresh JSON decision and Markdown report, then exits with status `1`; malformed or invalid evidence exits with status `2`. The generated report records all four artifact paths and byte hashes, role/batch identity, clean checkout result, comparator identity, imported runtime provenance, and actual finite/convergence diagnostics. Attach it and its four input artifacts to #1048 with the command log. The static attachment outline is in [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md).
+
+## Re-pinning the candidate revision
+
+`PYMC6_COMMIT` was first pinned at `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (the merge of #1091). On 2026-08-01 it was moved to the current value, because 121 further commits had merged into the integration branch since, changing 60 files under `causalpy/`. Evidence captured at that superseded pin would have described a tree predating most of the migration. This section records why the pin moves; it is not a running changelog of every value it has held.
+
+Move the pin again when behavioral change to `causalpy/` merges into the integration branch before a capture is run. Commits that change only this harness, its documentation or its tests do not make the pin stale, because they cannot change a sampled posterior — the harness is executed from its own checkout, not from the sampled candidate tree.
+
+Re-pin only by editing `PYMC6_COMMIT`, this document, and [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md) together in a reviewed commit; `test_pinned_revisions_are_documented_consistently` fails when they disagree. Re-pinning invalidates any capture taken at the previous pin: `capture` refuses a checkout whose `HEAD` is not the pinned revision, and `compare` refuses an artifact whose recorded `expected_commit` or `actual_commit` is not the currently pinned revision, so a stale artifact cannot be mixed into a new batch. Discard it and capture a fresh batch.
+
+Read this file from the harness checkout. `$PYMC5_ROOT` and `$PYMC6_ROOT` are full CausalPy checkouts and carry their own copies of this document, pinned to whatever the candidate was at that revision; a re-pin necessarily lags the merge it describes, so the sampled tree's copy always names an older pin.
 
 ## Continuous verification of the capture path
 

--- a/scripts/migration_baseline/README.md
+++ b/scripts/migration_baseline/README.md
@@ -1,8 +1,16 @@
 # PyMC Migration Baseline Harness
 
-This permanent harness produces reproducible evidence for the PyMC 5 → PyMC 6 migration at the only two revisions that may be attributed to that migration: PyMC 5 reference `79c0a87072fd4653bfaed1eb085f965594c7f03a` and PyMC 6 migration candidate `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a`. It rejects every other source revision so later features are investigated as separate changes rather than mislabeled migration drift.
+This permanent harness produces reproducible evidence for the PyMC 5 → PyMC 6 migration at the only two revisions that may be attributed to that migration: PyMC 5 reference `79c0a87072fd4653bfaed1eb085f965594c7f03a` and PyMC 6 migration candidate `7b3e257b4b006800f445bec6303a399ef7ec2ffc`. It rejects every other source revision so later features are investigated as separate changes rather than mislabeled migration drift.
+
+The candidate is the head of the `pymc6_and_pymcmarketing1_migration` integration branch, so the evidence describes the tree that is proposed for `main`. It is not the harness checkout: `scripts/migration_baseline/harness.py` is executed from its own committed checkout, whose `HEAD` intentionally differs from both sampled revisions.
 
 The tracked implementation is `scripts/migration_baseline/harness.py`; generated JSON and Markdown evidence belongs outside every Git checkout. The harness rejects destinations inside its own checkout or either sampled checkout, and creates evidence files without replacing an existing path.
+
+## Re-pinning the candidate revision
+
+`PYMC6_COMMIT` in `harness.py` moved once already, from `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (the merge of #1091) to the current value, because 121 further commits touching 60 files under `causalpy/` merged into the integration branch afterwards. Evidence captured at the superseded pin would have described a tree predating most of the migration.
+
+Re-pin only by editing `PYMC6_COMMIT`, this document, and [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md) together in a reviewed commit; `test_pinned_revisions_are_documented_consistently` fails when they disagree. Re-pinning invalidates any capture taken at the previous pin: `capture` refuses a checkout whose `HEAD` is not the pinned revision, and `compare` refuses an artifact whose recorded `expected_commit` or `actual_commit` is not the currently pinned revision, so a stale artifact cannot be mixed into a new batch. Discard it and capture a fresh batch.
 
 ## Historical v1 result and v2 evidence requirement
 
@@ -47,7 +55,18 @@ The two repeat captures for one stack must have identical runtime provenance, po
 
 Run the four capture commands as independent processes from a clean, committed harness checkout. One coordinator-generated canonical UUID is required for the whole batch; each capture receives its fixed role and a fresh capture UUID is generated inside the harness. The outputs below are create-only: use a newly created evidence directory, not an existing directory or old v1 evidence.
 
-The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` and install it into its own editable-install prefix. Do not use the committed `migration/1048-baseline-harness` checkout as `PYMC6_ROOT`: its source `HEAD` intentionally differs from the migration candidate.
+The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `7b3e257b4b006800f445bec6303a399ef7ec2ffc` and install it into its own editable-install prefix. Do not use the committed `migration/1048-baseline-harness` checkout as `PYMC6_ROOT`: its source `HEAD` intentionally differs from the migration candidate.
+
+### Host requirements
+
+The protocol is not runnable on a small shared CI container or agent sandbox; it must be scheduled on a host that provides all of the following.
+
+- **Environment manager:** `mamba`, `micromamba` or `conda` on `PATH`, able to create two prefixes. `pip` alone is not sufficient: the two stacks need incompatible PyMC/PyTensor/ArviZ trees and their compiled dependencies.
+- **Two distinct prefixes:** `PYMC5_PREFIX` with PyMC 5 / PyTensor 2 / ArviZ 0, and `PYMC6_PREFIX` with PyMC 6 / PyTensor 3 / ArviZ 1, each with an editable CausalPy install whose `direct_url.json` target is exactly that stack's checkout. The two prefixes must agree on platform, machine, Python version/implementation and NumPy/pandas/xarray versions, or capture is rejected. Budget roughly 5–8 GB of disk for the two prefixes, the two worktrees and the PyTensor compile caches.
+- **Memory:** at least 8 GB of RAM available to the run. Each capture holds four chains of retained draws plus both models' posteriors in memory before serializing summaries, on top of a full PyTensor/NumPy toolchain and its C/numba compilation.
+- **CPU:** at least 4 cores. `cores=1` is a registered protocol constant, so the four chains of each model are sampled serially and extra cores do not shorten a capture; they are needed for the C/numba compilation steps and to keep the host from thrashing. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
+- **Wall time:** hours, not minutes. Four captures run sequentially, each sampling two models at four chains × (1,000 tune + 1,000 draws) with `target_accept=0.95`, i.e. 32 serial chain runs in total, preceded by a cold PyTensor compile in each prefix. Schedule it as a long uninterrupted job.
+- **Isolation:** a clean host with no other memory-hungry work. Point `PYTENSOR_FLAGS=compiledir=...` at a per-prefix directory so the two stacks never share a compile cache.
 
 Set the six coordinator variables below to your own locations. `WORKTREES` is any
 directory outside every CausalPy checkout; `MAMBA` is whichever environment

--- a/scripts/migration_baseline/README.md
+++ b/scripts/migration_baseline/README.md
@@ -2,13 +2,15 @@
 
 This permanent harness produces reproducible evidence for the PyMC 5 → PyMC 6 migration at the only two revisions that may be attributed to that migration: PyMC 5 reference `79c0a87072fd4653bfaed1eb085f965594c7f03a` and PyMC 6 migration candidate `7b3e257b4b006800f445bec6303a399ef7ec2ffc`. It rejects every other source revision so later features are investigated as separate changes rather than mislabeled migration drift.
 
-The candidate is the head of the `pymc6_and_pymcmarketing1_migration` integration branch, so the evidence describes the tree that is proposed for `main`. It is not the harness checkout: `scripts/migration_baseline/harness.py` is executed from its own committed checkout, whose `HEAD` intentionally differs from both sampled revisions.
+The candidate was the head of the `pymc6_and_pymcmarketing1_migration` integration branch when it was pinned, so the evidence describes the tree proposed for `main`. It is deliberately not the harness checkout: run `scripts/migration_baseline/harness.py` from its own committed checkout, whose `HEAD` differs from both sampled revisions.
 
 The tracked implementation is `scripts/migration_baseline/harness.py`; generated JSON and Markdown evidence belongs outside every Git checkout. The harness rejects destinations inside its own checkout or either sampled checkout, and creates evidence files without replacing an existing path.
 
 ## Re-pinning the candidate revision
 
-`PYMC6_COMMIT` in `harness.py` moved once already, from `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (the merge of #1091) to the current value, because 121 further commits touching 60 files under `causalpy/` merged into the integration branch afterwards. Evidence captured at the superseded pin would have described a tree predating most of the migration.
+`PYMC6_COMMIT` in `harness.py` moved once already, from `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (the merge of #1091) to the current value: 121 further commits merged into the integration branch afterwards, changing 60 files under `causalpy/`. Evidence captured at the superseded pin would have described a tree predating most of the migration.
+
+Move the pin again when behavioral change to `causalpy/` merges into the integration branch before a capture is run. Commits that change only this harness, its documentation or its tests do not make the pin stale, because they cannot change a sampled posterior — the harness is executed from its own checkout, not from the sampled candidate tree.
 
 Re-pin only by editing `PYMC6_COMMIT`, this document, and [REPORT_TEMPLATE.md](REPORT_TEMPLATE.md) together in a reviewed commit; `test_pinned_revisions_are_documented_consistently` fails when they disagree. Re-pinning invalidates any capture taken at the previous pin: `capture` refuses a checkout whose `HEAD` is not the pinned revision, and `compare` refuses an artifact whose recorded `expected_commit` or `actual_commit` is not the currently pinned revision, so a stale artifact cannot be mixed into a new batch. Discard it and capture a fresh batch.
 
@@ -55,20 +57,20 @@ The two repeat captures for one stack must have identical runtime provenance, po
 
 Run the four capture commands as independent processes from a clean, committed harness checkout. One coordinator-generated canonical UUID is required for the whole batch; each capture receives its fixed role and a fresh capture UUID is generated inside the harness. The outputs below are create-only: use a newly created evidence directory, not an existing directory or old v1 evidence.
 
-The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `7b3e257b4b006800f445bec6303a399ef7ec2ffc` and install it into its own editable-install prefix. Do not use the committed `migration/1048-baseline-harness` checkout as `PYMC6_ROOT`: its source `HEAD` intentionally differs from the migration candidate.
+The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `7b3e257b4b006800f445bec6303a399ef7ec2ffc` and install it into its own editable-install prefix. Do not use the harness checkout (`MIGRATION_ROOT`) as `PYMC6_ROOT`: its `HEAD` intentionally differs from the migration candidate, so `capture` would reject it.
 
 ### Host requirements
 
 The protocol is not runnable on a small shared CI container or agent sandbox; it must be scheduled on a host that provides all of the following.
 
 - **Environment manager:** `mamba`, `micromamba` or `conda` on `PATH`, able to create two prefixes. `pip` alone is not sufficient: the two stacks need incompatible PyMC/PyTensor/ArviZ trees and their compiled dependencies.
-- **Two distinct prefixes:** `PYMC5_PREFIX` with PyMC 5 / PyTensor 2 / ArviZ 0, and `PYMC6_PREFIX` with PyMC 6 / PyTensor 3 / ArviZ 1, each with an editable CausalPy install whose `direct_url.json` target is exactly that stack's checkout. The two prefixes must agree on platform, machine, Python version/implementation and NumPy/pandas/xarray versions, or capture is rejected. Budget roughly 5–8 GB of disk for the two prefixes, the two worktrees and the PyTensor compile caches.
+- **Two distinct prefixes:** `PYMC5_PREFIX` with PyMC 5 / PyTensor 2 / ArviZ 0, and `PYMC6_PREFIX` with PyMC 6 / PyTensor 3 / ArviZ 1, each with an editable CausalPy install whose `direct_url.json` target is exactly that stack's checkout. The two prefixes must agree on platform, machine, Python version/implementation and NumPy/pandas/xarray versions: `capture` never sees the other prefix, so this is checked at `compare` time by the cross-stack runtime gate, and a mismatch there fails the comparison rather than being reported as migration drift. Budget roughly 5–8 GB of disk for the two prefixes, the two worktrees and the PyTensor compile caches.
 - **Memory:** at least 8 GB of RAM available to the run. Each capture holds four chains of retained draws plus both models' posteriors in memory before serializing summaries, on top of a full PyTensor/NumPy toolchain and its C/numba compilation.
 - **CPU:** at least 4 cores. `cores=1` is a registered protocol constant, so the four chains of each model are sampled serially and extra cores do not shorten a capture; they are needed for the C/numba compilation steps and to keep the host from thrashing. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
 - **Wall time:** hours, not minutes. Four captures run sequentially, each sampling two models at four chains × (1,000 tune + 1,000 draws) with `target_accept=0.95`, i.e. 32 serial chain runs in total, preceded by a cold PyTensor compile in each prefix. Schedule it as a long uninterrupted job.
-- **Isolation:** a clean host with no other memory-hungry work. Point `PYTENSOR_FLAGS=compiledir=...` at a per-prefix directory so the two stacks never share a compile cache.
+- **Isolation:** a clean host with no other memory-hungry work. The command block below points `PYTENSOR_FLAGS=compiledir=...` at a per-prefix directory so a PyTensor 2 and a PyTensor 3 stack never share a compile cache; the harness does not record or validate `compiledir`, so this one is on the coordinator.
 
-Set the six coordinator variables below to your own locations. `WORKTREES` is any
+Set the coordinator locations below to your own paths. `WORKTREES` is any
 directory outside every CausalPy checkout; `MAMBA` is whichever environment
 manager provides the two prefixes.
 
@@ -82,25 +84,27 @@ PYMC5_ROOT="$WORKTREES/CausalPy-1048-pymc5"
 PYMC5_PREFIX="$WORKTREES/.mamba/CausalPy-1048-pymc5"
 PYMC6_ROOT="$WORKTREES/CausalPy-1048-pymc6"
 PYMC6_PREFIX="$WORKTREES/.mamba/CausalPy-1048-pymc6"
+PYMC5_FLAGS="compiledir=$PYMC5_PREFIX/.pytensor"
+PYMC6_FLAGS="compiledir=$PYMC6_PREFIX/.pytensor"
 BATCH_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 EVIDENCE_ROOT="$WORKTREES/migration-baseline-v2-${BATCH_ID}"
 HARNESS="$MIGRATION_ROOT/scripts/migration_baseline/harness.py"
 
 mkdir "$EVIDENCE_ROOT"
 
-"$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="$PYMC5_FLAGS" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-1.json"
-"$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="$PYMC5_FLAGS" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-2.json"
-"$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-1.json"
-"$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-2.json"
-"$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
+PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
   --reference-first "$EVIDENCE_ROOT/pymc5-run-1.json" \
   --reference-second "$EVIDENCE_ROOT/pymc5-run-2.json" \
   --candidate-first "$EVIDENCE_ROOT/pymc6-run-1.json" \

--- a/scripts/migration_baseline/REPORT_TEMPLATE.md
+++ b/scripts/migration_baseline/REPORT_TEMPLATE.md
@@ -7,7 +7,7 @@ This is the permanent attachment structure for #1048. It is not evidence by itse
 ## Scope and attribution
 
 - Reference checkout: `79c0a87072fd4653bfaed1eb085f965594c7f03a` in the PyMC 5 environment.
-- Candidate checkout: `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` in the PyMC 6 migration environment.
+- Candidate checkout: `7b3e257b4b006800f445bec6303a399ef7ec2ffc` in the PyMC 6 migration environment.
 - Both sampled checkouts and the executing harness checkout had an empty `git status --porcelain` before CausalPy import. The committed harness implementation checkout is not a sampled candidate checkout.
 - Attribution statement: this evidence covers only the fixed migration delta. Any behavior on a later source commit is a separate feature comparison and must not be described as migration drift.
 

--- a/scripts/migration_baseline/harness.py
+++ b/scripts/migration_baseline/harness.py
@@ -31,8 +31,23 @@ ARTIFACT_SCHEMA_VERSION = 2
 COMPARISON_SCHEMA_VERSION = 2
 SCENARIO_VERSION = 2
 
+# The only two revisions whose numerical difference may be attributed to the
+# PyMC 5 -> PyMC 6 migration. ``PYMC5_COMMIT`` is the pre-migration reference and
+# never moves. ``PYMC6_COMMIT`` is the migration candidate: the head of the
+# `pymc6_and_pymcmarketing1_migration` integration branch that the evidence will
+# describe. The coordinator checks both out as clean detached worktrees and every
+# other revision is rejected, so evidence can never silently describe two
+# arbitrary trees.
+#
+# Re-pinning the candidate is a deliberate, reviewed source change to this line
+# plus `scripts/migration_baseline/README.md` and
+# `scripts/migration_baseline/REPORT_TEMPLATE.md`, which
+# `test_pinned_revisions_are_documented_consistently` keeps in agreement. Move it
+# only when further behavioral change merges into the integration branch before a
+# capture is run, and then discard evidence captured at the superseded pin rather
+# than mixing the two batches.
 PYMC5_COMMIT = "79c0a87072fd4653bfaed1eb085f965594c7f03a"
-PYMC6_COMMIT = "18a524a1a8512aaa21c46e0ccddbc54501c9eb1a"
+PYMC6_COMMIT = "7b3e257b4b006800f445bec6303a399ef7ec2ffc"
 STACK_COMMITS = {"pymc5": PYMC5_COMMIT, "pymc6": PYMC6_COMMIT}
 _COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}\Z")
 _SHA256_PATTERN = re.compile(r"[0-9a-f]{64}\Z")


### PR DESCRIPTION
Re-pins the migration baseline harness candidate revision to the current integration-branch head. Refs #1048.

## The problem

`scripts/migration_baseline/harness.py` hard-pins the two revisions it will accept:

- PyMC 5 reference `79c0a87072fd4653bfaed1eb085f965594c7f03a`
- PyMC 6 candidate `18a524a1a8512aaa21c46e0ccddbc54501c9eb1a` (merge of #1091, 2026-07-28)

The `pymc6_and_pymcmarketing1_migration` head is now `7b3e257b4b006800f445bec6303a399ef7ec2ffc` (merge of #1120, 2026-08-01), which is **121 commits** past that candidate, touching **60 files under `causalpy/`** (`git diff --stat 18a524a1..7b3e257b -- causalpy/`: 6,720 insertions, 1,222 deletions). Merges in that range include #1096, #1099, #1100, #1101, #1102, #1103, #1097, #1098, #1105, #1106, #1107, #1108, #1087, #850, #1110 and #1120.

So the harness would only have accepted a checkout that predates almost all of the merged migration work. Any baseline captured today would have been evidence about the wrong tree — and, because the harness reports success on the revision it pins, that would not have been visibly wrong.

## The change

- `PYMC6_COMMIT` → `7b3e257b4b006800f445bec6303a399ef7ec2ffc`. `PYMC5_COMMIT` is unchanged.
- The two documents that quote the pin are moved in step: `README.md` (intro line and the `PYMC6_ROOT` worktree provisioning step) and `REPORT_TEMPLATE.md` (candidate checkout line).
- Five new tests, none of which sample:
  - `test_pinned_revisions_are_documented_consistently` (parametrized over the four documented quote sites) checks each site against `STACK_COMMITS`. The coordinator provisions its worktrees from the README and transcribes the attribution statement from the template, so a stale SHA in either document sends a real capture at the wrong tree; that failure mode is now caught in CI instead of after hours of sampling. The anchors tolerate reflowed whitespace so rewrapping a paragraph cannot masquerade as pin drift.
  - `test_pinned_revisions_are_distinct_full_shas` — the two pins are distinct, full, lowercase SHA-1s.
  - `test_capture_rejects_an_unpinned_revision_before_import` — a *clean* checkout at a superseded revision is refused before CausalPy is imported. The pre-existing dirty-checkout test returns the correct commit and never reached that branch, so this guarantee was documented but untested.
  - `test_comparator_rejects_an_artifact_from_a_superseded_pin` (parametrized over `expected_commit` / `actual_commit`) — a stale artifact cannot enter a new batch.
  - `test_superseded_pin_is_recorded_as_history_only` — the re-pinning section cannot name the current pin as its own predecessor.
- `README.md` gains a "Re-pinning the candidate revision" section and a "Host requirements" section (below).

## Why the pin is no weaker than before

Nothing in the enforcement path changed — only the pinned value.

- `capture` still resolves `git rev-parse HEAD` in `--repo-root` and raises unless it equals `STACK_COMMITS[stack]` (`harness.py`, `_capture_artifact`), still requires an empty `git status --porcelain` in the sampled checkout, and still binds the executing harness blob via `_harness_identity`.
- `_validate_artifact` still rejects any artifact whose `provenance.expected_commit` or `provenance.actual_commit` differs from the currently pinned revision, and `compare` still requires all four artifacts to bind the executing comparator's SHA-256, blob SHA-256 and commit.
- Consequence: artifacts captured at the superseded pin `18a524a1` are now *rejected* by `compare`. A stale capture cannot be silently mixed into a new batch. The re-pin is strictly narrowing, not widening — the harness accepts exactly one candidate revision before and after.
- No schema bump is needed or wanted. `ARTIFACT_SCHEMA_VERSION` / `COMPARISON_SCHEMA_VERSION` / `SCENARIO_VERSION` describe artifact structure and the fixed fixtures, none of which changed. Distinguishability of a future batch from the historical v1 evidence is already guaranteed by schema v2 rejecting v1 artifacts outright, and stale v2 artifacts are now excluded by the commit check above.
- The re-pin is only possible as a reviewed source change to a tracked constant plus two documents held in agreement by a test. It cannot be done by a flag, an environment variable or a CLI argument.

## The v1 evidence is untouched

No file under the historical evidence path is modified: the #1048 evidence comment and gist revision `ac7db2676caf0eec0ae2da46ac52e48b3b00f86a` are not referenced by this change except in the unchanged README paragraph that declares them immutable. A future run produces a NEW v2 batch alongside them.

## Compute specification for the real capture run

**The capture was NOT executed in this PR, by design.** The protocol cannot run in a CI container or agent sandbox; it needs a dedicated host. Schedule it with the following:

| Resource | Requirement |
| --- | --- |
| Environment manager | `mamba`, `micromamba` or `conda` on `PATH` |
| Environments | 2 separate prefixes: PyMC 5 / PyTensor 2 / ArviZ 0, and PyMC 6 / PyTensor 3 / ArviZ 1 |
| Checkouts | 2 clean detached worktrees: `79c0a870…` and `7b3e257b…`, each editable-installed into its own prefix |
| RAM | ≥ 8 GB available to the run |
| CPU | ≥ 4 cores |
| Disk | ~5–8 GB for the two prefixes, two worktrees and PyTensor compile caches |
| Wall time | Hours. Schedule as one long uninterrupted job |

Detail:

- **Two prefixes are mandatory.** The stacks need incompatible PyMC/PyTensor/ArviZ trees; `pip` into one environment cannot satisfy this. The harness verifies imported major versions per stack, requires the imported third-party dependency paths to sit below the active `sys.prefix` (CausalPy itself is exempt, since an editable install lives outside the prefix), and requires the active CausalPy distribution to be an editable install whose `direct_url.json` target is exactly `--repo-root`.
- **The two prefixes must otherwise match**: same platform, machine, Python version/implementation and NumPy/pandas/xarray versions, or the run is rejected as a host change rather than migration evidence.
- **CPU:** `cores=1` is a registered protocol constant, so the four chains of each model are sampled *serially*; extra cores do not shorten a capture. They are needed for the C/numba compilation steps and headroom. Do not run the four captures concurrently — the two stacks must not contend for memory.
- **Work performed:** 4 captures (`reference_first`, `reference_second`, `candidate_first`, `candidate_second`), each sampling 2 models (DiD/`LinearRegression`, SyntheticControl/`WeightedSumFitter`) at 4 chains × (1,000 tune + 1,000 draws), `target_accept=0.95`, `max_treedepth=12`, master seed 1048 — 32 serial chain runs total, plus a cold PyTensor compile in each prefix.
- **Gates:** rank-Rhat ≤ 1.01, bulk ESS ≥ 400, tail ESS ≥ 400 with the explicit `(0.05, 0.95)` probability pair, zero divergences, no tree-depth saturation, all values finite. Failing any of these invalidates the capture rather than being reported as migration drift.
- **Isolation:** clean host, no other memory-hungry work, `PYTENSOR_FLAGS=compiledir=…` pointed at a per-prefix directory so the stacks never share a compile cache.
- **Outputs:** a newly created evidence directory outside every checkout, one shared batch UUID, four artifacts plus the comparison JSON and Markdown report, attached to #1048 following `REPORT_TEMPLATE.md`.

The exact command sequence is in `scripts/migration_baseline/README.md`.

**Note for whoever schedules it:** if further behavioral change merges into `pymc6_and_pymcmarketing1_migration` before the run, `PYMC6_COMMIT` must be re-pinned again first. Merging *this* PR does not require another re-pin: it changes only the harness, its documentation and its tests, none of which can change a sampled posterior — the harness is executed from its own checkout, whose `HEAD` intentionally differs from the sampled candidate.

## Testing

`causalpy/tests/test_migration_baseline_harness.py` — 37 passed, 1 deselected (`test_capture_reproduces_the_fixed_manifest_on_the_installed_stack`, marked `slow`/`integration`; it runs a reduced 2×500 protocol and is covered by the full CI job, not by the targeted local run). No capture was executed.
