### PR TITLE
fix: clear the mechanical type errors and shrink the allowlist to one open question

### DIFF
--- a/causalpy/_arviz_compat.py
+++ b/causalpy/_arviz_compat.py
@@ -202,7 +202,9 @@ def hdi_bounds(
     ).squeeze(drop=True)
     remaining_dims = set(result.dims) - {"hdi"}
     if remaining_dims:
-        msg = f"Scalar HDI bounds require reduced draws; remaining dims={sorted(remaining_dims)!r}"
+        # Dimension names are Hashable in xarray's typing, so sort them as strings.
+        dim_names = sorted(str(dim) for dim in remaining_dims)
+        msg = f"Scalar HDI bounds require reduced draws; remaining dims={dim_names!r}"
         raise ValueError(msg)
     return float(result.sel(hdi="lower").item()), float(result.sel(hdi="higher").item())
 

--- a/causalpy/checks/operating_characteristics.py
+++ b/causalpy/checks/operating_characteristics.py
@@ -555,7 +555,7 @@ class OperatingCharacteristics:
         )
         ax.yaxis.set_major_formatter(plt.FuncFormatter(lambda value, _: f"{value:.0%}"))
         ax.legend(loc="lower right", fontsize=8, framealpha=0.9, edgecolor="#cbd5e1")
-        figure.tight_layout(rect=[0, 0, 1, 0.97] if has_prior else None)
+        figure.tight_layout(rect=(0, 0, 1, 0.97) if has_prior else None)
         return figure
 
 

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -119,8 +119,7 @@ class DifferenceInDifferences(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
         self.causal_impact: xr.DataArray | float | None
-        # to_pandas returns a copy, so index metadata is normalized on an
-        # owned frame rather than the caller's.
+        # to_pandas returns a copy, so index metadata is normalized on an owned frame rather than the caller's.
         pandas_data = to_pandas(data)
         pandas_data.index.name = "obs_ind"
         self.data = pandas_data
@@ -506,8 +505,7 @@ class DifferenceInDifferences(BaseExperiment):
                     showmedians=False,
                     widths=0.2,
                 )
-                # violinplot types every entry as a single Collection, but the
-                # "bodies" entry is a list of them.
+                # violinplot types every entry as a single Collection, but the "bodies" entry is a list of them.
                 for pc in parts["bodies"]:  # type: ignore[attr-defined]
                     pc.set_facecolor("C0")
                     pc.set_edgecolor("None")

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -506,7 +506,9 @@ class DifferenceInDifferences(BaseExperiment):
                     showmedians=False,
                     widths=0.2,
                 )
-                for pc in parts["bodies"]:
+                # violinplot types every entry as a single Collection, but the
+                # "bodies" entry is a list of them.
+                for pc in parts["bodies"]:  # type: ignore[attr-defined]
                     pc.set_facecolor("C0")
                     pc.set_edgecolor("None")
                     pc.set_alpha(0.5)

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -121,9 +121,9 @@ class DifferenceInDifferences(BaseExperiment):
         self.causal_impact: xr.DataArray | float | None
         # to_pandas returns a copy, so index metadata is normalized on an
         # owned frame rather than the caller's.
-        data = to_pandas(data)
-        data.index.name = "obs_ind"
-        self.data = data
+        pandas_data = to_pandas(data)
+        pandas_data.index.name = "obs_ind"
+        self.data = pandas_data
         self.expt_type = "Difference in Differences"
         self.formula = formula
         self.time_variable_name = time_variable_name

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -166,10 +166,10 @@ class InterruptedTimeSeries(BaseExperiment):
         self.post_design: xr.Dataset
         # to_pandas_with_time_index returns a copy, so index metadata is
         # normalized on an owned frame rather than the caller's.
-        data = to_pandas_with_time_index(data, time_column)
-        data.index.name = "obs_ind"
-        self.data = data
-        self.input_validation(data, treatment_time, treatment_end_time)
+        pandas_data = to_pandas_with_time_index(data, time_column)
+        pandas_data.index.name = "obs_ind"
+        self.data = pandas_data
+        self.input_validation(pandas_data, treatment_time, treatment_end_time)
         self.treatment_time = treatment_time
         self.treatment_end_time = treatment_end_time
         self.expt_type = "Pre-Post Fit"

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -164,8 +164,7 @@ class InterruptedTimeSeries(BaseExperiment):
         super().__init__(model=model)
         self.pre_design: xr.Dataset
         self.post_design: xr.Dataset
-        # to_pandas_with_time_index returns a copy, so index metadata is
-        # normalized on an owned frame rather than the caller's.
+        # to_pandas_with_time_index returns a copy, so index metadata is normalized on an owned frame rather than the caller's.
         pandas_data = to_pandas_with_time_index(data, time_column)
         pandas_data.index.name = "obs_ind"
         self.data = pandas_data

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -198,9 +198,9 @@ class PanelRegression(BaseExperiment):
 
         # to_pandas returns a copy, so this rename lands on ours, not the
         # caller's dataframe.
