### PR TITLE
release: set version to 1.0.0 and drop the unused tidydraws pin

### DIFF
--- a/causalpy/version.py
+++ b/causalpy/version.py
@@ -13,4 +13,4 @@
 #   limitations under the License.
 """CausalPy Version."""
 
-__version__ = "0.9.0"
+__version__ = "1.0.0"

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -188,6 +188,4 @@ See also the [runtime notes in the README](https://github.com/pymc-labs/CausalPy
 
 ### Version
 
-This release is intended to be **1.0.0** (the migration is
-backwards-incompatible, so the major version increments). The version is
-single-sourced from `causalpy/version.py`.
+This release is **1.0.0**: the migration is backwards-incompatible, so the major version increments. The version is single-sourced from `causalpy/version.py`, and `pyproject.toml` reads it dynamically, so `causalpy.__version__` and the installed distribution metadata cannot drift apart.

--- a/environment.yml
+++ b/environment.yml
@@ -48,4 +48,3 @@ dependencies:
   - pip:
       - marimo[mcp]
       - pymc-forecast[extras]<0.3,>=0.2
-      - tidydraws==0.4.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,6 @@ dependencies = [
     "scipy",
     "seaborn>=0.11.2",
     "statsmodels",
-    "tidydraws==0.4.3",
     "xarray>=v2022.11.0",
     "pymc-extras>=0.3.0",
 ]
@@ -145,7 +144,6 @@ channels = ["conda-forge"]
 # pymc-forecast is PyPI-only (not on conda-forge): route it to the pip
 # section of the generated environment.yml.
 [tool.pyproject2conda.dependencies]
-tidydraws = { pip = true }
 pymc-forecast = { pip = true }
 
 [project.urls]


### PR DESCRIPTION
Part of #1048, coordinator-owned release prep. This is the last non-behavioural change before the baseline candidate is frozen.

## Version

Sets `causalpy/version.py` to `1.0.0`. `pyproject.toml` reads it dynamically (#155), so `causalpy.__version__` and the installed distribution metadata cannot drift. Verified in a clean editable install: runtime `1.0.0`, `importlib.metadata` `1.0.0`. The release-notes version section now states 1.0.0 as decided rather than intended.

## Unused dependency removed

#1135 added both `plotnine>=0.15.7` and `tidydraws==0.4.3` to the runtime dependencies. Nothing under `causalpy/` imports `tidydraws` — the only new plotting import is `from plotnine import ...` in `causalpy/experiments/regression_discontinuity.py` — and it was declared as an exact pin, so shipping it would force every user to install a pinned package the library never loads. Removed it, along with its `pyproject2conda` pip routing. `plotnine` stays. `environment.yml` was regenerated by the `pyproject2conda-yaml` prek hook, not hand-edited. When a later step in #988 actually consumes tidydraws it should come back with a range rather than an exact pin.

## Validation

`prek run --files pyproject.toml environment.yml causalpy/version.py docs/source/release_notes.md` passes, including the environment sync hook after regeneration. Full CI runs here.

## Next, after this merges

Re-pin the #1048 schema-v2 baseline candidate to this head, run the four-capture campaign on a dedicated host, attach the report to #1048, then open the transition-to-`main` PR once the maintainer approves the branch.