### PR TITLE
Fix RD OLS threshold-contrast uncertainty

### DIFF
--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -232,6 +232,9 @@ class RegressionDiscontinuity(BaseExperiment):
             }
         )
         (new_x,) = build_design_matrices([self._x_design_info], self.x_discon)
+        # Preserve the design rows used for the threshold prediction contrast:
+        # row 0 is below the threshold and row 1 is above it.
+        self.x_discon_design = np.asarray(new_x)
         self.pred_discon = self._model_backend.predict(X=np.asarray(new_x))
         self.discontinuity_at_threshold = self.pred_discon.isel(
             obs_ind=1, treated_units=0

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -1609,26 +1609,46 @@ def _compute_statistics_rd_ols(result, alpha=0.05):
     # with the degrees of freedom used below for the t-distribution.
     mse = np.sum(residuals**2) / df
 
-    # Find the treated coefficient index
-    coeff_idx = None
-    for i, label in enumerate(result.labels):
-        if "treated" in label.lower() and ":" in label:
-            coeff_idx = i
-            break
+    try:
+        threshold_design = np.asarray(result.x_discon_design, dtype=float)
+    except AttributeError as err:
+        raise ValueError(
+            "Cannot compute the RD threshold-contrast standard error because "
+            "the threshold design rows are unavailable."
+        ) from err
+    except (TypeError, ValueError) as err:
+        raise ValueError(
+            "RD threshold design must be a finite numeric two-row array."
+        ) from err
 
-    if coeff_idx is None:
-        se = np.std(residuals) / np.sqrt(n)
-    else:
-        X = X_da
-        try:
-            if hasattr(X, "values"):
-                X = X.values
-            elif hasattr(X, "data"):
-                X = X.data
-            XtX_inv = np.linalg.inv(X.T @ X)
-            se = np.sqrt(mse * XtX_inv[coeff_idx, coeff_idx])
-        except (np.linalg.LinAlgError, AttributeError):
-            se = np.std(residuals) / np.sqrt(n)
+    if threshold_design.ndim != 2 or threshold_design.shape[0] != 2:
+        raise ValueError(
+            "RD threshold design must contain exactly two rows: below threshold "
+            "followed by above threshold."
+        )
+
+    if not np.isfinite(threshold_design).all():
+        raise ValueError("RD threshold design must be a finite numeric two-row array.")
+
+    X = np.asarray(X_da)
+    if threshold_design.shape[1] != X.shape[1]:
+        raise ValueError(
+            "RD threshold design must have the same number of columns as the "
+            "fitted design matrix."
+        )
+
+    try:
+        XtX_inv = np.linalg.inv(X.T @ X)
+    except np.linalg.LinAlgError as err:
+        raise ValueError(
+            "Cannot compute the RD threshold-contrast standard error because "
+            "X.T @ X is singular."
+        ) from err
+
+    # discontinuity_at_threshold is the prediction above the threshold minus
+    # the prediction below it, so its uncertainty must use that same contrast.
+    contrast = threshold_design[1] - threshold_design[0]
+    se = np.sqrt(mse * contrast @ XtX_inv @ contrast)
 
     # t-critical value
     t_critical = t.ppf(1 - alpha / 2, df=df)

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -477,63 +477,79 @@ def test_effect_summary_rd_ols(mock_pymc_sample, rd_data):
 
 @pytest.mark.integration
 def test_effect_summary_ols_rd_residuals_are_per_observation(rd_data):
-    """Regression-pin for RD OLS ``effect_summary()`` intervals.
-
-    The pre-#1049 ``_compute_statistics_rd_ols`` subtracted a bare ``(n,)``
-    ``y_pred`` array from the ``(n, 1)`` y DataArray, broadcasting to an
-    ``(n, n)`` residual matrix (every observation's y minus every *other*
-    observation's prediction) and inflating the MSE ~9x on this dataset, so
-    the reported standard errors were ~3x too wide. ``_point_residuals``
-    fixed that. Separately, the residual variance was estimated as SSR/n
-    (biased) rather than SSR/(n-p) (unbiased), inconsistent with the
-    ``df = n - p`` already used for the t-distribution critical value. With
-    both bugs fixed, this test pins the corrected residual shape and SE
-    against an independent statsmodels fit almost exactly, not just up to
-    some remaining conversion factor.
-    """
+    """RD OLS residuals must have one value per fitted observation."""
     from sklearn.linear_model import LinearRegression
 
     from causalpy.reporting import _point_residuals
 
-    formula = "y ~ 1 + x + treated + x:treated"
+    result = cp.RegressionDiscontinuity(
+        rd_data,
+        formula="y ~ 1 + x + treated + x:treated",
+        treatment_threshold=0.5,
+        model=LinearRegression(),
+    )
+
+    n, _ = result.design["X"].shape
+    residuals = _point_residuals(result)
+
+    assert residuals.shape == (n,)
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "formula",
+    [
+        "y ~ 1 + x + treated + x:treated",
+        "y ~ 1 + x + treated",
+    ],
+    ids=["interaction", "parallel_slopes"],
+)
+def test_effect_summary_ols_rd_matches_statsmodels_threshold_contrast(rd_data, formula):
+    """RD OLS summaries must match the exact threshold prediction contrast."""
+    import statsmodels.formula.api as smf
+    from patsy import build_design_matrices
+    from scipy.stats import t as t_dist
+    from sklearn.linear_model import LinearRegression
+
     result = cp.RegressionDiscontinuity(
         rd_data,
         formula=formula,
         treatment_threshold=0.5,
         model=LinearRegression(),
     )