-        data = to_pandas(data)
-        data.index.name = "obs_ind"
-        self.data = data
+        pandas_data = to_pandas(data)
+        pandas_data.index.name = "obs_ind"
+        self.data = pandas_data
         self.expt_type = "Panel Regression"
         self.formula = formula
         self.unit_fe_variable = unit_fe_variable
@@ -210,7 +210,7 @@ class PanelRegression(BaseExperiment):
         # Store a copy of original data for recovering group means in demeaned
         # transformation.  Other experiment classes don't need this because
         # they don't demean the data before fitting.
-        self._original_data = data.copy()
+        self._original_data = pandas_data.copy()
 
         # Initialize storage for group means (used in demeaned transformation)
         self._group_means: dict[str, pd.DataFrame] = {}
@@ -219,8 +219,10 @@ class PanelRegression(BaseExperiment):
         self.input_validation()
 
         # Store panel dimensions (after validation confirms columns exist)
-        self.n_units = data[unit_fe_variable].nunique()
-        self.n_periods = data[time_fe_variable].nunique() if time_fe_variable else None
+        self.n_units = pandas_data[unit_fe_variable].nunique()
+        self.n_periods = (
+            pandas_data[time_fe_variable].nunique() if time_fe_variable else None
+        )
         self._build_design_matrices()
         self._prepare_data()
         self.algorithm()

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -196,8 +196,7 @@ class PanelRegression(BaseExperiment):
     ) -> None:
         super().__init__(model=model)
 
-        # to_pandas returns a copy, so this rename lands on ours, not the
-        # caller's dataframe.
+        # to_pandas returns a copy, so this rename lands on ours, not the caller's dataframe.
         pandas_data = to_pandas(data)
         pandas_data.index.name = "obs_ind"
         self.data = pandas_data

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -189,11 +189,11 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         self.reference_event_time = reference_event_time
 
         # to_pandas returns a copy, so the caller's dataframe is left alone
-        data = to_pandas(data)
-        data.index.name = "obs_ind"
+        pandas_data = to_pandas(data)
+        pandas_data.index.name = "obs_ind"
 
         # Input validation
-        self.data = data
+        self.data = pandas_data
         self.input_validation()
 
         # Step 1: Compute treatment time G_i for each unit

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -131,8 +131,7 @@ class SyntheticControl(BaseExperiment):
         time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # to_pandas_with_time_index returns a copy, so index metadata is
-        # normalized on an owned frame rather than the caller's.
+        # to_pandas_with_time_index returns a copy, so index metadata is normalized on an owned frame rather than the caller's.
         pandas_data = to_pandas_with_time_index(data, time_column)
         pandas_data.index.name = "obs_ind"
         self.data = pandas_data

--- a/causalpy/experiments/synthetic_control.py
+++ b/causalpy/experiments/synthetic_control.py
@@ -133,10 +133,10 @@ class SyntheticControl(BaseExperiment):
         super().__init__(model=model)
         # to_pandas_with_time_index returns a copy, so index metadata is
         # normalized on an owned frame rather than the caller's.
-        data = to_pandas_with_time_index(data, time_column)
-        data.index.name = "obs_ind"
-        self.data = data
-        self.input_validation(data, treatment_time)
+        pandas_data = to_pandas_with_time_index(data, time_column)
+        pandas_data.index.name = "obs_ind"
+        self.data = pandas_data
+        self.input_validation(pandas_data, treatment_time)
         self.treatment_time = treatment_time
         self.control_units = control_units
         self.labels = control_units

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -136,8 +136,7 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         time_column: str | None = None,
     ) -> None:
         super().__init__(model=model)
-        # to_pandas_with_time_index returns a copy, so index metadata is
-        # normalized on an owned frame rather than the caller's.
+        # to_pandas_with_time_index returns a copy, so index metadata is normalized on an owned frame rather than the caller's.
         pandas_data = to_pandas_with_time_index(data, time_column)
         pandas_data.index.name = "obs_ind"
         self.data = pandas_data

--- a/causalpy/experiments/synthetic_difference_in_differences.py
+++ b/causalpy/experiments/synthetic_difference_in_differences.py
@@ -138,10 +138,10 @@ class SyntheticDifferenceInDifferences(BaseExperiment):
         super().__init__(model=model)
         # to_pandas_with_time_index returns a copy, so index metadata is
         # normalized on an owned frame rather than the caller's.
