### PR TITLE
fix: repair and harden the UML diagram workflow

### DIFF
--- a/.github/workflows/uml.yml
+++ b/.github/workflows/uml.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # to push branches
+      contents: write # to push the bot branch
       pull-requests: write # to create PRs
     steps:
 
@@ -18,21 +18,20 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: main
-          persist-credentials: true # needed for git push
+          # The push-capable token is handed to create-pull-request explicitly
+          # instead of being left in .git/config while pip installs run.
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.12"
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install 'causalpy[docs]'
+          pip install -e '.[docs]'
           sudo apt-get update && sudo apt-get install -y graphviz
-
-      - name: Install pylint explicitly
-        run: python -m pip install pylint
 
       - name: Verify pylint and pyreverse
         run: |
@@ -40,48 +39,27 @@ jobs:
           which pyreverse
           pyreverse --version
 
-      - name: Configure Git Identity
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
       - name: Update the UML Diagrams
         run: |
           make uml
 
-      - name: Detect UML changes
-        id: changes
-        run: |
-          git add docs/source/_static/*.png
-          if git diff --staged --exit-code; then
-            echo "No changes to commit"
-            echo "changes_exist=false" >> $GITHUB_OUTPUT
-          else
-            echo "changes_exist=true" >> $GITHUB_OUTPUT
-          fi
-
       - name: Create PR for changes
-        if: steps.changes.outputs.changes_exist == 'true'
-        run: |
-          BRANCH_NAME="update-uml-diagrams"
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "Update UML Diagrams"
+          title: "Update UML Diagrams"
+          body: |
+            This PR updates the UML diagrams.
 
-          # Delete the branch locally and remotely if it exists
-          git branch -D $BRANCH_NAME 2>/dev/null || true
-          git push origin --delete $BRANCH_NAME 2>/dev/null || true
-
-          # Create and push the new branch
-          git checkout -b $BRANCH_NAME
-          git commit -m "Update UML Diagrams"
-          git push -u origin $BRANCH_NAME
-
-          # Create PR (will fail gracefully if PR already exists)
-          gh pr create \
-            --base main \
-            --title "Update UML Diagrams" \
-            --body "This PR updates the UML diagrams
-            This PR was created automatically by the [UML workflow](https://github.com/pymc-labs/CausalPy/blob/main/.github/workflows/uml.yml).
-            See the logs [here](https://github.com/pymc-labs/CausalPy/actions/workflows/uml.yml) for more details." \
-            --label "no releasenotes" \
-            --reviewer drbenvincent || echo "PR may already exist"
-        env:
-          GH_TOKEN: ${{ github.token }}
+            Created automatically by the [UML workflow](https://github.com/pymc-labs/CausalPy/blob/main/.github/workflows/uml.yml)
+            from the checked-out source via `make uml`. See the
+            [logs](https://github.com/pymc-labs/CausalPy/actions/workflows/uml.yml)
+            for more details.
+          branch: update-uml-diagrams
+          delete-branch: true
+          add-paths: |
+            docs/source/_static/classes.png
+            docs/source/_static/packages.png
+          labels: no releasenotes
+          reviewers: drbenvincent


### PR DESCRIPTION
Part of a deeper hardening pass over CI, pre-commit, packaging and pinning, done with Opus 5.

Two problems in `.github/workflows/uml.yml`, so one PR.

**Stale environment.** The job pins Python 3.10, the package needs 3.11 or newer, and it installs `causalpy[docs]` from PyPI rather than the checkout. Pip backtracks to 0.5.0, from 2025-07-24, five releases back. The diagrams stayed correct anyway, so the weekly job has been green on a year-old environment.

**Token exposure.** The job runs two pip installs while holding `contents: write` with `persist-credentials: true`, so a compromised transitive dependency would execute alongside a repo-write token in `.git/config`.

Rationale for each change is inline on the diff. `prek run --all-files` is green.

### Before merge

Workflows only really test by running, and the `reviewers` input is the one part with no precedent in this repo. Could you dispatch it from this branch? A successful run will open or update a real "Update UML Diagrams" PR, so it is not side-effect free.

Targeting `main` since scheduled workflows run from the default branch. Happy to retarget behind #1048.
