### PR TITLE
feat: complete dataframe-like experiment inputs

### DIFF
--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -472,6 +472,12 @@ class PlaceboInTime:
             """Create a fresh experiment with the given treatment time."""
             kw = dict(kwargs)
             kw["treatment_time"] = treatment_time
+            # This factory receives a slice of experiment.data, which is already
+            # normalized: time_column has been moved onto the index, so the
+            # column no longer exists and replaying the argument would fail.
+            # The other checks re-fit from the caller's original data and do
+            # need it, so this is dropped here rather than at the source.
+            kw.pop("time_column", None)
             if model_template is not None:
                 kw["model"] = self._clone_model_for_fold(
                     model_template, fold_random_seed

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -16,7 +16,6 @@
 from typing import Any, Literal
 
 import numpy as np
-import pandas as pd
 import seaborn as sns
 import xarray as xr
 from matplotlib import pyplot as plt
@@ -30,6 +29,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     has_posterior_draws,
@@ -63,8 +63,9 @@ class DifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     time_variable_name : str
@@ -110,7 +111,7 @@ class DifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         time_variable_name: str,
         group_variable_name: str,
@@ -119,8 +120,9 @@ class DifferenceInDifferences(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray | float | None
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas returns a copy, so index metadata is normalized on an
+        # owned frame rather than the caller's.
+        data = to_pandas(data)
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Difference in Differences"

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -16,7 +16,6 @@
 import warnings  # noqa: I001
 
 import numpy as np
-import pandas as pd
 from patsy import PatsyError
 from sklearn.linear_model import LinearRegression as sk_lin_reg
 
@@ -25,6 +24,7 @@ import arviz as az
 from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.pymc_models import InstrumentalVariableRegression
 from causalpy.utils import round_num
 
@@ -37,13 +37,14 @@ class InstrumentalVariable(BaseExperiment):
 
     Parameters
     ----------
-    instruments_data : pd.DataFrame
-        A pandas dataframe of instruments for our treatment variable.
-        Should contain instruments Z, and treatment t.
-    data : pd.DataFrame
-        A pandas dataframe of covariates for fitting the focal regression
-        of interest. Should contain covariates X including treatment t and
-        outcome y.
+    instruments_data : dataframe-like
+        Instruments for our treatment variable, as any eager dataframe
+        Narwhals supports, such as pandas, Polars, or PyArrow. Should contain
+        instruments Z, and treatment t. Converted to pandas internally.
+    data : dataframe-like
+        Covariates for fitting the focal regression of interest, as any eager
+        dataframe Narwhals supports. Should contain covariates X including
+        treatment t and outcome y. Converted to pandas internally.
     instruments_formula : str
         A statistical model formula for the instrumental stage regression,
         e.g. ``t ~ 1 + z1 + z2 + z3``.
@@ -125,8 +126,8 @@ class InstrumentalVariable(BaseExperiment):
 
     def __init__(
         self,
-        instruments_data: pd.DataFrame,
-        data: pd.DataFrame,
+        instruments_data: DataFrameLike,
+        data: DataFrameLike,
         instruments_formula: str,
         formula: str,
         model: InstrumentalVariableRegression | None = None,
@@ -137,8 +138,10 @@ class InstrumentalVariable(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Instrumental Variable Regression"
-        self.data = data
-        self.instruments_data = instruments_data
+        self.data = to_pandas(data)
+        self.instruments_data = to_pandas(
+            instruments_data, argument_name="instruments_data"
+        )
         self.formula = formula
         self.instruments_formula = instruments_formula
         self.vs_prior_type = vs_prior_type

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -139,9 +139,11 @@ class InstrumentalVariable(BaseExperiment):
         super().__init__(model=model)
         self.expt_type = "Instrumental Variable Regression"
         self.data = to_pandas(data)
+        self.data.index.name = "obs_ind"
         self.instruments_data = to_pandas(
             instruments_data, argument_name="instruments_data"
         )
+        self.instruments_data.index.name = "obs_ind"
         self.formula = formula
         self.instruments_formula = instruments_formula
         self.vs_prior_type = vs_prior_type

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -31,6 +31,7 @@ from causalpy.date_utils import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -57,10 +58,12 @@ class InterruptedTimeSeries(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with time series data. The index should be either
-        a DatetimeIndex or numeric (integer/float), with unique values in
-        monotonically increasing order.
+    data : dataframe-like
+        Time series data as any eager dataframe Narwhals supports. For a pandas
+        dataframe the index carries the time axis, and it should be either a
+        DatetimeIndex or numeric (integer/float), with unique values in
+        monotonically increasing order. Dataframes from other libraries have no
+        index, so those callers must pass ``time_column``.
     treatment_time : Union[int, float, pd.Timestamp]
         The time when treatment occurred, should be in reference to the data index.
         Must match the index type (DatetimeIndex requires pd.Timestamp).
@@ -81,6 +84,11 @@ class InterruptedTimeSeries(BaseExperiment):
         the analysis assumes a permanent intervention (two-period design).
         **INCLUSIVE**: Observations at exactly ``treatment_end_time`` are included in the
         post-intervention period (uses ``>=`` comparison).
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -152,17 +160,19 @@ class InterruptedTimeSeries(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         formula: str,
         model: PyMCModel | RegressorMixin | PyMCForecastModel | None = None,
         treatment_end_time: int | float | pd.Timestamp | None = None,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
         self.pre_design: xr.Dataset
         self.post_design: xr.Dataset
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time, treatment_end_time)

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -95,6 +95,7 @@ class InversePropensityWeighting(BaseExperiment):
         super().__init__(model=model)
         self.expt_type = "Inverse Propensity Score Weighting"
         self.data = to_pandas(data)
+        self.data.index.name = "obs_ind"
         self.formula = formula
         self.outcome_variable = outcome_variable
         self.weighting_scheme = weighting_scheme

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -27,6 +27,7 @@ from sklearn.linear_model import LinearRegression as sk_lin_reg
 
 from causalpy.custom_exceptions import DataException
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.pymc_models import PropensityScore
 
 from .base import BaseExperiment
@@ -37,8 +38,9 @@ class InversePropensityWeighting(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula for the propensity model.
     outcome_variable : str
@@ -84,7 +86,7 @@ class InversePropensityWeighting(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         outcome_variable: str,
         weighting_scheme: str,
@@ -92,7 +94,7 @@ class InversePropensityWeighting(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Inverse Propensity Score Weighting"
-        self.data = data
+        self.data = to_pandas(data)
         self.formula = formula
         self.outcome_variable = outcome_variable
         self.weighting_scheme = weighting_scheme

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -29,6 +29,7 @@ from causalpy.constants import HDI_PROB
 from causalpy.custom_exceptions import DataException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import _plot_interval_band
 from causalpy.pymc_models import PyMCModel
 from causalpy.utils import round_num
@@ -44,9 +45,10 @@ class PanelRegression(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with panel data. Each row is an observation for a
-        unit at a time period.
+    data : dataframe-like
+        Panel data as any eager dataframe Narwhals supports, such as pandas,
+        Polars, or PyArrow. Each row is an observation for a unit at a time
+        period. Converted to pandas internally.
     formula : str
         A statistical model formula using patsy syntax. For the unpooled
         dummy-variable fixed-effects approach, include ``C(unit_var)`` (and
@@ -186,7 +188,7 @@ class PanelRegression(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         unit_fe_variable: str,
         time_fe_variable: str | None = None,
@@ -195,8 +197,9 @@ class PanelRegression(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
 
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas returns a copy, so this rename lands on ours, not the
+        # caller's dataframe.
+        data = to_pandas(data)
         data.index.name = "obs_ind"
         self.data = data
         self.expt_type = "Panel Regression"

--- a/causalpy/experiments/piecewise_its.py
+++ b/causalpy/experiments/piecewise_its.py
@@ -28,6 +28,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -61,8 +62,11 @@ class PiecewiseITS(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas DataFrame containing the time series data.
+    data : dataframe-like
+        Time series data as any eager dataframe Narwhals supports, such as
+        pandas, Polars, or PyArrow. The time axis comes from the ``step()`` or
+        ``ramp()`` column in the formula, not from the index, so a dataframe
+        without an index works here. Converted to pandas internally.
     formula : str
         A patsy formula specifying the model. Must include at least one
         ``step()`` or ``ramp()`` term, and all such terms must use the same
@@ -156,7 +160,7 @@ class PiecewiseITS(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         model: PyMCModel | RegressorMixin | None = None,
     ) -> None:
@@ -165,7 +169,7 @@ class PiecewiseITS(BaseExperiment):
         # Store configuration
         self.expt_type = "Piecewise Interrupted Time Series"
         self.formula = formula
-        self.data = data.copy()
+        self.data = to_pandas(data)
 
         # Rename the index to "obs_ind" for consistency
         self.data.index.name = "obs_ind"

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -27,6 +27,7 @@ from causalpy.custom_exceptions import (
 )
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     plot_posterior_over_x,
@@ -45,8 +46,9 @@ class PrePostNEGD(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     group_variable_name : str
@@ -101,7 +103,7 @@ class PrePostNEGD(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         group_variable_name: str,
         pretreatment_variable_name: str,
@@ -112,7 +114,7 @@ class PrePostNEGD(BaseExperiment):
         self.pred_xi: np.ndarray
         self.pred_untreated: xr.DataArray
         self.pred_treated: xr.DataArray
-        self.data = data
+        self.data = to_pandas(data)
         self.expt_type = "Pretest/posttest Nonequivalent Group Design"
         self.formula = formula
         self.group_variable_name = group_variable_name

--- a/causalpy/experiments/prepostnegd.py
+++ b/causalpy/experiments/prepostnegd.py
@@ -115,6 +115,7 @@ class PrePostNEGD(BaseExperiment):
         self.pred_untreated: xr.DataArray
         self.pred_treated: xr.DataArray
         self.data = to_pandas(data)
+        self.data.index.name = "obs_ind"
         self.expt_type = "Pretest/posttest Nonequivalent Group Design"
         self.formula = formula
         self.group_variable_name = group_variable_name

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -25,6 +25,7 @@ from patsy import ModelDesc
 from sklearn.base import RegressorMixin
 
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.custom_exceptions import (
     DataException,
@@ -55,8 +56,9 @@ class RegressionDiscontinuity(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     treatment_threshold : float
@@ -112,7 +114,7 @@ class RegressionDiscontinuity(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         treatment_threshold: float,
         model: PyMCModel | RegressorMixin | None = None,
@@ -123,9 +125,9 @@ class RegressionDiscontinuity(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Discontinuity"
-        # Work on an owned frame before normalizing the treated indicator.
-        data = data.copy()
-        self.data = data
+        # to_pandas returns a copy, so the treated indicator is normalized on
+        # an owned frame rather than the caller's.
+        self.data = to_pandas(data)
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.treatment_threshold = treatment_threshold

--- a/causalpy/experiments/regression_discontinuity.py
+++ b/causalpy/experiments/regression_discontinuity.py
@@ -128,6 +128,7 @@ class RegressionDiscontinuity(BaseExperiment):
         # to_pandas returns a copy, so the treated indicator is normalized on
         # an owned frame rather than the caller's.
         self.data = to_pandas(data)
+        self.data.index.name = "obs_ind"
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.treatment_threshold = treatment_threshold

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -25,6 +25,7 @@ import seaborn as sns
 from patsy import ModelDesc
 import xarray as xr
 from causalpy.formula_utils import build_design_matrices, build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
@@ -51,8 +52,9 @@ class RegressionKink(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, such as pandas, Polars, or
+        PyArrow. Converted to pandas internally.
     formula : str
         A statistical model formula.
     kink_point : float
@@ -81,7 +83,7 @@ class RegressionKink(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         kink_point: float,
         model: PyMCModel | None = None,
@@ -91,7 +93,7 @@ class RegressionKink(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.expt_type = "Regression Kink"
-        self.data = data
+        self.data = to_pandas(data)
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.kink_point = kink_point

--- a/causalpy/experiments/regression_kink.py
+++ b/causalpy/experiments/regression_kink.py
@@ -94,6 +94,7 @@ class RegressionKink(BaseExperiment):
         super().__init__(model=model)
         self.expt_type = "Regression Kink"
         self.data = to_pandas(data)
+        self.data.index.name = "obs_ind"
         self.formula = formula
         self.running_variable_name = running_variable_name
         self.kink_point = kink_point

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -32,6 +32,7 @@ from causalpy.constants import HDI_PROB, LEGEND_FONT_SIZE
 from causalpy.custom_exceptions import DataException, FormulaException
 from causalpy.experiments.model_adapter import build_coords
 from causalpy.formula_utils import build_formula_matrices
+from causalpy.input_data import DataFrameLike, to_pandas
 from causalpy.plot_utils import has_posterior_draws
 from causalpy.pymc_models import LinearRegression, PyMCModel
 from causalpy.reporting import EffectSummary
@@ -52,8 +53,10 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe with panel data (unit x time observations).
+    data : dataframe-like
+        Panel data (unit x time observations) as any eager dataframe Narwhals
+        supports, such as pandas, Polars, or PyArrow. Converted to pandas
+        internally.
     formula : str
         A statistical model formula. Recommended: "y ~ 1 + C(unit) + C(time)"
         for unit and time fixed effects.
@@ -161,7 +164,7 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         formula: str,
         unit_variable_name: str,
         time_variable_name: str,
@@ -185,8 +188,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         self.event_window = event_window
         self.reference_event_time = reference_event_time
 
-        # Make a copy of data to avoid modifying the original
-        data = data.copy()
+        # to_pandas returns a copy, so the caller's dataframe is left alone
+        data = to_pandas(data)
         data.index.name = "obs_ind"
 
         # Input validation

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -29,6 +29,7 @@ from causalpy.date_utils import (
     validate_treatment_time_against_index,
 )
 from causalpy.experiments.model_adapter import PyMCModelAdapter, build_coords
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import (
     _PosteriorPlotStyle,
     format_r2_score,
@@ -53,8 +54,10 @@ class SyntheticControl(BaseExperiment):
 
     Parameters
     ----------
-    data : pd.DataFrame
-        A pandas dataframe.
+    data : dataframe-like
+        Any eager dataframe Narwhals supports. For a pandas dataframe the index
+        carries the time axis. Dataframes from other libraries have no index,
+        so those callers must pass ``time_column``.
     treatment_time : int, float, or pd.Timestamp
         The time when treatment occurred, in reference to the data index.
     control_units : list of str
@@ -79,6 +82,11 @@ class SyntheticControl(BaseExperiment):
         pinned explicitly, leaving the instance you passed in untouched. A model
         constructed with an explicit ``y_hat`` prior is never rescaled either
         way.
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -119,17 +127,19 @@ class SyntheticControl(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         control_units: list[str],
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
         min_donor_correlation: float = 0.0,
         auto_scale_sigma: bool = True,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -31,6 +31,7 @@ from causalpy.date_utils import (
     format_date_axes,
     validate_treatment_time_against_index,
 )
+from causalpy.input_data import DataFrameLike, to_pandas_with_time_index
 from causalpy.plot_utils import _PosteriorPlotStyle, plot_posterior_over_x
 from causalpy.pymc_models import PyMCModel, SyntheticDifferenceInDifferencesWeightFitter
 from causalpy.reporting import EffectSummary
@@ -49,8 +50,11 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
     Parameters
     ----------
-    data : pandas.DataFrame
-        A dataframe in wide format (columns = units, rows = time periods).
+    data : dataframe-like
+        Any eager dataframe Narwhals supports, in wide format (columns = units,
+        rows = time periods). For a pandas dataframe the index carries the time
+        axis. Dataframes from other libraries have no index, so those callers
+        must pass ``time_column``.
     treatment_time : int, float or pandas.Timestamp
         The time when treatment occurred, should be in reference to the data
         index.
@@ -61,6 +65,11 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
     model : PyMCModel or sklearn.base.RegressorMixin, optional
         A ``SyntheticDifferenceInDifferencesWeightFitter`` instance. Defaults
         to ``SyntheticDifferenceInDifferencesWeightFitter``.
+    time_column : str, optional
+        Column holding the time axis. It becomes the index of the data. Required
+        for non-pandas inputs, which carry no index. If None (default), the
+        pandas index of ``data`` is used. Passing it for data that already has a
+        meaningful index raises, since only one of the two can be the time axis.
 
     Notes
     -----
@@ -125,15 +134,17 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
 
     def __init__(
         self,
-        data: pd.DataFrame,
+        data: DataFrameLike,
         treatment_time: int | float | pd.Timestamp,
         control_units: list[str],
         treated_units: list[str],
         model: PyMCModel | RegressorMixin | None = None,
+        time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # Work on an owned frame before normalizing its index metadata.
-        data = data.copy()
+        # to_pandas_with_time_index returns a copy, so index metadata is
+        # normalized on an owned frame rather than the caller's.
+        data = to_pandas_with_time_index(data, time_column)
         data.index.name = "obs_ind"
         self.data = data
         self.input_validation(data, treatment_time)

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -146,8 +146,9 @@ def to_pandas_with_time_index(
     Raises
     ------
     DataException
-        If ``time_column`` is missing from the data, or if a non-pandas input
-        arrives without a ``time_column``.
+        If ``time_column`` is missing from the data, if a non-pandas input
+        arrives without a ``time_column``, or if ``time_column`` is given for a
+        dataframe that already carries a meaningful index.
 
     Examples
     --------
@@ -179,4 +180,33 @@ def to_pandas_with_time_index(
             f"`time_column` '{time_column}' is not a column of `{argument_name}`. "
             f"Available columns: {list(frame.columns)}."
         )
+    if not _has_default_index(frame):
+        raise DataException(
+            f"`{argument_name}` already has a meaningful index "
+            f"({frame.index.name or 'unnamed'}, {type(frame.index).__name__}), and "
+            f"`time_column` '{time_column}' was also given. Setting the column as "
+            "the index would drop the existing one, which would silently change the "
+            "time axis. Pass only one: drop `time_column` to keep the index, or "
+            "call `.reset_index(drop=True)` on the data to discard the index."
+        )
     return frame.set_index(time_column)
+
+
+def _has_default_index(frame: pd.DataFrame) -> bool:
+    """Report whether a dataframe carries no meaningful index.
+
+    A default ``RangeIndex`` with no name is what pandas assigns when nobody
+    chose an index, and it is what conversion from an index-less dataframe
+    library produces.
+
+    Parameters
+    ----------
+    frame : pandas.DataFrame
+        The dataframe to inspect.
+
+    Returns
+    -------
+    bool
+        True when the index is an unnamed ``RangeIndex``.
+    """
+    return isinstance(frame.index, pd.RangeIndex) and frame.index.name is None

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -31,7 +31,9 @@ loaders in :mod:`causalpy.data` all hand back pandas regardless of what was
 passed in. This module widens what you may pass, not what you get back.
 
 Pandas inputs retain their index. Dataframes from other libraries have no
-index concept, so conversion produces a default ``RangeIndex``.
+index concept, so conversion produces a default ``RangeIndex``. Experiments
+that read the index as a time axis take a ``time_column`` argument instead;
+see :func:`to_pandas_with_time_index`.
 """
 
 from __future__ import annotations
@@ -40,7 +42,9 @@ import narwhals as nw
 import pandas as pd
 from narwhals.typing import IntoDataFrame
 
-__all__ = ["DataFrameLike", "to_pandas"]
+from causalpy.custom_exceptions import DataException
+
+__all__ = ["DataFrameLike", "to_pandas", "to_pandas_with_time_index"]
 
 type DataFrameLike = IntoDataFrame
 """Any eager dataframe Narwhals supports: pandas, Polars, PyArrow, and others.
@@ -108,3 +112,71 @@ def to_pandas(data: DataFrameLike, *, argument_name: str = "data") -> pd.DataFra
             f"Got {type(data).__name__}.{hint}"
         ) from error
     return frame.to_pandas()
+
+
+def to_pandas_with_time_index(
+    data: DataFrameLike,
+    time_column: str | None = None,
+    *,
+    argument_name: str = "data",
+) -> pd.DataFrame:
+    """Convert a dataframe-like input and put its time axis on the index.
+
+    Experiments that compare observations against a ``treatment_time`` need a
+    time axis. Pandas callers have historically supplied it as the dataframe
+    index. Dataframes from other libraries have no index, so those callers must
+    name the column that holds the time axis.
+
+    Parameters
+    ----------
+    data : dataframe-like
+        Any eager dataframe supported by Narwhals.
+    time_column : str or None, default None
+        Column holding the time axis. When given, it becomes the index. When
+        None, the pandas index of ``data`` is used, which requires a pandas
+        input.
+    argument_name : str, default "data"
+        Name of the calling argument, used in error messages.
+
+    Returns
+    -------
+    pandas.DataFrame
+        A pandas dataframe indexed by the time axis.
+
+    Raises
+    ------
+    DataException
+        If ``time_column`` is missing from the data, or if a non-pandas input
+        arrives without a ``time_column``.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from causalpy.input_data import to_pandas_with_time_index
+    >>> frame = pd.DataFrame({"t": [1, 2], "y": [3, 4]})
+    >>> result = to_pandas_with_time_index(frame, time_column="t")
+    >>> result.index.name
+    't'
+    >>> result.index.tolist()
+    [1, 2]
+    >>> result.columns.tolist()
+    ['y']
+    """
+    has_pandas_index = isinstance(data, pd.DataFrame)
+    frame = to_pandas(data, argument_name=argument_name)
+
+    if time_column is None:
+        if not has_pandas_index:
+            raise DataException(
+                f"`{argument_name}` is not a pandas dataframe, so it carries no "
+                "index to use as the time axis. Pass `time_column` naming the "
+                "column that holds the time axis."
+            )
+        return frame
+
+    if time_column not in frame.columns:
+        raise DataException(
+            f"`time_column` '{time_column}' is not a column of `{argument_name}`. "
+            f"Available columns: {list(frame.columns)}."
+        )
+    return frame.set_index(time_column)

--- a/causalpy/input_data.py
+++ b/causalpy/input_data.py
@@ -147,8 +147,9 @@ def to_pandas_with_time_index(
     ------
     DataException
         If ``time_column`` is missing from the data, if a non-pandas input
-        arrives without a ``time_column``, or if ``time_column`` is given for a
-        dataframe that already carries a meaningful index.
+        arrives without a ``time_column``, if ``time_column`` is given for a
+        dataframe that already carries a meaningful index, or if the resulting
+        time axis has duplicates or is not sorted.
 
     Examples
     --------
@@ -189,7 +190,23 @@ def to_pandas_with_time_index(
             "time axis. Pass only one: drop `time_column` to keep the index, or "
             "call `.reset_index(drop=True)` on the data to discard the index."
         )
-    return frame.set_index(time_column)
+    frame = frame.set_index(time_column)
+
+    # Only reachable through the time_column path. A dataframe library with no
+    # index also carries no row-order guarantee, so an unsorted column is an
+    # easy accident. The pre/post split is value-based and would survive it,
+    # but everything order-dependent downstream would not.
+    if not frame.index.is_unique:
+        raise DataException(
+            f"`time_column` '{time_column}' has duplicate values, so it cannot "
+            "be the time axis. Remove the duplicates before fitting."
+        )
+    if not frame.index.is_monotonic_increasing:
+        raise DataException(
+            f"`time_column` '{time_column}' is not sorted, so the time axis "
+            "would be out of order. Sort the data by that column before fitting."
+        )
+    return frame
 
 
 def _has_default_index(frame: pd.DataFrame) -> bool:

--- a/causalpy/tests/test_dataframe_backends.py
+++ b/causalpy/tests/test_dataframe_backends.py
@@ -1,0 +1,379 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Tests that column-based experiments accept non-pandas dataframes.
+
+Each experiment is built twice, once from the pandas fixture and once from the
+same data as a Polars dataframe. The two runs must agree. Experiments that
+treat the pandas index as a time axis are not covered here; they need an
+explicit time column first.
+"""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.data.simulate_data import (
+    generate_ancova_data,
+    generate_piecewise_its_data,
+    generate_staggered_did_data,
+)
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def to_polars(data: pd.DataFrame) -> pl.DataFrame:
+    """Convert a pandas fixture to Polars, dropping the index."""
+    return pl.from_pandas(data.reset_index(drop=True))
+
+
+def assert_data_matches(result_pandas, result_polars, attribute="data"):
+    """The stored dataframe must agree between the two backends.
+
+    The index is dropped before comparing because the two backends are not
+    expected to agree on it. A Polars input has no index to carry over, so it
+    gets a positional one. That contract is asserted separately, per
+    experiment, by ``assert_positional_obs_ind``.
+    """
+    left = getattr(result_pandas, attribute).reset_index(drop=True)
+    right = getattr(result_polars, attribute).reset_index(drop=True)
+    pd.testing.assert_frame_equal(left, right, check_dtype=False)
+
+
+def assert_positional_obs_ind(result_polars, attribute="data"):
+    """A converted input carries a positional observation coordinate.
+
+    Polars and PyArrow have no index to carry over, so conversion assigns
+    ``0..n-1``. Asserted for every experiment rather than one representative,
+    since the coordinate reaches user-facing results.
+    """
+    index = getattr(result_polars, attribute).index
+    assert index.tolist() == list(range(len(index)))
+
+
+def assert_model_input_matches(result_pandas, result_polars):
+    """The model must see identical inputs from both backends.
+
+    Sampling is mocked suite-wide, so posterior draws from two separate
+    constructions are not comparable. The design matrices are a deterministic
+    function of the data and the formula, which is what a conversion bug would
+    actually corrupt.
+    """
+    assert result_polars.labels == result_pandas.labels
+    if hasattr(result_pandas, "design"):
+        pairs = [
+            (result_pandas.design[key], result_polars.design[key]) for key in ("X", "y")
+        ]
+    else:
+        pairs = [
+            (result_pandas.X, result_polars.X),
+            (result_pandas.y, result_polars.y),
+        ]
+    for from_pandas, from_polars in pairs:
+        np.testing.assert_allclose(
+            np.asarray(from_polars, dtype=float), np.asarray(from_pandas, dtype=float)
+        )
+
+
+def test_did_accepts_polars(did_data):
+    """DifferenceInDifferences gives the same fit from pandas and Polars."""
+
+    def build(data):
+        return cp.DifferenceInDifferences(
+            data,
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(did_data)
+    from_polars = build(to_polars(did_data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert from_polars.causal_impact == pytest.approx(from_pandas.causal_impact)
+
+
+def test_regression_discontinuity_accepts_polars(rd_data):
+    """RegressionDiscontinuity gives the same fit from pandas and Polars."""
+
+    def build(data):
+        return cp.RegressionDiscontinuity(
+            data,
+            formula="y ~ 1 + x + treated",
+            model=LinearRegression(),
+            treatment_threshold=0.5,
+        )
+
+    from_pandas = build(rd_data)
+    from_polars = build(to_polars(rd_data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert np.asarray(from_polars.discontinuity_at_threshold).item() == pytest.approx(
+        np.asarray(from_pandas.discontinuity_at_threshold).item()
+    )
+
+
+def test_regression_kink_accepts_polars(mock_pymc_sample):
+    """RegressionKink accepts a Polars dataframe."""
+    from causalpy.tests.conftest import setup_regression_kink_data
+
+    kink = 0.5
+    data = setup_regression_kink_data(kink)
+
+    def build(frame):
+        return cp.RegressionKink(
+            frame,
+            formula=f"y ~ 1 + x + I((x-{kink})*treated)",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+            kink_point=kink,
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_prepostnegd_accepts_polars(mock_pymc_sample):
+    """PrePostNEGD accepts a Polars dataframe."""
+    data = generate_ancova_data(seed=42)
+
+    def build(frame):
+        return cp.PrePostNEGD(
+            frame,
+            formula="post ~ 1 + C(group) + pre",
+            group_variable_name="group",
+            pretreatment_variable_name="pre",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_inverse_propensity_weighting_accepts_polars(mock_pymc_sample):
+    """InversePropensityWeighting accepts a Polars dataframe."""
+    data = cp.load_data("nhefs")
+
+    def build(frame):
+        return cp.InversePropensityWeighting(
+            data=frame,
+            formula="trt ~ 1 + age + race",
+            outcome_variable="outcome",
+            weighting_scheme="robust",
+            model=cp.pymc_models.PropensityScore(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_instrumental_variable_accepts_polars(mock_pymc_sample):
+    """InstrumentalVariable converts both of its dataframe arguments."""
+    df = cp.load_data("risk")
+    instruments_data = df[["risk", "logmort0"]]
+    data = df[["loggdp", "risk"]]
+
+    def build(instruments, covariates):
+        return cp.InstrumentalVariable(
+            instruments_data=instruments,
+            data=covariates,
+            instruments_formula="risk ~ 1 + logmort0",
+            formula="loggdp ~ 1 + risk",
+            model=cp.pymc_models.InstrumentalVariableRegression(
+                sample_kwargs=sample_kwargs
+            ),
+        )
+
+    from_pandas = build(instruments_data, data)
+    from_polars = build(to_polars(instruments_data), to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_data_matches(from_pandas, from_polars, attribute="instruments_data")
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_panel_regression_accepts_polars(mock_pymc_sample):
+    """PanelRegression accepts a Polars dataframe."""
+    rng = np.random.default_rng(42)
+    data = pd.DataFrame(
+        {
+            "unit": np.repeat([f"unit_{i}" for i in range(5)], 10),
+            "time": np.tile(range(10), 5),
+            "treatment": np.tile([0] * 5 + [1] * 5, 5),
+            "x1": rng.normal(size=50),
+            "y": rng.normal(size=50),
+        }
+    )
+
+    def build(frame):
+        return cp.PanelRegression(
+            data=frame,
+            formula="y ~ C(unit) + C(time) + treatment + x1",
+            unit_fe_variable="unit",
+            time_fe_variable="time",
+            fe_method="dummies",
+            model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert_model_input_matches(from_pandas, from_polars)
+
+
+def test_staggered_did_accepts_polars(mock_pymc_sample):
+    """StaggeredDifferenceInDifferences accepts a Polars dataframe."""
+    data = generate_staggered_did_data(n_units=30, n_time_periods=15, seed=42)
+
+    def build(frame):
+        return cp.StaggeredDifferenceInDifferences(
+            frame,
+            formula="y ~ 1 + C(unit) + C(time)",
+            unit_variable_name="unit",
+            time_variable_name="time",
+            treated_variable_name="treated",
+            treatment_time_variable_name="treatment_time",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    pd.testing.assert_frame_equal(
+        from_pandas.att_event_time_.reset_index(drop=True),
+        from_polars.att_event_time_.reset_index(drop=True),
+        check_dtype=False,
+    )
+
+
+def test_piecewise_its_accepts_polars():
+    """PiecewiseITS reads time from the step() column, so Polars works."""
+    data, _ = generate_piecewise_its_data(N=100, seed=42)
+
+    def build(frame):
+        return cp.PiecewiseITS(
+            frame,
+            formula="y ~ 1 + t + step(t, 50) + ramp(t, 50)",
+            model=LinearRegression(),
+        )
+
+    from_pandas = build(data)
+    from_polars = build(to_polars(data))
+
+    assert_data_matches(from_pandas, from_polars)
+    assert_positional_obs_ind(from_polars)
+    assert from_polars.time_col == from_pandas.time_col
+
+
+def test_polars_input_leaves_caller_frame_alone(did_data):
+    """Constructing an experiment does not mutate the caller's dataframe."""
+    data = to_polars(did_data)
+    before = data.clone()
+    cp.DifferenceInDifferences(
+        data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    assert data.equals(before)
+
+
+def test_pandas_input_index_is_not_renamed(did_data):
+    """Constructing an experiment no longer renames the caller's index."""
+    data = did_data.copy()
+    data.index.name = "my_index"
+    cp.DifferenceInDifferences(
+        data,
+        formula="y ~ 1 + group*post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    assert data.index.name == "my_index"
+
+
+def test_panel_regression_pandas_input_index_is_not_renamed(mock_pymc_sample):
+    """PanelRegression also leaves the caller's index name alone."""
+    rng = np.random.default_rng(42)
+    data = pd.DataFrame(
+        {
+            "unit": np.repeat([f"unit_{i}" for i in range(5)], 10),
+            "time": np.tile(range(10), 5),
+            "treatment": np.tile([0] * 5 + [1] * 5, 5),
+            "x1": rng.normal(size=50),
+            "y": rng.normal(size=50),
+        }
+    )
+    data.index.name = "my_index"
+    cp.PanelRegression(
+        data=data,
+        formula="y ~ C(unit) + C(time) + treatment + x1",
+        unit_fe_variable="unit",
+        time_fe_variable="time",
+        fe_method="dummies",
+        model=cp.pymc_models.LinearRegression(sample_kwargs=sample_kwargs),
+    )
+    assert data.index.name == "my_index"
+
+
+def test_polars_input_gets_positional_obs_ind(did_data):
+    """A dataframe without an index gets a positional observation coordinate.
+
+    Pandas callers keep whatever their index holds. Polars and PyArrow have no
+    index to carry over, so conversion assigns ``0..n-1``. That coordinate is
+    row identity for these column-based classes, not a semantic axis, and no
+    existing caller can regress: a frame with no index never had labels to
+    lose. Pinned here so the contract is explicit rather than incidental.
+    """
+
+    def build(data):
+        return cp.DifferenceInDifferences(
+            data,
+            formula="y ~ 1 + group*post_treatment",
+            time_variable_name="t",
+            group_variable_name="group",
+            model=LinearRegression(),
+        )
+
+    labelled = did_data.copy()
+    labelled.index = pd.Index([f"row_{i}" for i in range(len(labelled))], name="key")
+
+    from_pandas = build(labelled)
+    from_polars = build(to_polars(did_data))
+
+    assert from_pandas.data.index.tolist() == labelled.index.tolist()
+    assert from_polars.data.index.tolist() == list(range(len(did_data)))

--- a/causalpy/tests/test_dataframe_backends.py
+++ b/causalpy/tests/test_dataframe_backends.py
@@ -63,6 +63,7 @@ def assert_positional_obs_ind(result_polars, attribute="data"):
     """
     index = getattr(result_polars, attribute).index
     assert index.tolist() == list(range(len(index)))
+    assert index.name == "obs_ind"
 
 
 def assert_model_input_matches(result_pandas, result_polars):
@@ -218,6 +219,7 @@ def test_instrumental_variable_accepts_polars(mock_pymc_sample):
     assert_data_matches(from_pandas, from_polars)
     assert_positional_obs_ind(from_polars)
     assert_data_matches(from_pandas, from_polars, attribute="instruments_data")
+    assert_positional_obs_ind(from_polars, attribute="instruments_data")
     assert_model_input_matches(from_pandas, from_polars)
 
 

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -72,6 +72,29 @@ class TestToPandasWithTimeIndex:
         with pytest.raises(DataException, match="is not a column of"):
             to_pandas_with_time_index(frame, time_column="date")
 
+    def test_time_column_conflicting_with_named_index_raises(self):
+        """A named index plus a time_column is ambiguous, so it is refused."""
+        frame = pd.DataFrame(
+            {"t": [100, 200], "y": [1, 2]}, index=pd.Index([7, 8], name="old")
+        )
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_time_column_conflicting_with_datetime_index_raises(self):
+        """A DatetimeIndex plus a time_column is refused rather than dropped."""
+        frame = pd.DataFrame(
+            {"t": [100, 200], "y": [1, 2]},
+            index=pd.to_datetime(["2020-01-01", "2020-01-02"]),
+        )
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_time_column_with_default_index_is_allowed(self):
+        """An unnamed RangeIndex is not meaningful, so time_column is fine."""
+        frame = pd.DataFrame({"t": [100, 200], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [100, 200]
+
 
 class TestInterruptedTimeSeries:
     """InterruptedTimeSeries with an explicit time column."""
@@ -122,6 +145,19 @@ class TestInterruptedTimeSeries:
                 pd.to_datetime("2015-01-01"),
                 formula="timeseries ~ 1 + linear_trend",
                 model=LinearRegression(),
+            )
+
+    def test_time_column_with_existing_index_raises(self, its_simple_data):
+        """Passing time_column alongside a DatetimeIndex is refused."""
+        flat = its_simple_data.rename_axis("date").reset_index()
+        both = flat.set_index(pd.Index(range(len(flat)), name="row"))
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            cp.InterruptedTimeSeries(
+                both,
+                pd.to_datetime("2015-01-01"),
+                formula="timeseries ~ 1 + linear_trend",
+                model=LinearRegression(),
+                time_column="date",
             )
 
     def test_pandas_input_index_is_not_renamed(self, its_simple_data):

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -95,6 +95,23 @@ class TestToPandasWithTimeIndex:
         result = to_pandas_with_time_index(frame, time_column="t")
         assert result.index.tolist() == [100, 200]
 
+    def test_duplicate_time_column_raises(self):
+        """A time axis with repeats is refused."""
+        frame = pl.DataFrame({"t": [1, 1, 2], "y": [3, 4, 5]})
+        with pytest.raises(DataException, match="duplicate values"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_unsorted_time_column_raises(self):
+        """An out-of-order time axis is refused rather than silently accepted.
+
+        A dataframe library with no index carries no row-order guarantee, so
+        this is an easy accident. The pre/post split is value-based and would
+        survive it, but anything order-dependent downstream would not.
+        """
+        frame = pl.DataFrame({"t": [3, 1, 2], "y": [4, 5, 6]})
+        with pytest.raises(DataException, match="is not sorted"):
+            to_pandas_with_time_index(frame, time_column="t")
+
 
 class TestInterruptedTimeSeries:
     """InterruptedTimeSeries with an explicit time column."""
@@ -242,4 +259,29 @@ class TestSyntheticDifferenceInDifferences:
                 70,
                 control_units=["a", "b", "c", "d", "e", "f", "g"],
                 treated_units=["actual"],
+            )
+
+
+class TestUnsortedTimeColumnEndToEnd:
+    """An unsorted time column is refused at the experiment boundary.
+
+    SyntheticControl and SyntheticDifferenceInDifferences validate only the
+    treatment-time type, not index order, so before this guard they accepted a
+    shuffled time axis and scrambled it silently. InterruptedTimeSeries already
+    refused it via its own index validation.
+    """
+
+    @pytest.mark.parametrize(
+        "experiment", ["SyntheticControl", "SyntheticDifferenceInDifferences"]
+    )
+    def test_shuffled_time_column_raises(self, sc_data, experiment):
+        """Shuffling the rows of an otherwise valid frame is refused."""
+        shuffled = sc_data.sample(frac=1.0, random_state=1)
+        with pytest.raises(DataException, match="is not sorted"):
+            getattr(cp, experiment)(
+                to_polars_with_time(shuffled, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                time_column="time",
             )

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -27,8 +27,10 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
+from causalpy.checks.placebo_in_time import PlaceboInTime
 from causalpy.custom_exceptions import BadIndexException, DataException
 from causalpy.input_data import to_pandas_with_time_index
+from causalpy.pipeline import PipelineContext
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
 
@@ -272,18 +274,47 @@ class TestTimestampMismatchMessage:
     than dates lands here, which is what surfaced it.
     """
 
-    def test_non_datetime_index_with_timestamp_treatment_time(self, sc_data):
-        """A string time axis plus a Timestamp treatment time explains itself."""
-        as_text = sc_data.copy()
-        as_text.index = as_text.index.astype(str)
-        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
-            cp.SyntheticControl(
-                as_text,
-                pd.Timestamp("2020-01-01"),
-                control_units=["a", "b", "c", "d", "e", "f", "g"],
-                treated_units=["actual"],
-                model=LinearRegression(),
+    @staticmethod
+    def _build(name, data):
+        """Construct one of the three classes with a Timestamp treatment time."""
+        units = {
+            "control_units": ["a", "b", "c", "d", "e", "f", "g"],
+            "treated_units": ["actual"],
+        }
+        treatment_time = pd.Timestamp("2020-01-01")
+        if name == "InterruptedTimeSeries":
+            return cp.InterruptedTimeSeries(
+                data, treatment_time, formula="actual ~ 1 + a", model=LinearRegression()
             )
+        if name == "SyntheticControl":
+            return cp.SyntheticControl(
+                data, treatment_time, model=LinearRegression(), **units
+            )
+        return cp.SyntheticDifferenceInDifferences(data, treatment_time, **units)
+
+    @pytest.mark.parametrize(
+        "experiment",
+        [
+            "InterruptedTimeSeries",
+            "SyntheticControl",
+            "SyntheticDifferenceInDifferences",
+        ],
+    )
+    def test_non_datetime_index_with_timestamp_treatment_time(
+        self, sc_data, experiment, mock_pymc_sample
+    ):
+        """A string time axis plus a Timestamp treatment time explains itself.
+
+        Checked on all three classes, since the slip was copy-pasted into each
+        of them rather than living in one shared place.
+        """
+        as_text = sc_data.copy()
+        # Zero-padded so the string index stays sorted. Plain str() would give
+        # "10" < "9", and InterruptedTimeSeries checks monotonicity first, so
+        # it would raise about ordering before reaching the type check.
+        as_text.index = [f"{i:04d}" for i in range(len(as_text))]
+        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
+            self._build(experiment, as_text)
 
 
 class TestUnsortedTimeColumnEndToEnd:
@@ -309,3 +340,48 @@ class TestUnsortedTimeColumnEndToEnd:
                 treated_units=["actual"],
                 time_column="time",
             )
+
+
+class TestSensitivityRefit:
+    """Checks that re-fit an experiment must not replay ``time_column``.
+
+    ``PlaceboInTime`` hands its factory a slice of ``experiment.data``, which
+    is already normalized: the time column has been moved onto the index, so
+    replaying the argument raised ``DataException`` on every fold. The check
+    swallows per-fold failures, so the user saw an inconclusive result rather
+    than an error. The other checks re-fit from the caller's original data and
+    do still need the argument.
+    """
+
+    def _context(self):
+        """Build a pipeline context from a Polars frame using time_column."""
+        n = 200
+        rng = np.random.default_rng(0)
+        frame = pd.DataFrame(
+            {
+                "date": np.arange(n),
+                "trend": np.arange(n) / n,
+                "y": rng.normal(size=n),
+            }
+        )
+        step = cp.steps.EstimateEffect(
+            cp.InterruptedTimeSeries,
+            treatment_time=150,
+            formula="y ~ 1 + trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+        return step.run(PipelineContext(data=pl.from_pandas(frame)))
+
+    def test_config_still_carries_time_column(self):
+        """The recorded config keeps it, since other checks re-fit raw data."""
+        context = self._context()
+        assert context.experiment_config["time_column"] == "date"
+        assert "date" not in context.experiment.data.columns
+
+    def test_placebo_factory_refits_without_time_column(self):
+        """The placebo factory rebuilds from normalized data without raising."""
+        context = self._context()
+        factory = PlaceboInTime(n_folds=2)._get_factory(context)
+        refit = factory(context.experiment.data.iloc[:100], 75)
+        assert isinstance(refit, cp.InterruptedTimeSeries)

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -27,7 +27,7 @@ import pytest
 from sklearn.linear_model import LinearRegression
 
 import causalpy as cp
-from causalpy.custom_exceptions import DataException
+from causalpy.custom_exceptions import BadIndexException, DataException
 from causalpy.input_data import to_pandas_with_time_index
 
 sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
@@ -259,6 +259,30 @@ class TestSyntheticDifferenceInDifferences:
                 70,
                 control_units=["a", "b", "c", "d", "e", "f", "g"],
                 treated_units=["actual"],
+            )
+
+
+class TestTimestampMismatchMessage:
+    """The treatment-time mismatch error states the right requirement.
+
+    The ``treatment_time`` branch read "must be pd.Timestamp" on the path that
+    fires precisely because it already is one. The sibling
+    ``treatment_end_time`` branch had it right, so this was a copy-paste slip.
+    Reachable from any backend, but a ``time_column`` holding strings rather
+    than dates lands here, which is what surfaced it.
+    """
+
+    def test_non_datetime_index_with_timestamp_treatment_time(self, sc_data):
+        """A string time axis plus a Timestamp treatment time explains itself."""
+        as_text = sc_data.copy()
+        as_text.index = as_text.index.astype(str)
+        with pytest.raises(BadIndexException, match="must not be pd.Timestamp"):
+            cp.SyntheticControl(
+                as_text,
+                pd.Timestamp("2020-01-01"),
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                model=LinearRegression(),
             )
 
 

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -1,0 +1,209 @@
+#   Copyright 2022 - 2026 The PyMC Labs Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+"""
+Tests for the explicit time axis on index-based experiments.
+
+InterruptedTimeSeries, SyntheticControl, and SyntheticDifferenceInDifferences
+compare observations against a treatment time. Pandas callers supply that axis
+as the dataframe index. Callers using another dataframe library have no index
+and must name the time column instead.
+"""
+
+import numpy as np
+import pandas as pd
+import polars as pl
+import pytest
+from sklearn.linear_model import LinearRegression
+
+import causalpy as cp
+from causalpy.custom_exceptions import DataException
+from causalpy.input_data import to_pandas_with_time_index
+
+sample_kwargs = {"tune": 20, "draws": 20, "chains": 2, "cores": 2}
+
+
+def to_polars_with_time(data: pd.DataFrame, time_name: str) -> pl.DataFrame:
+    """Move a pandas index into a named column and convert to Polars."""
+    return pl.from_pandas(data.rename_axis(time_name).reset_index())
+
+
+class TestToPandasWithTimeIndex:
+    """Unit tests for the shared helper."""
+
+    def test_pandas_without_time_column_keeps_index(self):
+        """A pandas input without time_column keeps its own index."""
+        frame = pd.DataFrame({"y": [1, 2]}, index=pd.Index([10, 11], name="t"))
+        result = to_pandas_with_time_index(frame)
+        assert result.index.tolist() == [10, 11]
+
+    def test_time_column_becomes_index(self):
+        """time_column moves out of the columns and onto the index."""
+        frame = pd.DataFrame({"t": [10, 11], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [10, 11]
+        assert "t" not in result.columns
+
+    def test_polars_time_column_becomes_index(self):
+        """A Polars input with time_column gets a real time index."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        result = to_pandas_with_time_index(frame, time_column="t")
+        assert result.index.tolist() == [10, 11]
+
+    def test_polars_without_time_column_raises(self):
+        """A non-pandas input without time_column is rejected, not guessed."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            to_pandas_with_time_index(frame)
+
+    def test_missing_time_column_raises(self):
+        """A time_column that is not in the data is rejected."""
+        frame = pl.DataFrame({"t": [10, 11], "y": [1, 2]})
+        with pytest.raises(DataException, match="is not a column of"):
+            to_pandas_with_time_index(frame, time_column="date")
+
+
+class TestInterruptedTimeSeries:
+    """InterruptedTimeSeries with an explicit time column."""
+
+    def test_polars_matches_pandas(self, its_simple_data):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = pd.to_datetime("2015-01-01")
+
+        from_pandas = cp.InterruptedTimeSeries(
+            its_simple_data,
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+        )
+        from_polars = cp.InterruptedTimeSeries(
+            to_polars_with_time(its_simple_data, "date"),
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+        np.testing.assert_allclose(
+            np.asarray(from_polars.post_impact), np.asarray(from_pandas.post_impact)
+        )
+
+    def test_time_column_on_pandas_input(self, its_simple_data):
+        """A pandas caller can use time_column instead of setting the index."""
+        treatment_time = pd.to_datetime("2015-01-01")
+        flat = its_simple_data.rename_axis("date").reset_index()
+
+        result = cp.InterruptedTimeSeries(
+            flat,
+            treatment_time,
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+            time_column="date",
+        )
+        assert isinstance(result.data.index, pd.DatetimeIndex)
+
+    def test_polars_without_time_column_raises(self, its_simple_data):
+        """Without time_column the Polars input is refused, not silently ranked."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.InterruptedTimeSeries(
+                to_polars_with_time(its_simple_data, "date"),
+                pd.to_datetime("2015-01-01"),
+                formula="timeseries ~ 1 + linear_trend",
+                model=LinearRegression(),
+            )
+
+    def test_pandas_input_index_is_not_renamed(self, its_simple_data):
+        """The caller's index name survives construction."""
+        data = its_simple_data.copy()
+        data.index.name = "my_dates"
+        cp.InterruptedTimeSeries(
+            data,
+            pd.to_datetime("2015-01-01"),
+            formula="timeseries ~ 1 + linear_trend",
+            model=LinearRegression(),
+        )
+        assert data.index.name == "my_dates"
+
+
+class TestSyntheticControl:
+    """SyntheticControl with an explicit time column."""
+
+    def test_polars_matches_pandas(self, sc_data, mock_pymc_sample):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = 70
+        control_units = ["a", "b", "c", "d", "e", "f", "g"]
+        treated_units = ["actual"]
+
+        def build(frame, time_column=None):
+            return cp.SyntheticControl(
+                frame,
+                treatment_time,
+                control_units=control_units,
+                treated_units=treated_units,
+                model=LinearRegression(),
+                time_column=time_column,
+            )
+
+        from_pandas = build(sc_data)
+        from_polars = build(to_polars_with_time(sc_data, "time"), time_column="time")
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+
+    def test_polars_without_time_column_raises(self, sc_data):
+        """Without time_column the Polars input is refused."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.SyntheticControl(
+                to_polars_with_time(sc_data, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                model=LinearRegression(),
+            )
+
+
+class TestSyntheticDifferenceInDifferences:
+    """SyntheticDifferenceInDifferences with an explicit time column."""
+
+    def test_polars_matches_pandas(self, sc_data, mock_pymc_sample):
+        """The Polars run with time_column matches the pandas run."""
+        treatment_time = 70
+        control_units = ["a", "b", "c", "d", "e", "f", "g"]
+        treated_units = ["actual"]
+
+        def build(frame, time_column=None):
+            return cp.SyntheticDifferenceInDifferences(
+                frame,
+                treatment_time,
+                control_units=control_units,
+                treated_units=treated_units,
+                time_column=time_column,
+            )
+
+        from_pandas = build(sc_data)
+        from_polars = build(to_polars_with_time(sc_data, "time"), time_column="time")
+
+        assert from_polars.datapre.index.equals(from_pandas.datapre.index)
+        assert from_polars.datapost.index.equals(from_pandas.datapost.index)
+
+    def test_polars_without_time_column_raises(self, sc_data):
+        """Without time_column the Polars input is refused."""
+        with pytest.raises(DataException, match="Pass `time_column`"):
+            cp.SyntheticDifferenceInDifferences(
+                to_polars_with_time(sc_data, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+            )

--- a/causalpy/tests/test_time_column.py
+++ b/causalpy/tests/test_time_column.py
@@ -49,6 +49,21 @@ class TestToPandasWithTimeIndex:
         result = to_pandas_with_time_index(frame)
         assert result.index.tolist() == [10, 11]
 
+    def test_pandas_without_time_column_keeps_unsorted_duplicate_index(self):
+        """Native pandas indexes remain untouched without explicit time_column."""
+        frame = pd.DataFrame({"y": [1, 2, 3]}, index=pd.Index([2, 0, 0], name="t"))
+        result = to_pandas_with_time_index(frame)
+        assert result.index.equals(frame.index)
+
+    def test_pandas_without_time_column_preserves_named_datetime_index(self):
+        """The legacy pandas-index path retains its time-axis type and name."""
+        index = pd.date_range("2020-01-01", periods=2, name="date")
+        frame = pd.DataFrame({"y": [1, 2]}, index=index)
+        result = to_pandas_with_time_index(frame)
+        assert isinstance(result.index, pd.DatetimeIndex)
+        assert result.index.equals(index)
+        assert result.index.name == "date"
+
     def test_time_column_becomes_index(self):
         """time_column moves out of the columns and onto the index."""
         frame = pd.DataFrame({"t": [10, 11], "y": [1, 2]})
@@ -79,6 +94,13 @@ class TestToPandasWithTimeIndex:
         frame = pd.DataFrame(
             {"t": [100, 200], "y": [1, 2]}, index=pd.Index([7, 8], name="old")
         )
+        with pytest.raises(DataException, match="already has a meaningful index"):
+            to_pandas_with_time_index(frame, time_column="t")
+
+    def test_time_column_conflicting_with_named_range_index_raises(self):
+        """A named RangeIndex is meaningful and cannot be overwritten."""
+        frame = pd.DataFrame({"t": [100, 200], "y": [1, 2]})
+        frame.index.name = "row"
         with pytest.raises(DataException, match="already has a meaningful index"):
             to_pandas_with_time_index(frame, time_column="t")
 
@@ -183,13 +205,14 @@ class TestInterruptedTimeSeries:
         """The caller's index name survives construction."""
         data = its_simple_data.copy()
         data.index.name = "my_dates"
-        cp.InterruptedTimeSeries(
+        result = cp.InterruptedTimeSeries(
             data,
             pd.to_datetime("2015-01-01"),
             formula="timeseries ~ 1 + linear_trend",
             model=LinearRegression(),
         )
         assert data.index.name == "my_dates"
+        assert result.data.index.name == "obs_ind"
 
 
 class TestSyntheticControl:
@@ -264,6 +287,37 @@ class TestSyntheticDifferenceInDifferences:
             )
 
 
+class TestNativePandasTimeIndex:
+    """Index-based experiments preserve a pandas time axis without time_column."""
+
+    @pytest.mark.parametrize(
+        "experiment", ["SyntheticControl", "SyntheticDifferenceInDifferences"]
+    )
+    def test_native_datetime_index_is_preserved(
+        self, sc_data, mock_pymc_sample, experiment
+    ):
+        """A named DatetimeIndex remains the native time axis for SC and SDiD."""
+        index = pd.date_range("2020-01-01", periods=len(sc_data), freq="D", name="date")
+        data = sc_data.copy()
+        data.index = index
+        treatment_time = index[70]
+        kwargs = {
+            "control_units": ["a", "b", "c", "d", "e", "f", "g"],
+            "treated_units": ["actual"],
+        }
+        if experiment == "SyntheticControl":
+            kwargs["model"] = LinearRegression()
+        result = getattr(cp, experiment)(data, treatment_time, **kwargs)
+
+        expected_index = index.rename("obs_ind")
+        assert data.index.equals(index)
+        assert data.index.name == "date"
+        assert result.data.index.equals(expected_index)
+        assert result.data.index.name == "obs_ind"
+        assert result.datapre.index.equals(expected_index[:70])
+        assert result.datapost.index.equals(expected_index[70:])
+
+
 class TestTimestampMismatchMessage:
     """The treatment-time mismatch error states the right requirement.
 
@@ -335,6 +389,22 @@ class TestUnsortedTimeColumnEndToEnd:
         with pytest.raises(DataException, match="is not sorted"):
             getattr(cp, experiment)(
                 to_polars_with_time(shuffled, "time"),
+                70,
+                control_units=["a", "b", "c", "d", "e", "f", "g"],
+                treated_units=["actual"],
+                time_column="time",
+            )
+
+    @pytest.mark.parametrize(
+        "experiment", ["SyntheticControl", "SyntheticDifferenceInDifferences"]
+    )
+    def test_duplicate_time_column_raises(self, sc_data, experiment):
+        """A duplicate explicit time axis is refused at both public boundaries."""
+        duplicate = sc_data.rename_axis("time").reset_index()
+        duplicate.loc[1, "time"] = duplicate.loc[0, "time"]
+        with pytest.raises(DataException, match="duplicate values"):
+            getattr(cp, experiment)(
+                pl.from_pandas(duplicate),
                 70,
                 control_units=["a", "b", "c", "d", "e", "f", "g"],
                 treated_units=["actual"],


### PR DESCRIPTION
## Summary
This combines the reviewed dataframe-boundary work from @anevolbap's #1088 and #1089 on the current integration head, preserving their authored commits and adding focused integration regressions. The original #1088 and #1089 should be closed as superseded rather than merged.

All nine column-based experiments accept Polars input and retain a positional `obs_ind` coordinate (`0..n-1`) on owned pandas frames, including both `InstrumentalVariable` inputs. The three index-based experiments retain their pandas-index workflow and accept index-less Polars input via `time_column`; an explicit time column is rejected when it collides with a named or datetime index, or contains duplicate or out-of-order values. `PlaceboInTime` removes `time_column` only while refitting normalized data.

## Evidence
`/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-930-narwhals python -m pytest causalpy/tests/test_dataframe_backends.py causalpy/tests/test_time_column.py --no-cov` → 46 passed, 31 warnings.

`/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-930-narwhals python -m pytest causalpy/tests/test_input_data.py --no-cov` → 13 passed.

`/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-930-narwhals prek run --files` on all 16 changed paths → all applicable hooks passed.

## Maintainer decisions not taken unilaterally
None. This follows the settled #930 contract: only explicit `time_column` axes receive the new duplicate/order validation; the native pandas-index path remains unchanged.

## Release notes needed
CausalPy experiment constructors now accept eager Narwhals-supported dataframe inputs, including Polars and PyArrow-backed data, while outputs remain pandas-backed. Pandas inputs are copied before CausalPy normalizes the internal `obs_ind` index, so passing a frame no longer mutates the caller's `data.index.name`. For InterruptedTimeSeries, SyntheticControl, and SyntheticDifferenceInDifferences, use `time_column` with index-less inputs; duplicate or out-of-order explicit time axes now raise instead of allowing SyntheticControl or SyntheticDifferenceInDifferences to silently scramble time order. Index-less inputs receive a positional `obs_ind` coordinate (`0..n-1`).

Closes #930