### PR TITLE
Clarify PyMC 6 dependency ranges

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -53,8 +53,8 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
-   # Install the unpublished PyMC-6-compatible marketing branch first. Its
-   # metadata selects the matching PyMC, PyTensor, and pymc-extras versions.
+   # Install the docs-only PyMC-Marketing transition dependencies first.
+   # docs/requirements.txt pins its immutable source commit and dependency constraints.
    - requirements: docs/requirements.txt
    - method: pip
      path: .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ See the [python-environment skill](.agents/skills/python-environment/SKILL.md) f
 - If `$CONDA_EXE run -n CausalPy ...` fails because the named env cannot be resolved, inspect `$CONDA_EXE env list` and retry with `$CONDA_EXE run -p <full-prefix> <command>`.
 - In git worktrees, prefer reusing an existing env. Because the repo uses editable installs, rerun `make setup` in the current worktree only when that checkout has not been installed into the env yet or when dependencies changed.
 
-- Dependencies live in `pyproject.toml`; `environment.yml` is generated from it by a prek hook (do not edit by hand). Optional: `pymc-marketing` is in the `docs` extra only.
+- Dependencies live in `pyproject.toml`; `environment.yml` is generated from it by a prek hook (do not edit by hand). The docs-only PyMC-Marketing transition snapshot is pinned separately in `docs/requirements.txt`.
 - **Development**: The supported setup is the conda env (`environment.yml`). `pip install -e .[dev]` works but does not include conda-only tooling (e.g. `make`, `pymc-bart`, `marimo`); do not suggest pip-only dev as equivalent.
 
 ## Testing

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 # This VCS dependency is intentionally docs-only: PyPI rejects direct VCS references in published package metadata.
-# d710dc0 is the immutable merge commit from pymc-marketing #2677, merged into upstream main; it remains reachable after the v1.0.0 ref was deleted.
+# d710dc0 is the immutable PyMC-Marketing transition commit used by the documentation notebooks.
 pymc-marketing @ git+https://github.com/pymc-labs/pymc-marketing.git@d710dc035b654b96d6abab2087df4f577beb66f1
-# Match the upstream dependency bound explicitly; the expected resolver selection is pymc-extras 0.12.1.
+# Match the pinned commit's declared pymc-extras interval, which permits compatible 0.11.x and 0.12.x releases.
 pymc-extras>=0.11,<0.13

--- a/docs/source/release_notes.md
+++ b/docs/source/release_notes.md
@@ -8,33 +8,19 @@ page is the curated, human-written companion to it.
 
 ## 1.0.0 (unreleased) — PyMC 6 migration
 
-This is a **major, breaking release**. It migrates CausalPy off the PyMC 5
-stack and onto PyMC 6 / PyTensor 3 / ArviZ 1.x (compatible with
-`pymc-marketing` v1.0.0). Read the breaking-change section below before
-upgrading; several public signatures and default behaviours changed.
+This is a **major, breaking release**. It migrates CausalPy off the PyMC 5 stack and onto PyMC 6 / PyTensor 3 / ArviZ 1.x; the docs-only PyMC-Marketing transition snapshot is pinned separately in `docs/requirements.txt`. Read the breaking-change section below before upgrading; several public signatures and default behaviours changed.
 
-### Supported versions and dependencies
+### Declared dependency ranges
 