+    row = result.effect_summary().table.loc["discontinuity"]
 
-    n, p = result.design["X"].shape
-    residuals = _point_residuals(result)
-    assert residuals.shape == (n,)
-
-    stats = result.effect_summary()
-    row = stats.table.loc["discontinuity"]
-
-    import statsmodels.formula.api as smf
-    from scipy.stats import t as t_dist
+    threshold_data = pd.DataFrame(
+        {
+            result.running_variable_name: [
+                result.treatment_threshold - result.epsilon,
+                result.treatment_threshold + result.epsilon,
+            ],
+            "treated": [False, True],
+        }
+    )
+    (expected_threshold_design,) = build_design_matrices(
+        [result._x_design_info], threshold_data
+    )
+    expected_threshold_design = np.asarray(expected_threshold_design)
+    np.testing.assert_allclose(result.x_discon_design, expected_threshold_design)
 
     sm_fit = smf.ols(formula, data=result.fit_data).fit()
-    interaction_col = next(name for name in sm_fit.params.index if "x:treated" in name)
-    unbiased_se = sm_fit.bse[interaction_col]
+    assert list(sm_fit.params.index) == result.labels
+    contrast = expected_threshold_design[1] - expected_threshold_design[0]
+    expected = sm_fit.t_test(contrast)
+    expected_ci = np.asarray(expected.conf_int(alpha=0.05)).squeeze()
+    n, p = result.design["X"].shape
+    t_critical = t_dist.ppf(1 - 0.05 / 2, df=n - p)
+    reported_se = (row["ci_upper"] - row["ci_lower"]) / (2 * t_critical)
+    expected_se = float(np.asarray(expected.sd).squeeze())
 
-    t_crit = t_dist.ppf(1 - 0.05 / 2, df=n - p)
-    reported_se = (row["ci_upper"] - row["ci_lower"]) / (2 * t_crit)
+    assert reported_se == pytest.approx(expected_se)
 
-    assert reported_se == pytest.approx(unbiased_se, rel=1e-8)
-    # Guard against regressing to either the (n, n) broadcast bug (~3x
-    # inflation) or the biased SSR/n denominator understatement.
-    biased_mse = np.mean(residuals**2)
-    XtX_inv = np.linalg.inv(
-        np.asarray(result.design["X"]).T @ np.asarray(result.design["X"])
-    )
-    coeff_idx = next(
-        i
-        for i, label in enumerate(result.labels)
-        if "treated" in label.lower() and ":" in label
-    )
-    biased_se = np.sqrt(biased_mse * XtX_inv[coeff_idx, coeff_idx])
-    assert reported_se != pytest.approx(biased_se, rel=1e-3)
+    assert row["mean"] == pytest.approx(float(np.asarray(expected.effect).squeeze()))
+    assert row["ci_lower"] == pytest.approx(expected_ci[0])
+    assert row["ci_upper"] == pytest.approx(expected_ci[1])
+    assert row["p_value"] == pytest.approx(float(np.asarray(expected.pvalue).squeeze()))
 
 
 @pytest.mark.integration
