### PR TITLE
chore: remove dead config from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,14 +101,12 @@ docs = [
     "pymc-bart",
     "linkify-it-py",
     "myst-nb<=1.0.0",
-    "pathlib",
     "pylint",
     "sphinx",
     "sphinx-autodoc-typehints",
     "sphinx_autodoc_defaultargs",
     "labs-sphinx-theme",
     "sphinx-copybutton",
-    "sphinx-rtd-theme",
     "sphinx-sitemap",
     "statsmodels",
     "sphinxcontrib-bibtex>=2.7.0",
@@ -164,7 +162,6 @@ addopts = [
 ]
 testpaths = "causalpy/tests"
 markers = [
-    "correctness: mark as a statistical correctness test.",
     "integration: mark as an integration test.",
     "slow: mark test as slow.",
     "correctness: mark statistical correctness and reproducibility tests.",
@@ -232,21 +229,6 @@ exclude_lines = [
 [tool.mypy]
 files = "causalpy/*.py"
 exclude = "build|dist|docs|notebooks|tests|setup.py"
-
-[tool.mypy-matplotlib]
-ignore_missing_imports = true
-
-[tool.mypy-pymc]
-ignore_missing_imports = true
-
-[tool.mypy-seaborn]
-ignore_missing_imports = true
-
-[tool.mypy-sklearn]
-ignore_missing_imports = true
-
-[tool.mypy-scipy]
-ignore_missing_imports = true
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"


### PR DESCRIPTION
Part of a deeper hardening pass over CI, pre-commit, packaging and pinning, done with Opus 5.

Four entries in `pyproject.toml` that nothing uses: two dead docs dependencies, a pytest marker registered twice, and five mypy tables written in `mypy.ini` syntax that `pyproject.toml` never reads. 18 deleted lines in one file, so I kept them together rather than splitting.

Rationale for each removal is inline on the diff.

### Checked

`prek run --all-files` is green. `environment.yml` is unchanged, as expected, since it is generated from the `dev` and `test` extras. Read the Docs built this PR and passed, and I also built the docs locally as an A/B: a clean 3.12 environment installed from this branch, then the same environment with `pathlib` and `sphinx-rtd-theme` reinstalled. Both exit 0 with 103 warnings and identical warning sets.

One unrelated thing that surfaced while checking that: the skip filter in `.readthedocs.yaml` diffs against `origin/main`, not against the PR base. A pyproject-only PR based on `main` would exit 183 and skip the preview build. This one builds because its base, the integration branch, is already 109 files ahead of `main` under `causalpy/`. Harmless here, but it means whether a PR gets a docs preview depends on its base branch rather than on what the PR changes.
