### PR TITLE
chore: make mypy a real gate with a per-module allowlist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,6 +251,12 @@ jobs:
                   f"expected pandas {expected}, got {pd.__version__}"
               )
           PY
+      - name: Type check
+        # Runs here rather than in prek because mypy only says anything useful
+        # when the real dependencies are importable, and the pre-commit env has
+        # none of them (issue #1127). Scope and the per-module allowlist that
+        # keeps this green live in [tool.mypy] in pyproject.toml.
+        run: make typecheck
       - name: Run doctests
         # -p causalpy.tests.doctest_sampling loads the plugin that mocks
         # pm.sample for doctests (an autouse fixture in causalpy/tests/conftest.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,10 +252,7 @@ jobs:
               )
           PY
       - name: Type check
-        # Runs here rather than in prek because mypy only says anything useful
-        # when the real dependencies are importable, and the pre-commit env has
-        # none of them (issue #1127). Scope and the per-module allowlist that
-        # keeps this green live in [tool.mypy] in pyproject.toml.
+        # Runs here rather than in prek because mypy only says anything useful when the real dependencies are importable, and the pre-commit env has none of them (issue #1127). Scope and the per-module allowlist that keeps this green live in [tool.mypy] in pyproject.toml.
         run: make typecheck
       - name: Run doctests
         # -p causalpy.tests.doctest_sampling loads the plugin that mocks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,13 +53,10 @@ repos:
     hooks:
       - id: numpydoc-validation
         files: ^causalpy/(?!tests/|data/).*\.py$
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v2.3.0
-    hooks:
-      - id: mypy
-        args: [--ignore-missing-imports]
-        files: ^causalpy/
-        additional_dependencies: [numpy>=1.20, pandas-stubs]
+  # Type checking is not a hook (issue #1127). It ran here against an isolated env holding
+  # only numpy and pandas-stubs, so pymc, pytensor, arviz, patsy and sklearn were not present
+  # to analyse and the hook passed on code that fails a real check. It now runs as
+  # ``make typecheck`` in the project environment, from the test job in ci.yml.
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.25
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,10 +53,7 @@ repos:
     hooks:
       - id: numpydoc-validation
         files: ^causalpy/(?!tests/|data/).*\.py$
-  # Type checking is not a hook (issue #1127). It ran here against an isolated env holding
-  # only numpy and pandas-stubs, so pymc, pytensor, arviz, patsy and sklearn were not present
-  # to analyse and the hook passed on code that fails a real check. It now runs as
-  # ``make typecheck`` in the project environment, from the test job in ci.yml.
+  # Type checking is not a hook (issue #1127). It ran here against an isolated env holding only numpy and pandas-stubs, so pymc, pytensor, arviz, patsy and sklearn were not present to analyse and the hook passed on code that fails a real check. It now runs as ``make typecheck`` in the project environment, from the test job in ci.yml.
   - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.25
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,8 @@ Renamed or deleted how-to pages must keep a **permanent** entry in `rediraffe_re
 
 ## Code quality checks
 
-- **Before committing**: Use `prek run` during iterative edits and run `prek run --all-files` before committing to ensure all checks pass (linting, formatting, type checking)
+- **Before committing**: Use `prek run` during iterative edits and run `prek run --all-files` before committing to ensure all checks pass (linting, formatting)
+- **Type checking**: `mypy` is intentionally **not** in `prek` — it only says anything useful when the project dependencies are importable, and a hook environment does not have them (issue #1127). Run `$CONDA_EXE run -n CausalPy make typecheck`; CI runs the same target from the test job. Scope and the per-module allowlist live in `[tool.mypy]` in `pyproject.toml`.
 - **Patch coverage (milestones, not every commit)**: `make test-patch-cov` is intentionally **not** in `prek` — it runs the full test suite (~90s+) and needs the conda env. Run it at meaningful checkpoints when Python source or tests under `causalpy/` changed, not on every small commit:
   - A PR is ready for review, or you are about to push for CI
   - You finished a large or multi-file task touching production code

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -283,6 +283,14 @@ When adding a new example notebook to the documentation gallery:
   make lint
   ```
 