@@ -1646,34 +1662,82 @@ def test_compute_statistics_did_ols_missing_interaction_term(
 
 
 @pytest.mark.integration
-def test_compute_statistics_rd_ols_fallback_path(mock_pymc_sample, rd_data):
-    """Test _compute_statistics_rd_ols uses fallback when coefficient not found."""
+def test_compute_statistics_rd_ols_raises_when_threshold_design_is_missing(rd_data):
+    """RD contrast inference requires the stored threshold design rows."""
     from sklearn.linear_model import LinearRegression
 
     from causalpy.reporting import _compute_statistics_rd_ols
 
-    df = rd_data
     result = cp.RegressionDiscontinuity(
-        df,
+        rd_data,
         formula="y ~ 1 + x + treated + x:treated",
         treatment_threshold=0.5,
         model=LinearRegression(),
     )
+    del result.x_discon_design
 
-    # Manually corrupt the labels to trigger fallback
-    original_labels = result.labels
-    result.labels = ["Intercept", "x", "some_other_term"]
+    with pytest.raises(ValueError, match="threshold design rows are unavailable"):
+        _compute_statistics_rd_ols(result)
 
-    # Should not raise error, but use fallback SE calculation
-    stats = _compute_statistics_rd_ols(result, alpha=0.05)
 
-    # Restore labels
-    result.labels = original_labels
+@pytest.mark.integration
+@pytest.mark.parametrize(
+    "invalid_design",
+    [
+        lambda design: design[:1],
+        lambda design: design[0],
+        lambda design: design[:, :-1],
+        lambda design: np.full(design.shape, "not-a-number", dtype=object),
+        lambda design: np.full_like(design, np.nan),
+        lambda design: np.full_like(design, np.inf),
+        lambda design: np.full_like(design, -np.inf),
+    ],
+    ids=[
+        "one_row",
+        "one_dimensional",
+        "wrong_width",
+        "nonnumeric",
+        "nan",
+        "positive_infinity",
+        "negative_infinity",
+    ],
+)
+def test_compute_statistics_rd_ols_raises_when_threshold_design_is_malformed(
+    rd_data, invalid_design
+):
+    """RD contrast inference rejects stored design rows that cannot form c."""
+    from sklearn.linear_model import LinearRegression
 
-    assert "mean" in stats
-    assert "ci_lower" in stats
-    assert "ci_upper" in stats
-    assert "p_value" in stats
+    from causalpy.reporting import _compute_statistics_rd_ols
+
+    result = cp.RegressionDiscontinuity(
+        rd_data,
+        formula="y ~ 1 + x + treated + x:treated",
+        treatment_threshold=0.5,
+        model=LinearRegression(),
+    )
+    result.x_discon_design = invalid_design(result.x_discon_design)
+
+    with pytest.raises(ValueError, match="threshold design"):
+        _compute_statistics_rd_ols(result)
+
+
+@pytest.mark.integration
+def test_compute_statistics_rd_ols_raises_when_fitted_design_is_singular(rd_data):
+    """RD contrast inference rejects singular normal equations."""
+    from sklearn.linear_model import LinearRegression
+
+    from causalpy.reporting import _compute_statistics_rd_ols
+
+    result = cp.RegressionDiscontinuity(
+        rd_data,
+        formula="y ~ 1 + x + I(2 * x) + treated",
+        treatment_threshold=0.5,
+        model=LinearRegression(),
+    )
+
+    with pytest.raises(ValueError, match="X.T @ X is singular"):
+        _compute_statistics_rd_ols(result)
 
 
 # ==============================================================================


### PR DESCRIPTION
## Problem
RD OLS reporting paired `discontinuity_at_threshold`—the prediction difference at the threshold—with a single interaction-coefficient SE selected by label, or with a residual-only fallback. That made the reported uncertainty, CI, and p-value describe a different estimand and failed for valid parallel-slopes formulas.

## Change
Persist the exact Patsy threshold design rows used for prediction, ordered below then above threshold. RD OLS reporting now forms their upper-minus-lower contrast and computes its covariance-based SE from the existing unbiased residual MSE and inverse normal equations. It removes coefficient-label selection and the fallback, and raises clear `ValueError`s for unavailable, malformed, nonnumeric, nonfinite, or width-incompatible threshold designs and for singular normal equations.

## Evidence
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se python -m pytest causalpy/tests/test_reporting.py -k 'rd' --no-cov` — 15 passed.
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se python -m pytest causalpy/tests/test_integration_skl_examples.py -k 'rd_linear_main_effects or rd_linear_with_interaction' --no-cov` — 4 passed.
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se prek run --files causalpy/reporting.py causalpy/experiments/regression_discontinuity.py causalpy/tests/test_reporting.py` — passed.
- New parameterized tests independently rebuild the threshold rows and compare unscaled `statsmodels` `OLSResults.t_test(contrast)` SE, mean, CI, and p-value for interacted and parallel-slopes RD formulas.

## Maintainer decisions
I followed the final PR #1028 review instruction not to rescale `statsmodels` contrast SE by `sqrt((n-p)/n)`, because the transition base already uses the unbiased `SSR/(n-p)` residual variance. I did not change residual shaping, the MSE denominator, plotting, dataframe handling, or non-RD reporting.

## Release notes needed
RD OLS `effect_summary()` now reports threshold-discontinuity uncertainty as the covariance of the exact upper-minus-lower prediction contrast, including for parallel-slopes specifications without an interaction term.

Closes #1028
