### PR TITLE
fix: keep plot_ate axes as a list so the panels type-check

### DIFF
--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -669,8 +669,9 @@ class InversePropensityWeighting(BaseExperiment):
         mosaic = """AAAAAA
                     BBBBCC"""
 
-        fig, axs = plt.subplot_mosaic(mosaic, figsize=(20, 13))
-        axs = [axs[k] for k in axs]
+        fig, mosaic_axes = plt.subplot_mosaic(mosaic, figsize=(20, 13))
+        # Keyed by mosaic label; the panels are used positionally from here on.
+        axs = [mosaic_axes[k] for k in mosaic_axes]
         axs[0].axvline(
             0.1, linestyle="--", label="Low Extreme Propensity Scores", color="black"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -236,12 +236,9 @@ warn_unused_configs = true
 
 # Allowlist of modules that already fail, so the gate starts green and ratchets down (49 errors in 16 files, measured on pymc6_and_pymcmarketing1_migration at 194343ca). Each entry disables only the error codes that module actually produces, so everything else is still checked there. Removing an entry, or a single code from one, is a self-contained follow-up PR.
 [[tool.mypy.overrides]]
-module = "causalpy.experiments.inverse_propensity_weighting"
-disable_error_code = ["arg-type", "assignment", "index", "return-value"]
-
-[[tool.mypy.overrides]]
 module = [
     "causalpy.experiments.instrumental_variable",
+    "causalpy.experiments.inverse_propensity_weighting",
     "causalpy.experiments.prepostnegd",
     "causalpy.experiments.regression_discontinuity",
     "causalpy.experiments.regression_kink",


### PR DESCRIPTION
Stacked on #1145. First allowlist entry to shrink.

`plot_ate` called `plt.subplot_mosaic`, which returns `dict[str, Axes]`, then rebound the same name to a list of the panels on the next line. mypy keeps the dict type for the rest of the function, so every positional `axs[0]`, `axs[1]` and `axs[2]` was an `index` error and the declared `tuple[Figure, list[Axes]]` return was a `return-value` error. That single rebinding accounted for 19 of the 49 errors on the base branch.

The mosaic result now keeps its own name and the list takes the old one. Iteration over the mosaic dict is insertion order, A then B then C, exactly as before, so the panels keep their meaning and nothing renders differently.

`inverse_propensity_weighting` drops out of its dedicated `[[tool.mypy.overrides]]` entry and joins the plain `arg-type` group, which is the two remaining errors where `fit` is called with numpy arrays against a `DataArray` annotation. Those are the public-signature question and are left alone here.

Branch total: 49 errors in 16 files becomes 30 in 16.

## Verification

- `mypy` green under `--python-version 3.12` and `3.14`.
- `causalpy/tests/test_ipw_extreme_ps.py` and `test_ipw_get_ate.py`: 39 passed. The first is the #645 regression suite and drives `plot_ate` for every weighting scheme.
- `test_integration_pymc_examples.py::test_inverse_prop` passed; it asserts `isinstance(axs, list)` and that each element is an `Axes`, which is the contract this preserves.

Being stacked on a feature branch, this gets the repo-wide workflows but not the test matrix. That arrives when #1145 merges and this retargets.