-        data = to_pandas_with_time_index(data, time_column)
-        data.index.name = "obs_ind"
-        self.data = data
-        self.input_validation(data, treatment_time)
+        pandas_data = to_pandas_with_time_index(data, time_column)
+        pandas_data.index.name = "obs_ind"
+        self.data = pandas_data
+        self.input_validation(pandas_data, treatment_time)
         self.treatment_time = treatment_time
         self.control_units = control_units
         self.labels = control_units

--- a/causalpy/plot_utils.py
+++ b/causalpy/plot_utils.py
@@ -221,14 +221,15 @@ def _interval_bound_values(
             dim=["chain", "draw"],
         )
     else:
-        lower, upper = _equal_tailed_interval(Y, ci_prob)
-        preserved_dims = list(lower.dims)
+        eti_lower, eti_upper = _equal_tailed_interval(Y, ci_prob)
+        preserved_dims = list(eti_lower.dims)
         if len(preserved_dims) != 1:
             msg = (
                 "Vector ETI bounds require exactly one preserved dimension; "
                 f"got {preserved_dims!r}"
             )
             raise ValueError(msg)
+        lower, upper = eti_lower.to_numpy(), eti_upper.to_numpy()
 
     lower_vals = np.asarray(lower, dtype=float).ravel()
     upper_vals = np.asarray(upper, dtype=float).ravel()

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -377,7 +377,7 @@ class PyMCModel(pm.Model):
         coords = {} if coords is None else coords.copy()
         for data in (X, y):
             for dimension in data.dims:
-                coords.setdefault(dimension, data.get_index(dimension))
+                coords.setdefault(str(dimension), data.get_index(dimension))
         self._n_treated_units = y.sizes.get("treated_units", 1)
         return self._fit_with_validated_data(X, y, coords)
 