+- Your code passes type checking. This is deliberately not a pre-commit hook: mypy only says anything useful when the project dependencies are importable, so run it from the project environment.
+
+  ```bash
+  make typecheck
+  ```
+
+  Modules that already fail are listed as `[[tool.mypy.overrides]]` entries in `pyproject.toml`, each disabling only the error codes that module currently produces. New code should not need a new entry. Removing an existing one is a welcome contribution.
+
 ## Building the documentation locally
 
 To build the documentation, run from the **project root**:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ PACKAGE_DIR = causalpy
 # COMMANDS                                                                      #
 #################################################################################
 
-.PHONY: init setup lint check_lint check-exports check-architecture test test-correctness test-patch-cov uml gallery html cleandocs doctest run_notebooks_full help
+.PHONY: init setup lint check_lint typecheck check-exports check-architecture test test-correctness test-patch-cov uml gallery html cleandocs doctest run_notebooks_full help
 
 # Patch coverage must be measured against the branch the PR actually targets.
 # While the 1.0 transition branch exists, work branched from it targets it, not
@@ -51,6 +51,9 @@ lint: ## Run ruff linter and formatter
 check_lint: ## Check code formatting and linting without making changes
 	ruff check .
 	ruff format --diff --check .
+
+typecheck: ## Run mypy over causalpy (scope and per-module allowlist in pyproject.toml)
+	mypy
 
 check-exports: ## Verify public API export and documentation wiring
 	python scripts/check_public_exports.py --check

--- a/environment.yml
+++ b/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - jinja2
   - make
   - matplotlib>=3.5.3
