### PR TITLE
chore: add concurrency guards and pin zizmor in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
 
   prek:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,9 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only supersede pull request builds. A push to main must finish so the commit
+  # keeps its Codecov report.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 
@@ -71,6 +73,10 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # Guard (issue #1117): a wedged doctest fails as `failure` in minutes instead
+    # of being `cancelled` at GitHub's 6h ceiling. Headroom over the observed
+    # ~21 min max for this job (incl. cold micromamba-cache solves).
+    timeout-minutes: 30
     permissions:
       contents: read
     defaults:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,12 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Only supersede pull request builds. A push to main or a published release
+  # must never be cancelled part way through.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     name: Build source distribution

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -9,9 +9,13 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   zizmor:
-    name: zizmor latest via PyPI
+    name: zizmor via PyPI
     runs-on: ubuntu-latest
     permissions:
       security-events: write
@@ -24,7 +28,9 @@ jobs:
       - uses: hynek/setup-cached-uv@4300ec2180bc77d705e626a34e381b81a4772c51 # v2.5.0
 
       - name: Run zizmor 🌈
-        run: uvx zizmor --format sarif . > results.sarif
+        # Pinned: an unpinned `uvx zizmor` turns CI red on an unchanged branch
+        # whenever upstream ships a new audit.
+        run: uvx zizmor@1.29.0 --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -11,7 +11,9 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Only supersede pull request builds. A push to main must finish so the commit
+  # keeps its code scanning results.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   zizmor:
@@ -29,7 +31,9 @@ jobs:
 
       - name: Run zizmor 🌈
         # Pinned: an unpinned `uvx zizmor` turns CI red on an unchanged branch
-        # whenever upstream ships a new audit.
+        # whenever upstream ships a new audit. Dependabot cannot see a version
+        # inside `run:`, so bump this by hand when adopting new audits, or the
+        # audit set silently freezes here.
         run: uvx zizmor@1.29.0 --format sarif . > results.sarif
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Part of a deeper hardening pass over CI, pre-commit, packaging and pinning, done with Opus 5.

Three small things. `ci.yml` and `zizmor.yml` have no `concurrency` block, so pushing three times to a PR runs three full matrices to completion. `uvx zizmor` is unpinned, so a new upstream audit can turn CI red on a branch nobody touched. And the `test` job has no `timeout-minutes`, so a wedged doctest holds a runner for six hours.

Cancellation is limited to pull request builds, matching `release.yml`. A push to `main` finishes, so the commit keeps its Codecov report and its code scanning results.

Rationale for each change is inline on the diff.

### On the timeout

An earlier revision of this PR left the timeout out, on the grounds that #1119 had already fixed it. That was wrong for this branch. #1119 landed on the integration branch, so `main` has neither the guard nor the doctest sampling fix behind it. This PR's own `test (3.11)` job then wedged in `Run doctests` and was cancelled at the 6 hour ceiling, the third occurrence of #1117 after the two on #1087. The cap here reuses the wording from #1119 so the two branches converge instead of drifting.

`main` still carries the root cause. Backporting the doctest sampling fix from #1119 is a separate change.

### Deliberately not included

The audit that produced this PR suggested three more changes. Each was dropped after checking, so recording why:

- Moving the numpydoc hook off `v1.11.0rc0`. That rc came from pre-commit.ci autoupdate picking the newest tag in #969, and there is no stable 1.11.0, so pinning back would just be re-bumped next run.
- Skipping the SARIF upload on fork PRs, on the theory that `security-events: write` is not granted there. Wrong: #1063 and #989 are genuine fork PRs and zizmor passes on both, so `upload-sarif` already handles the read-only token.
- `cache: pip` on the notebooks job. Real but marginal: installing takes 75 seconds of a job that spends nine minutes running notebooks.
