### PR TITLE
ci: cache the PyTensor compile cache between runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,19 +117,102 @@ jobs:
         # --no-deps so pip does not pull pip-built pymc/pytensor on top of the
         # conda-forge ones. Runtime deps come from environment.yml.
         run: pip install --no-deps -e .
-      - name: Cache the PyTensor compile cache
-        # Every job currently starts with an empty ~/.pytensor and recompiles the
-        # C code for each model graph. Locally that is 307s of a 649s cold run.
-        # The compiledir name already embeds OS, Python and PyTensor version, so
-        # a restored cache for a different leg lands in its own subdirectory.
-        # run_id makes each run save a fresh entry; restore-keys picks the most
-        # recent one for this leg.
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          path: ~/.pytensor
-          key: pytensor-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-${{ hashFiles('environment.yml') }}-${{ github.run_id }}
-          restore-keys: |
-            pytensor-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-${{ hashFiles('environment.yml') }}-
+      - name: Fingerprint the resolved PyTensor C-cache runtime
+        id: pytensor-c-cache-fingerprint
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import platform
+          import shutil
+          import subprocess
+          import sys
+          from pathlib import Path
+
+          import numpy as np
+          import pandas as pd
+          import pymc
+          import pytensor
+          from pytensor.link.c.cmodule import GCC_compiler
+
+          cxx = pytensor.config.cxx
+          if not cxx:
+              raise RuntimeError("PyTensor C cache requires a configured C++ compiler")
+          compiler = Path(shutil.which(cxx) or cxx).resolve(strict=True)
+          compiler_version = subprocess.run(
+              [compiler, "--version"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout
+          with compiler.open("rb") as source:
+              compiler_sha256 = hashlib.file_digest(source, "sha256").hexdigest()
+          packages = json.loads(
+              subprocess.run(
+                  ["micromamba", "list", "--json"],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              ).stdout
+          )
+          runtime = {
+              "compiler": {
+                  "path": str(compiler),
+                  "sha256": compiler_sha256,
+                  "version": compiler_version,
+              },
+              "environment_flags": {
+                  name: os.environ.get(name, "")
+                  for name in ("CPPFLAGS", "CXXFLAGS", "LDFLAGS")
+              },
+              "packages": sorted(
+                  (
+                      {
+                          "build": package.get(
+                              "build_string", package.get("build", "")
+                          ),
+                          "channel": package.get("channel", ""),
+                          "name": package["name"],
+                          "version": package["version"],
+                      }
+                      for package in packages
+                  ),
+                  key=lambda package: (
+                      package["name"],
+                      package["version"],
+                      package["build"],
+                      package["channel"],
+                  ),
+              ),
+              "platform": {
+                  "machine": platform.machine(),
+                  "platform": platform.platform(),
+                  "python_cache_tag": sys.implementation.cache_tag,
+                  "python_version": sys.version,
+              },
+              "pytensor": {
+                  "blas_ldflags": pytensor.config.blas__ldflags,
+                  "cxx": cxx,
+                  "cxxflags": pytensor.config.gcc__cxxflags,
+                  "effective_compile_args": GCC_compiler.compile_args(),
+                  "gcc_version": pytensor.config.gcc_version_str,
+                  "config_hash": pytensor.config.get_config_hash(),
+                  "version": pytensor.__version__,
+              },
+              "versions": {
+                  "numpy": np.__version__,
+                  "pandas": pd.__version__,
+                  "pymc": pymc.__version__,
+              },
+          }
+          canonical = json.dumps(runtime, sort_keys=True, separators=(",", ":"))
+          print(json.dumps(runtime, indent=2, sort_keys=True))
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+              output.write(
+                  f"digest={hashlib.sha256(canonical.encode()).hexdigest()}\n"
+              )
+          PY
       - name: Show environment
         run: |
           micromamba list
@@ -167,21 +250,35 @@ jobs:
       - name: Run extra tests
         run: pytest docs/source/.codespell/test_notebook_to_markdown.py --no-cov
       - name: Run statistical correctness tests
-        run: pytest -o addopts='' -m correctness --cov=causalpy --cov-report= --cov-fail-under=0 --no-cov-on-fail
+        # CI restores a warm C cache only after these exact reproducibility tests; the manual migration baseline keeps a cold compiledir per capture for its exact raw-draw gate.
+        env:
+          PYTENSOR_FLAGS: base_compiledir=${{ runner.temp }}/pytensor-correctness
+        run: |
+          python -c "import pytensor; print('base_compiledir=', pytensor.config.base_compiledir); print('compiledir=', pytensor.config.compiledir)"
+          pytest -o addopts='' -m correctness --cov=causalpy --cov-report= --cov-fail-under=0 --no-cov-on-fail
+      - name: Restore the PyTensor C-module cache
+        id: pytensor-cmodules-cache
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pytensor/compiledir_*
+          key: >-
+            pytensor-cmodules-v1-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-env${{ hashFiles('environment.yml') }}-src${{ hashFiles('causalpy/**/*.py', 'pyproject.toml') }}-runtime${{ steps.pytensor-c-cache-fingerprint.outputs.digest }}
+      - name: Discard a non-exact PyTensor C-module cache restore
+        if: steps.pytensor-cmodules-cache.outputs.cache-hit != 'true'
+        run: rm -rf ~/.pytensor/compiledir_*
       - name: Run tests
         run: pytest --cov-append --cov-report=xml --no-cov-on-fail
+      - name: Save the PyTensor C-module cache
+        if: steps.pytensor-cmodules-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pytensor/compiledir_*
+          key: >-
+            pytensor-cmodules-v1-${{ runner.os }}-${{ runner.arch }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-env${{ hashFiles('environment.yml') }}-src${{ hashFiles('causalpy/**/*.py', 'pyproject.toml') }}-runtime${{ steps.pytensor-c-cache-fingerprint.outputs.digest }}
       - name: Check codespell for notebooks
         run: |
           python ./docs/source/.codespell/notebook_to_markdown.py --tempdir tmp_markdown
           codespell
-      - name: Report the PyTensor compile cache size
-        # TEMPORARY (issue #657 measurement): drop before review.
-        if: always()
-        run: |
-          du -sh ~/.pytensor || true
-          du -sh ~/.pytensor/* || true
-          python -c "import pytensor; print('active compiledir:', pytensor.config.compiledir)" || true
-          uname -r
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,11 @@ jobs:
       - name: Report the PyTensor compile cache size
         # TEMPORARY (issue #657 measurement): drop before review.
         if: always()
-        run: du -sh ~/.pytensor || true
+        run: |
+          du -sh ~/.pytensor || true
+          du -sh ~/.pytensor/* || true
+          python -c "import pytensor; print('active compiledir:', pytensor.config.compiledir)" || true
+          uname -r
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,19 @@ jobs:
         # --no-deps so pip does not pull pip-built pymc/pytensor on top of the
         # conda-forge ones. Runtime deps come from environment.yml.
         run: pip install --no-deps -e .
+      - name: Cache the PyTensor compile cache
+        # Every job currently starts with an empty ~/.pytensor and recompiles the
+        # C code for each model graph. Locally that is 307s of a 649s cold run.
+        # The compiledir name already embeds OS, Python and PyTensor version, so
+        # a restored cache for a different leg lands in its own subdirectory.
+        # run_id makes each run save a fresh entry; restore-keys picks the most
+        # recent one for this leg.
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.pytensor
+          key: pytensor-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-${{ hashFiles('environment.yml') }}-${{ github.run_id }}
+          restore-keys: |
+            pytensor-${{ runner.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}-${{ hashFiles('environment.yml') }}-
       - name: Show environment
         run: |
           micromamba list
@@ -161,6 +174,10 @@ jobs:
         run: |
           python ./docs/source/.codespell/notebook_to_markdown.py --tempdir tmp_markdown
           codespell
+      - name: Report the PyTensor compile cache size
+        # TEMPORARY (issue #657 measurement): drop before review.
+        if: always()
+        run: du -sh ~/.pytensor || true
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/scripts/migration_baseline/README.md
+++ b/scripts/migration_baseline/README.md
@@ -58,7 +58,8 @@ The protocol is not runnable on a small shared CI container or agent sandbox; it
 - **Memory:** at least 8 GB of RAM available to the run. The serialized fixtures are tiny — 24 and 20 rows — so the posteriors themselves are megabytes; the requirement is set by solving and building two full scientific stacks and by PyTensor's C/numba compilation, not by the draws.
 - **CPU:** at least 4 cores. Sampling does not use them: `cores=1` is a registered protocol constant (see the runtime protocol above), so the four chains of each model run serially and more cores do not shorten a capture. They are for provisioning the two prefixes and compiling, and for headroom. Do not run the captures concurrently — each is an independent process and the two stacks must not contend for memory.
 - **Wall time:** budget hours end to end and schedule it as one uninterrupted job. Sampling itself is the smaller part: 32 serial chain runs (4 captures × 2 models × 4 chains of 1,000 tune + 1,000 draws at `target_accept=0.95`) over small fixtures. The bulk of the wall time is creating the two prefixes and cold-compiling each stack.
-- **Isolation:** a clean host with no other memory-hungry work, and **one PyTensor compile cache per capture**. The command block below points `PYTENSOR_FLAGS=compiledir=...` at a directory unique to each of the four captures. Give every capture its own, not one per prefix and never one shared by all four: two captures of the same stack that share a compiledir compile the first graph cold and link the second from cache, and on the Synthetic Control graph that reproducibly changes the result at floating-point ulps, which fails the within-stack repeatability gate even though the protocol, seed, fixtures and runtime are identical. This is a property of compiled-cache reuse, not of CausalPy: the same cold-versus-warm difference reproduces in raw PyMC with a Dirichlet plus HalfNormal graph and no CausalPy import (`beta` max delta about 5e-13), it is unaffected by `PYTHONHASHSEED`, and independent fresh compiledirs are byte-identical across hash seeds. The harness neither records nor validates `compiledir`, so this one is on the coordinator.
+- **Isolation:** a clean host with no other memory-hungry work, and **one PyTensor cache root per capture**. The command block below points `PYTENSOR_FLAGS=base_compiledir=...` at a directory unique to each of the four captures, isolating both C modules and the Numba cache. Give every capture its own, not one per prefix and never one shared by all four: two captures of the same stack that share a compiledir compile the first graph cold and link the second from cache, and on the Synthetic Control graph that reproducibly changes the result at floating-point ulps, which fails the within-stack repeatability gate even though the protocol, seed, fixtures and runtime are identical. This is a property of compiled-cache reuse, not of CausalPy: the same cold-versus-warm difference reproduces in raw PyMC with a Dirichlet plus HalfNormal graph and no CausalPy import (`beta` max delta about 5e-13), it is unaffected by `PYTHONHASHSEED`, and independent fresh compiledirs are byte-identical across hash seeds. The harness neither records nor validates `compiledir`, so this one is on the coordinator.
+- **CI distinction:** CI reuses a warm, scoped PyTensor C-module cache only after its exact correctness lane; it never supplies a cache to this manual protocol, whose four captures deliberately use isolated cache roots to validate exact raw-draw repeatability.
 
 The coordinator must provision `PYMC6_ROOT` as a separate clean detached worktree at `ed425ae2e6c884256f7e3f12beba54d9184d021d` and install it into its own editable-install prefix. Do not use the harness checkout (`MIGRATION_ROOT`) as `PYMC6_ROOT`: its `HEAD` intentionally differs from the migration candidate, so `capture` would reject it.
 
@@ -84,19 +85,19 @@ HARNESS="$MIGRATION_ROOT/scripts/migration_baseline/harness.py"
 mkdir "$EVIDENCE_ROOT"
 mkdir -p "$CACHE_ROOT"/ref1 "$CACHE_ROOT"/ref2 "$CACHE_ROOT"/cand1 "$CACHE_ROOT"/cand2
 
-PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/ref1" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="base_compiledir=$CACHE_ROOT/ref1" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-1.json"
-PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/ref2" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="base_compiledir=$CACHE_ROOT/ref2" "$MAMBA" run -p "$PYMC5_PREFIX" python "$HARNESS" capture \
   --stack pymc5 --capture-role reference_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC5_ROOT" --output "$EVIDENCE_ROOT/pymc5-run-2.json"
-PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="base_compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_first --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-1.json"
-PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand2" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
+PYTENSOR_FLAGS="base_compiledir=$CACHE_ROOT/cand2" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" capture \
   --stack pymc6 --capture-role candidate_second --batch-id "$BATCH_ID" \
   --repo-root "$PYMC6_ROOT" --output "$EVIDENCE_ROOT/pymc6-run-2.json"
-PYTENSOR_FLAGS="compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
+PYTENSOR_FLAGS="base_compiledir=$CACHE_ROOT/cand1" "$MAMBA" run -p "$PYMC6_PREFIX" python "$HARNESS" compare \
   --reference-first "$EVIDENCE_ROOT/pymc5-run-1.json" \
   --reference-second "$EVIDENCE_ROOT/pymc5-run-2.json" \
   --candidate-first "$EVIDENCE_ROOT/pymc6-run-1.json" \


### PR DESCRIPTION
Refs #657.

## Why

The original experiment established that a warmed PyTensor C cache can save material CI time: on Python 3.12/pandas 3.x, doctests fell from 55s to 20s and the ordinary test step from 854s to 524s between its first and second run. It was not mergeable as written.

## What changed

- Cache only `~/.pytensor/compiledir_*`, never the whole `~/.pytensor` tree. This excludes PyTensor's separate Numba cache, whose source stamp is not safe to carry across revisions.
- Build a stable exact cache key from the actual post-solve package manifest plus Python/platform, PyTensor/PyMC/NumPy/pandas, PyTensor configuration and effective compile arguments, compiler path/full version/binary digest, environment flags, declared environment, and CausalPy source.
- Split cache restore from save. Any miss or prefix match is deleted before ordinary tests; only an exact primary-key hit is used, and a successful miss is saved under that exact key. This removes run-ID churn and prefix restoration.
- Run the exact real-MCMC `correctness` lane first with its own fresh `base_compiledir`, which isolates both C and Numba caches. Restore the scoped warm C cache only afterward for the ordinary suite.

The original compiledir-name claim was false: PyTensor's default compiledir names include platform, processor and Python version, but not PyTensor, NumPy or compiler versions. The original global cache also included `~/.pytensor/numba`, created a new run-ID key every run, accepted stale prefix restores, and exposed the exact correctness lane to a restored cache.

## Migration baseline

The four-capture migration-baseline campaign is manual, not a GitHub Actions workflow, so this CI cache does not run it or alter its evidence. Its README now gives each capture a distinct `base_compiledir`, isolating both C and Numba caches because same-stack raw draws must remain exactly repeatable.

## Validation

- `prek run --files .github/workflows/ci.yml scripts/migration_baseline/README.md`
- `prek run --all-files`
- Local PyTensor smoke checks for the resolved compiler/config fingerprint and for C-and-Numba `base_compiledir` isolation.

Fresh CI on this rebased head is required before merge.