-- **Python `>=3.12`** (raised from 3.11). The dependency stack currently
-  resolves on Python 3.12–3.14 (PyTensor caps Python `<3.15`). CI exercises
-  3.12 and 3.14.
-- **pymc `>=6.0.1,<7`** (previously the PyMC 5 series). The exact patch the
-  resolver selects depends on what else is installed — for example
-  `pymc-marketing` v1.0.0 caps `pymc<6.1`, so environments that include it
-  resolve to an older 6.x. Do not rely on a specific patch version.
-- **pytensor `>=3,<4`**.
-- **arviz `>=1.1,<2`** — the ArviZ 0.x → 1.x jump. `arviz.InferenceData` is no
-  longer available as a usable class — accessing it emits a `MigrationWarning`
-  (`"arviz.InferenceData is no longer available on the arviz package"`) — and
-  ArviZ now uses xarray's `DataTree` for the same role.
-- **pandas `>=2.3,<4`** — pandas 2.3 through the 3.x line are supported and are
-  exercised as separate CI legs.
-- **pymc-extras `>=0.3.0`**.
-- **numba is now effectively a hard (transitive) dependency.** It is
-  PyTensor 3's default compilation backend and is pulled in through the
-  PyTensor/PyMC dependency chain. See [Runtime characteristics](#runtime-characteristics).
+- **Python `>=3.12`** (raised from 3.11). The dependency stack currently resolves on Python 3.12–3.14 (PyTensor caps Python `<3.15`). CI exercises 3.12 and 3.14.
+- **pymc `>=6.0.1,<7`** (previously the PyMC 5 series). PyMC metadata determines its compatible PyTensor patch range. The pinned docs-only PyMC-Marketing transition snapshot narrows only a combined docs installation to `pymc>=6.0.1,<6.1`; base installs that omit `docs/requirements.txt` can select later compatible PyMC 6 minors.
+- **pytensor `>=3,<4`**. Its selected minor and patch version are paired by PyMC metadata.
+- **arviz `>=1.1,<2`** — the ArviZ 0.x → 1.x jump. `arviz.InferenceData` is no longer available as a usable class — accessing it emits a `MigrationWarning` (`"arviz.InferenceData is no longer available on the arviz package"`) — and ArviZ now uses xarray's `DataTree` for the same role.
+- **pandas `>=2.3,<4`** — pandas 2.3 through the 3.x line are supported and are exercised as separate CI legs.
+- **pymc-extras `>=0.11`**. This is the first release that declares PyMC 6 support and provides the structural state-space API used by CausalPy.
+- **numba is now effectively a hard (transitive) dependency.** It is PyTensor 3's default compilation backend and is pulled in through the PyTensor/PyMC dependency chain. See [Runtime characteristics](#runtime-characteristics).
 
-These floors are declared in `pyproject.toml`.
+These declared ranges are in `pyproject.toml`.
 
 ### Breaking changes
 

--- a/environment.yml
+++ b/environment.yml
@@ -32,7 +32,7 @@ dependencies:
   - prek
   - pyarrow
   - pymc-bart
-  - pymc-extras>=0.8.0
+  - pymc-extras>=0.11
   - pymc<7,>=6.0.1
   - pytensor<4,>=3
   - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,17 +53,9 @@ dependencies = [
     "patsy",
     "plotnine>=0.15.7",
     "polars",
-    # Floors per the PyMC 6 migration (#1039). Deliberately NOT pymc>=6.1
-    # (pymc-marketing v1.0.0 caps pymc<6.1.0, which would make the docs env
-    # unsolvable) and NOT pytensor>=3.2 (pymc 6.1.0 caps pytensor<3.2).
-    #
-    # Knock-on effect of that cap (#1048 deprecation cleanup): `pymc-extras`
-    # versions below 0.13 emit a `DeprecationWarning` from
-    # `BSplineBasis.infer_shape`'s fgraph path. The fix requires
-    # `pymc-extras>=0.13`, which requires `pymc>=6.1`; `pymc-marketing` v1.0.0
-    # currently caps `pymc<6.1`. Leave the warning visible -- do not add a
-    # warning filter -- until those dependency constraints can be resolved
-    # together.
+    # Keep these public major-version ranges broad. PyMC metadata supplies compatible PyTensor patch-level ranges, so base installs may select newer PyMC/PyTensor minors.
+    # The docs-only PyMC-Marketing transition snapshot in docs/requirements.txt has its own narrower resolver constraints; it does not restrict normal runtime installs.
+    # pymc-extras 0.11 is the first release that declares PyMC 6 support and provides the structural state-space API CausalPy imports.
     "pymc>=6.0.1,<7",
     "pytensor>=3,<4",
     "scikit-learn>=1",
@@ -71,7 +63,7 @@ dependencies = [
     "seaborn>=0.11.2",
     "statsmodels",
     "xarray>=v2022.11.0",
-    "pymc-extras>=0.8.0",
+    "pymc-extras>=0.11",
 ]
 
 # List additional groups of dependencies here (e.g. development dependencies). Users


### PR DESCRIPTION
## Summary
- Replace stale PyMC 6.1/PyTensor and pymc-extras comments with resolver-accurate range rationale.
- Raise the root `pymc-extras` floor to `>=0.11`, the first release that declares PyMC 6 support and exports CausalPy's structural state-space API.
- Keep the public `pymc>=6.0.1,<7` and `pytensor>=3,<4` ranges permissive; PyMC supplies the compatible patch-level PyTensor requirement.
- Keep the PyMC-Marketing transition snapshot docs-only, immutable, and separately constrained; regenerate `environment.yml` through the configured hook.

## Evidence
- Observed prefix: `causalpy=1.0.0`, `pymc=6.2.0`, and `pytensor=3.2.4`; importing `pymc_extras.prior.Prior` and `pymc_extras.statespace.structural` succeeds. The PyMC 6.2.0 installed metadata requires `pytensor>=3.2.2,<3.3`.
- PyPI metadata/source review verified that pymc-extras 0.11 declares `pymc>=6,<7` and exports the structural API CausalPy imports; 0.14.0 is the resolved installed version.
- The immutable docs SHA `d710dc035b654b96d6abab2087df4f577beb66f1` declares `pymc>=6,<6.1`, `pytensor>=3,<4`, and `pymc-extras>=0.11,<0.13`. It is installed only by RTD/docs requirements, not published runtime metadata.
- A clean `pip install --dry-run --ignore-installed --only-binary=:all: '.[docs]' -r docs/requirements.txt` resolved the combined docs stack.

## Validation
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se prek run --files pyproject.toml environment.yml docs/source/release_notes.md` — passed.
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se python -m pytest causalpy/tests/test_pymc_models_compat.py --no-cov` — 6 passed, 1 skipped (optional PyMC-Marketing unavailable).
- `/opt/anaconda3/condabin/mamba run -p /Users/carlostrujillo/Documents/GitHub/_worktrees/.mamba/CausalPy-1028-rd-se python -m pytest --no-cov causalpy/tests/test_integration_its_new_timeseries.py::test_state_space_predict_and_score` — passed.
- Post-rebase direct runtime import and smoke state-space fit/predict/score passed.

## Deliberately not changed
- I did not alter CI path filters because the assignment explicitly prohibits test-behaviour changes.
- I did not clean up an unrelated pyproject2conda policy-comment contradiction outside the PyMC/PyTensor/pymc-extras declaration-and-documentation scope.

## Release notes needed
CausalPy 1.0.0 supports PyMC 6 (`>=6.0.1,<7`) with PyTensor 3 (`>=3,<4`); compatible PyTensor patch releases are selected by PyMC. The optional PyMC Extras integration now requires `pymc-extras>=0.11`, the first release with declared PyMC 6 support and the structural state-space API used by CausalPy.
