### PR TITLE
migration: isolate the PyTensor compile cache per baseline capture

### DIFF
--- a/scripts/migration_baseline/README.md
+++ b/scripts/migration_baseline/README.md
@@ -58,7 +58,7 @@ The protocol is not runnable on a small shared CI container or agent sandbox; it
 - **Memory:** at least 8 GB of RAM available to the run. The serialized fixtures are tiny — 24 and 20 rows — so the posteriors themselves are megabytes; the requirement is set by solving and building two full scientific stacks and by PyTensor's C/numba compilation, not by the draws.
 - **CPU:** at least 4 cores. Sampling does not use them: `cores=1` is a registered protocol constant (see the runtime protocol above), so the four chains of each model run serially and more cores do not shorten a capture. They are for provisioning the two prefixes and compiling, and for headroom. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
 - **Wall time:** budget hours end to end and schedule it as one uninterrupted job. Sampling itself is the smaller part: 32 serial chain runs (4 captures × 2 models × 4 chains of 1,000 tune + 1,000 draws at `target_accept=0.95`) over small fixtures. The bulk of the wall time is creating the two prefixes and cold-compiling each stack.
-- **Isolation:** a clean host with no other memory-hungry work. The command block below points `PYTENSOR_FLAGS=compiledir=...` at a per-prefix directory so a PyTensor 2 and a PyTensor 3 stack never share a compile cache; the harness does not record or validate `compiledir`, so this one is on the coordinator.
+- **Isolation:** a clean host with no other memory-hungry work, and **one PyTensor compile cache per capture**. The command block below points `PYTENSOR_FLAGS=compiledir=...` at a directory unique to each of the four captures. Give every capture its own, not one per prefix and never one shared by all four: two captures of the same stack that share a compiledir compile the first graph cold and link the second from cache, and on the Synthetic Control graph that reproducibly changes the result at floating-point ulps, which fails the within-stack repeatability gate even though the protocol, seed, fixtures and runtime are identical. This is a property of compiled-cache reuse, not of CausalPy: the same cold-versus-warm difference reproduces in raw PyMC with a Dirichlet plus HalfNormal graph and no CausalPy import (`beta` max delta about 5e-13), it is unaffected by `PYTHONHASHSEED`, and independent fresh compiledirs are byte-identical across hash seeds. The harness neither records nor validates `compiledir`, so this one is on the coordinator.
 
 The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `ed425ae2e6c884256f7e3f12beba54d9184d021d` and install it into its own editable-install prefix. Do not use the harness checkout (`MIGRATION_ROOT`) as `PYMC6_ROOT`: its `HEAD` intentionally differs from the migration candidate, so `capture` would reject it.
 
@@ -76,27 +76,27 @@ PYMC5_ROOT="$WORKTREES/CausalPy-1048-pymc5"
 PYMC5_PREFIX="$WORKTREES/.mamba/CausalPy-1048-pymc5"
 PYMC6_ROOT="$WORKTREES/CausalPy-1048-pymc6"
 PYMC6_PREFIX="$WORKTREES/.mamba/CausalPy-1048-pymc6"
-PYMC5_FLAGS="compiledir=$PYMC5_PREFIX/.pytensor"
-PYMC6_FLAGS="compiledir=$PYMC6_PREFIX/.pytensor"
 BATCH_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
 EVIDENCE_ROOT="$WORKTREES/migration-baseline-v2-${BATCH_ID}"
+CACHE_ROOT="$WORKTREES/.pytensor-baseline-${BATCH_ID}"
 HARNESS="$MIGRATION_ROOT/scripts/migration_baseline/harness.py"
 
 mkdir "$EVIDENCE_ROOT"
+mkdir -p "$CACHE_ROOT"/ref1 "$CACHE_ROOT"/ref2 "$CACHE_ROOT"/cand1 "$CACHE_ROOT"/cand2
 
-PYTENSOR_FLAGS="$PYMC5_FLAGS" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/ref1" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-1.json"
-PYTENSOR_FLAGS="$PYMC5_FLAGS" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/ref2" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-2.json"
-PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-1.json"
-PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand2" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-2.json"
-PYTENSOR_FLAGS="$PYMC6_FLAGS" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
+PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
   --reference-first "$EVIDENCE_ROOT/pymc5-run-1.json" \
   --reference-second "$EVIDENCE_ROOT/pymc5-run-2.json" \
   --candidate-first "$EVIDENCE_ROOT/pymc6-run-1.json" \


### PR DESCRIPTION
Part of #1048. Documentation and coordinator procedure only; `harness.py` and both pins are untouched.

## What this fixes

Running the schema-v2 campaign at the re-pinned candidate failed exactly one gate: within-stack repeatability on PyMC 6. Eleven of nineteen metrics mismatched between two identical candidate captures, and all eleven were Synthetic Control — the eight post-treatment `counterfactual_mu` values, `draw_wise_r2`, `post_average_impact` and `post_cumulative_impact`. PyMC 5 was 19/19 identical, and every cross-stack gate passed.

The cause is PyTensor compile-cache reuse, not CausalPy and not the migration. When two captures of the same stack share one `compiledir`, the first compiles the graph cold and the second links it from cache, and on this graph that changes results at floating-point ulps. Evidence gathered while root-causing it:

- The same cold-versus-warm difference reproduces in **raw PyMC** with a Dirichlet plus HalfNormal/Normal graph and **no CausalPy import** (`beta` max delta about 5e-13, post-`mu` about 2e-13).
- It is **not** hash-order dependent: independent fresh compiledirs at `PYTHONHASHSEED` 0, 1 and 8675309 were byte-identical on donor order, resolved prior, `beta` and post-`mu`.
- It is **not** the #1106 data-scaled sigma prior: `auto_scale_sigma=False` with the legacy `HalfNormal(1)` shows the same mismatch.
- Donor column order is preserved through the dataframe-input normalisation, including a non-identity caller order, so #1131 is not implicated either.
- An initially empty *shared* compiledir reproduces it for the 0→0, 0→1 and 1→0 process orderings.

## The change

The coordinator command block now derives `CACHE_ROOT` per batch and gives each of the four captures its own `compiledir` (`ref1`, `ref2`, `cand1`, `cand2`) instead of one directory per prefix. The isolation bullet in the host requirements explains why, and records that this is the coordinators responsibility because the harness neither records nor validates `compiledir`.

With per-capture caches the campaign passes all eight gates, both stacks 19/19 repeatable. The evidence is attached to #1048.

## Validation

`pytest causalpy/tests/test_migration_baseline_harness.py` — 38 passed, so the documented-pin consistency guards still hold. `prek run --files scripts/migration_baseline/README.md` passes.