--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -160,7 +160,7 @@ def _compute_rope_probability(
         Probability that effect exceeds min_effect threshold
     """
     if direction == "two-sided":
-        return _posterior_probability(np.abs(effect) > min_effect, effect)
+        return _posterior_probability(abs(effect) > min_effect, effect)
     elif direction == "increase":
         return _posterior_probability(effect > min_effect, effect)
     elif direction == "decrease":

--- a/causalpy/utils.py
+++ b/causalpy/utils.py
@@ -90,13 +90,14 @@ def _series_has_2_levels(series: pd.Series) -> bool:
     return len(pd.Categorical(series).categories) == 2
 
 
-def round_num(n: float, round_to: int | None) -> str:
+def round_num(n: float | xr.DataArray, round_to: int | None) -> str:
     """Return a string representing a number with significant figures.
 
     Parameters
     ----------
-    n : float
-        Number to round.
+    n : float or xr.DataArray
+        Number to round. A zero-dimensional DataArray, as produced by
+        ``.mean()`` on posterior samples, formats like the scalar it wraps.
     round_to : int, optional
         Number of significant figures. If None, defaults to 2.
 
@@ -110,7 +111,7 @@ def round_num(n: float, round_to: int | None) -> str:
     return f"{n:.{sig_figs}g}"
 
 
-def _format_sig_figs(value: float, default: int | None = None) -> int:
+def _format_sig_figs(value: float | xr.DataArray, default: int | None = None) -> int:
     """Get a default number of significant figures.
 
     Gives the integer part or `default`, whichever is bigger.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,50 +234,24 @@ ignore_missing_imports = true
 # Report an override below that stops matching a real module, so a rename or a deletion does not leave a stale allowlist entry behind unnoticed. This warns rather than fails: mypy prints ``note: unused section(s)`` and still exits 0, so it surfaces the staleness in the log without turning the gate red on its own.
 warn_unused_configs = true
 
-# Allowlist of modules that already fail, so the gate starts green and ratchets down (49 errors in 16 files, measured on pymc6_and_pymcmarketing1_migration at 194343ca). Each entry disables only the error codes that module actually produces, so everything else is still checked there. Removing an entry, or a single code from one, is a self-contained follow-up PR.
+# Allowlist of modules that still fail, so the gate stays green and ratchets down. It started at 49 errors in 16 files and is now 10 in 5. Each entry disables only the error codes that module actually produces, so everything else is still checked there.
+#
+# What is left is one question rather than a backlog of small fixes: several attributes and parameters are declared wider than the values that reach them. ``PyMCModel.fit`` declares ``X`` and ``y`` as ``DataArray`` while two experiments pass numpy arrays; ``self.idata`` and ``self.causal_impact`` are None before fitting and never None at the points that read them; and ``Axes.get_figure`` is Optional for a detached artist that cannot occur here. Settling those means deciding what the model lifecycle promises, so they are left for a maintainer rather than papered over.
 [[tool.mypy.overrides]]
 module = [
+    "causalpy.experiments.diff_in_diff",
     "causalpy.experiments.instrumental_variable",
     "causalpy.experiments.inverse_propensity_weighting",
-    "causalpy.experiments.prepostnegd",
-    "causalpy.experiments.regression_discontinuity",
-    "causalpy.experiments.regression_kink",
-    "causalpy.reporting",
 ]
 disable_error_code = ["arg-type"]
 
 [[tool.mypy.overrides]]
-module = [
-    "causalpy.experiments.interrupted_time_series",
-    "causalpy.experiments.staggered_did",
-    "causalpy.experiments.synthetic_control",
-    "causalpy.experiments.synthetic_difference_in_differences",
-]
-disable_error_code = ["attr-defined"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.experiments.diff_in_diff"
-disable_error_code = ["arg-type", "attr-defined"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.experiments.panel_regression"
-disable_error_code = ["attr-defined", "index"]
+module = "causalpy.pymc_models"
+disable_error_code = ["return-value"]
 
 [[tool.mypy.overrides]]
 module = "causalpy.checks.operating_characteristics"
-disable_error_code = ["arg-type", "assignment"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.plot_utils"
-disable_error_code = ["assignment", "attr-defined"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.pymc_models"
-disable_error_code = ["call-overload", "return-value"]
-
-[[tool.mypy.overrides]]
-module = "causalpy._arviz_compat"
-disable_error_code = ["type-var"]
+disable_error_code = ["assignment"]
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"


### PR DESCRIPTION
Stacked on #1146. Takes the allowlist from nine entries to three, and the branch from 30 errors in 13 files to 10 in 5.

A final commit unwraps the comments this PR adds, per the AGENTS.md one-paragraph-per-line rule. No behaviour change.

Four clusters, not 20 separate bugs. In every case the annotation was narrower than the value that actually reaches it, and the runtime behaviour was already correct.

`round_num` declared `n: float` while four call sites pass a zero-dimensional DataArray from `.mean()` on posterior samples. xarray formats those like the scalar they wrap, so this was purely the annotation. Widened to `float | xr.DataArray`, matching its sibling `convert_to_string`, which already declared that union. Clears 4 errors in four modules.

Six constructors take `data: DataFrameLike` and rebind that same parameter to the pandas frame `to_pandas` returns. mypy keeps the declared parameter type, so `.index`, `.copy()` and `data[column]` were all reported against `NativeDataFrame`. The conversion helpers were already annotated `-> pd.DataFrame`; the information was lost at the rebinding. The converted frame now gets its own name, which is also what the existing comments in those constructors already claimed. Clears 9 errors.

Then five one-liners: `np.abs` on a DataArray replaced by the builtin `abs`, which xarray types correctly and which computes the same thing; xarray dimension names sorted as strings, since `Hashable` is not orderable and they only go into an error message; the ETI branch of `_interval_bound_values` given its own names so it stops colliding with the array-typed HDI branch; a dimension name cast to `str` for a coords key that PyMC requires to be a string anyway; and a list turned into the 4-tuple `tight_layout(rect=...)` documents.

One inline ignore, on iterating the "bodies" entry of a violinplot result. matplotlib types every entry as a single Collection rather than a list of them, so this is a stub limitation rather than our bug, and `warn_unused_ignores` will flag the ignore once matplotlib describes the return properly.

## What is left, and why

The remaining 10 errors are one question, not a backlog. Several attributes and parameters are declared wider than the values that reach them, and narrowing them means deciding what the model lifecycle promises:

- `self.model` is declared as the base model union on `inverse_propensity_weighting` and `instrumental_variable`, while both reach `PropensityScore.fit` and `InstrumentalVariableRegression.fit`, which take numpy arrays and extra keywords (6 errors). Both call sites already carry `type: ignore[call-arg]` for this, without `arg-type`. Narrowing the attribute to the subclass each experiment requires is the real fix, and it is a public type on the experiment classes.
- `self.idata` starts as `None` and is a `DataTree` at every point that returns it (2 errors), and `self.causal_impact` is the same shape (1 error).
- `Axes.get_figure` is Optional for a detached artist, which cannot happen at that call site (1 error).

I did not want to pick an answer to the first one inside a cleanup PR, and asserting non-None at the other three would be adding runtime checks for states that cannot occur just to satisfy the checker. Happy to do whichever you prefer.

Since opening this, #1149 takes a position on all four and gets the allowlist to empty, each decision marked in the code. It is a draft, and it stacks on this branch, so this PR still stands on its own if you would rather stop here.

## Verification

- `mypy` green under `--python-version 3.12` and `3.14`.
- Full suite: `2294 passed, 18 skipped, 3 deselected`, on the rebased branch.
- `prek run --all-files` clean, including the regenerated `environment.yml`.

Stacked on a feature branch, so this gets the repo-wide workflows but not the test matrix until the stack merges down.