+  - mypy==2.3.0
   - narwhals>=1.13.1
   - nbconvert
   - nbformat

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,10 @@ forecast = [
 ]
 dev = [
     "prek",
+    # Pinned: a type checker that floats turns an untouched branch red whenever
+    # upstream ships new checks. Bump deliberately, with the allowlist in
+    # [tool.mypy] re-measured (issue #1127).
+    "mypy==2.3.0",
     "twine",
     "codespell",
     "nbformat",
@@ -114,7 +118,7 @@ docs = [
     "PyYAML",
     "sphinxext-rediraffe",
 ]
-lint = ["prek", "ruff", "mypy"]
+lint = ["prek", "ruff", "mypy==2.3.0"]
 test = [
     "pytest",
     "pytest-cov",
@@ -223,9 +227,66 @@ exclude_lines = [
     "@(abc\\.)?abstractmethod",
 ]
 
+# Type checking (issue #1127). ``files = "causalpy"`` recurses, so the subpackages are
+# covered; the old ``causalpy/*.py`` glob did not and only reached 16 top-level modules.
+# ``make typecheck`` runs this from the project environment, where the real dependencies
+# are importable, and CI runs the same target. ``ignore_missing_imports`` drops the
+# untyped-third-party noise (pymc, patsy, arviz and friends ship no stubs).
 [tool.mypy]
-files = "causalpy/*.py"
+files = "causalpy"
 exclude = "build|dist|docs|notebooks|tests|setup.py"
+ignore_missing_imports = true
+
+# Allowlist of modules that already fail, so the gate starts green and ratchets down
+# (49 errors in 16 files at the time of writing). Each entry disables only the error
+# codes that module actually produces, so everything else is still checked there.
+# Removing an entry, or a single code from one, is a self-contained follow-up PR.
+[[tool.mypy.overrides]]
+module = "causalpy.experiments.inverse_propensity_weighting"
+disable_error_code = ["arg-type", "assignment", "index", "return-value"]
+
+[[tool.mypy.overrides]]
+module = [
+    "causalpy.experiments.instrumental_variable",
+    "causalpy.experiments.prepostnegd",
+    "causalpy.experiments.regression_discontinuity",
+    "causalpy.experiments.regression_kink",
+    "causalpy.reporting",
+]
+disable_error_code = ["arg-type"]
+
+[[tool.mypy.overrides]]
+module = [
+    "causalpy.experiments.interrupted_time_series",
+    "causalpy.experiments.staggered_did",
+    "causalpy.experiments.synthetic_control",
+    "causalpy.experiments.synthetic_difference_in_differences",
+]
+disable_error_code = ["attr-defined"]
+
+[[tool.mypy.overrides]]
+module = "causalpy.experiments.diff_in_diff"
+disable_error_code = ["arg-type", "attr-defined"]
+
+[[tool.mypy.overrides]]
+module = "causalpy.experiments.panel_regression"
+disable_error_code = ["attr-defined", "index"]
+
+[[tool.mypy.overrides]]
+module = "causalpy.checks.operating_characteristics"
+disable_error_code = ["arg-type", "assignment"]
+
+[[tool.mypy.overrides]]
+module = "causalpy.plot_utils"
+disable_error_code = ["assignment", "attr-defined"]
+
+[[tool.mypy.overrides]]
+module = "causalpy.pymc_models"
+disable_error_code = ["call-overload", "return-value"]
+
+[[tool.mypy.overrides]]
+module = "causalpy._arviz_compat"
+disable_error_code = ["type-var"]
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,11 +236,15 @@ exclude_lines = [
 files = "causalpy"
 exclude = "build|dist|docs|notebooks|tests|setup.py"
 ignore_missing_imports = true
+# Fail if an override below stops matching a real module, so a rename or a deletion
+# cannot leave a stale allowlist entry behind.
+warn_unused_configs = true
 
 # Allowlist of modules that already fail, so the gate starts green and ratchets down
-# (49 errors in 16 files at the time of writing). Each entry disables only the error
-# codes that module actually produces, so everything else is still checked there.
-# Removing an entry, or a single code from one, is a self-contained follow-up PR.
+# (49 errors in 16 files, measured on pymc6_and_pymcmarketing1_migration at 194343ca).
+# Each entry disables only the error codes that module actually produces, so everything
+# else is still checked there. Removing an entry, or a single code from one, is a
+# self-contained follow-up PR.
 [[tool.mypy.overrides]]
 module = "causalpy.experiments.inverse_propensity_weighting"
 disable_error_code = ["arg-type", "assignment", "index", "return-value"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,9 +82,7 @@ forecast = [
 ]
 dev = [
     "prek",
-    # Pinned: a type checker that floats turns an untouched branch red whenever
-    # upstream ships new checks. Bump deliberately, with the allowlist in
-    # [tool.mypy] re-measured (issue #1127).
+    # Pinned: a type checker that floats turns an untouched branch red whenever upstream ships new checks. Bump deliberately, with the allowlist in [tool.mypy] re-measured (issue #1127). TOML cannot share the value, so the same pin appears in the ``lint`` extra below and the two must be bumped together.
     "mypy==2.3.0",
     "twine",
     "codespell",
@@ -118,6 +116,7 @@ docs = [
     "PyYAML",
     "sphinxext-rediraffe",
 ]
+# The mypy pin here must match the one in the ``dev`` extra above; TOML cannot share the value, so bump both together.
 lint = ["prek", "ruff", "mypy==2.3.0"]
 test = [
     "pytest",
@@ -227,24 +226,15 @@ exclude_lines = [
     "@(abc\\.)?abstractmethod",
 ]
 
-# Type checking (issue #1127). ``files = "causalpy"`` recurses, so the subpackages are
-# covered; the old ``causalpy/*.py`` glob did not and only reached 16 top-level modules.
-# ``make typecheck`` runs this from the project environment, where the real dependencies
-# are importable, and CI runs the same target. ``ignore_missing_imports`` drops the
-# untyped-third-party noise (pymc, patsy, arviz and friends ship no stubs).
+# Type checking (issue #1127). ``files = "causalpy"`` recurses, so the subpackages are covered; the old ``causalpy/*.py`` glob did not and only reached the 18 top-level modules. ``make typecheck`` runs this from the project environment, where the real dependencies are importable, and CI runs the same target. ``ignore_missing_imports`` drops the untyped-third-party noise (pymc, patsy, arviz and friends ship no stubs).
 [tool.mypy]
 files = "causalpy"
 exclude = "build|dist|docs|notebooks|tests|setup.py"
 ignore_missing_imports = true
-# Fail if an override below stops matching a real module, so a rename or a deletion
-# cannot leave a stale allowlist entry behind.
+# Report an override below that stops matching a real module, so a rename or a deletion does not leave a stale allowlist entry behind unnoticed. This warns rather than fails: mypy prints ``note: unused section(s)`` and still exits 0, so it surfaces the staleness in the log without turning the gate red on its own.
 warn_unused_configs = true
 
-# Allowlist of modules that already fail, so the gate starts green and ratchets down
-# (49 errors in 16 files, measured on pymc6_and_pymcmarketing1_migration at 194343ca).
-# Each entry disables only the error codes that module actually produces, so everything
-# else is still checked there. Removing an entry, or a single code from one, is a
-# self-contained follow-up PR.
+# Allowlist of modules that already fail, so the gate starts green and ratchets down (49 errors in 16 files, measured on pymc6_and_pymcmarketing1_migration at 194343ca). Each entry disables only the error codes that module actually produces, so everything else is still checked there. Removing an entry, or a single code from one, is a self-contained follow-up PR.
 [[tool.mypy.overrides]]
 module = "causalpy.experiments.inverse_propensity_weighting"
 disable_error_code = ["arg-type", "assignment", "index", "return-value"]


### PR DESCRIPTION
Closes the decision in #1127 by taking the gate option.

## What was wrong

`[tool.mypy]` set `files = "causalpy/*.py"`, which does not recurse, so it reached the 18 top-level modules and nothing under `experiments/`, `checks/`, `steps/`, `data/` or `skills/`. Nothing ran it: no workflow, no Makefile target. The only runner was the pre-commit hook, and that hook's env holds numpy and pandas-stubs only, so pymc, pytensor, arviz, patsy and sklearn are not importable and it passes on code that fails a real check. The two also sat at different mypy versions, the hook pinned at `mirrors-mypy` v2.3.0 and the `lint` extra declaring a bare `mypy`.

## What this does

`files = "causalpy"` recurses, so 54 source files are checked instead of 16. `make typecheck` runs mypy from the project environment, where the dependencies actually resolve, and the test job in ci.yml calls that target so it gates on every matrix leg. The pre-commit hook is removed, leaving one contract instead of two. mypy is pinned at 2.3.0 in `dev` and `lint`, and `environment.yml` is regenerated from that.

A third commit corrects two comments this PR introduced, the module count above and a claim that `warn_unused_configs` fails rather than warns, and unwraps the comment blocks per the AGENTS.md one-paragraph-per-line rule. No behaviour change.

## Why an allowlist

There are 49 errors in 16 files today. Gating on zero would mean fixing all of them first, in four experiment modules that are moving on this branch, and would leave the ~38 already-clean modules unprotected until that lands. Instead each failing module gets a `[[tool.mypy.overrides]]` entry that disables only the error codes it actually produces, so every other code is still checked there. The gate is green on merge, new code is covered immediately, and removing an entry (or one code from one entry) is a self-contained follow-up PR.

The largest entry by far is `inverse_propensity_weighting` at 21 errors, 17 of them `index`. The rest is a long tail of one or two per module.

## Not in this PR

No source files change, so nothing user-visible moves and there is no release note. The 49 errors are not fixed here, only fenced.

Tests stay outside the checked set, as `[tool.mypy] exclude` already had them. Including them would add 73 errors in 19 files, which is its own decision.

Two known limits of a config-level allowlist. `ignore_missing_imports` is global, so an unresolvable first-party import is silenced along with the untyped third parties; the test suite imports every module, so that case fails there instead. And mypy has no `warn_unused_ignores` equivalent for `disable_error_code`, so an entry can outlive the errors it fences. `warn_unused_configs = true` catches only the rename and deletion case, and it warns rather than failing: mypy prints `note: unused section(s)` and still exits 0, so it surfaces a stale entry in the log without turning the gate red on its own.

## Verification

- `mypy` with this config: `Success: no issues found in 54 source files`, under `--python-version 3.12` and `--python-version 3.14`.
- `prek run --all-files`: clean, including the regenerated `environment.yml`.
- `micromamba create --dry-run -c conda-forge python=3.14 mypy==2.3.0` resolves (`py314h518bba1_0`), so the pin does not break the 3.14 leg.

