### PR TITLE
fix: empty the mypy allowlist by settling the four lifecycle types

### DIFF
--- a/causalpy/checks/operating_characteristics.py
+++ b/causalpy/checks/operating_characteristics.py
@@ -501,7 +501,10 @@ class OperatingCharacteristics:
             figure, ax = plt.subplots(figsize=(8, 5))
             ax.set_title(title, fontweight="bold", fontsize=11)
         else:
-            figure = ax.get_figure()
+            parent_figure = ax.get_figure()
+            # DECISION (#1127): narrowing assert, the idiom already used in checks/convex_hull.py. get_figure is typed `Figure | SubFigure | None`; None only happens for an artist never added to a figure, and this function returns a Figure, so a SubFigure would be wrong here too.
+            assert isinstance(parent_figure, plt.Figure)
+            figure = parent_figure
             ax.set_title(title, fontweight="bold", fontsize=11)
         ax.fill_between(
             effects, 0, nondetection, color="#94a3b8", alpha=0.30, label="Non-detection"

--- a/causalpy/experiments/diff_in_diff.py
+++ b/causalpy/experiments/diff_in_diff.py
@@ -118,7 +118,8 @@ class DifferenceInDifferences(BaseExperiment):
         model: PyMCModel | RegressorMixin | None = None,
     ) -> None:
         super().__init__(model=model)
-        self.causal_impact: xr.DataArray | float | None
+        # DECISION (#1127): no ``| None``. This is a bare annotation, so nothing ever assigns None; ``input_validation`` guarantees the interaction term that ``algorithm`` reads back, and reading before that already raises AttributeError rather than returning None.
+        self.causal_impact: xr.DataArray | float
         # to_pandas returns a copy, so index metadata is normalized on an owned frame rather than the caller's.
         pandas_data = to_pandas(data)
         pandas_data.index.name = "obs_ind"
@@ -593,7 +594,7 @@ class DifferenceInDifferences(BaseExperiment):
             "causal\nimpact",
             xy=(
                 arrow_x,
-                np.mean([y_pred_counterfactual_scalar, y_pred_treatment_scalar]),
+                float(np.mean([y_pred_counterfactual_scalar, y_pred_treatment_scalar])),
             ),
             xycoords="data",
             xytext=(5, 0),
@@ -614,11 +615,7 @@ class DifferenceInDifferences(BaseExperiment):
                 fontsize=LEGEND_FONT_SIZE,
             )
         else:
-            causal_impact_value = (
-                _as_scalar(self.causal_impact)
-                if self.causal_impact is not None
-                else 0.0
-            )
+            causal_impact_value = _as_scalar(self.causal_impact)
             ax.set(
                 xlim=[-0.05, 1.1],
                 xticks=[0, 1],

--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -206,10 +206,11 @@ class InstrumentalVariable(BaseExperiment):
                     "eta": 2,
                     "lkj_sd": 1,
                 }
+        # DECISION (#1127): the ignores below have one cause. `self.model` is declared as the base model union, while this experiment requires `InstrumentalVariableRegression`, whose `fit` takes numpy arrays plus `Z`, `t` and `priors`. Narrowing the attribute is the real fix and would drop every one of these codes, but that is a public type on the experiment classes, so it is left as a separate decision. mypy reports argument mismatches against the argument's own line, hence the per-argument ignores.
         self.model.fit(  # type: ignore[call-arg,union-attr]
-            X=self.X,
+            X=self.X,  # type: ignore[arg-type]
             Z=self.Z,
-            y=self.y,
+            y=self.y,  # type: ignore[arg-type]
             t=self.t,
             coords=COORDS,
             priors=self.priors,

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -135,7 +135,8 @@ class InversePropensityWeighting(BaseExperiment):
         Delegates to ``self.model.fit`` with the covariate matrix ``self.X``,
         treatment vector ``self.t``, and coordinate metadata ``self.coords``.
         """
-        self.model.fit(X=self.X, t=self.t, coords=self.coords)  # type: ignore[call-arg]
+        # DECISION (#1127): `arg-type` joins the `call-arg` ignore that was already here. Both come from the same cause: `self.model` is declared as the base model union, while this experiment requires `PropensityScore`, whose `fit` takes numpy arrays and the extra `t` argument. Narrowing the attribute is the real fix and would drop both codes, but that is a public type on the experiment classes. `warn_unused_ignores` will flag this line if that lands.
+        self.model.fit(X=self.X, t=self.t, coords=self.coords)  # type: ignore[call-arg,arg-type]
 
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness.

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -252,7 +252,8 @@ class PyMCModel(pm.Model):
             case default priors are used.
         """
         super().__init__()
-        self.idata = None
+        # DECISION (#1127): declared Optional rather than left to inference. It was inferred as exactly ``None`` before, which is why ``fit`` returning it was reported as returning None.
+        self.idata: xr.DataTree | None = None
         self.sample_kwargs = sample_kwargs if sample_kwargs is not None else {}
         self._user_priors = priors
 
@@ -1668,17 +1669,19 @@ class PropensityScore(PyMCModel):
 
         self.build_model(X, t, coords, prior, noncentred)
         with self:
-            self.idata = pm.sample(**self.sample_kwargs)
-            if self.idata is not None:
-                self.idata = _extend_datatree_left(
-                    self.idata, pm.sample_prior_predictive(random_seed=random_seed)
+            # DECISION (#1127): the guarded block works on a local and assigns once at the end. Guarding ``self.idata`` in place left it Optional again after the branch rejoined, which is what made this return look nullable; the sibling fit methods that assign straight through already type-check. One consequence worth stating: if the predictive sampling below raises, ``self.idata`` keeps its previous value rather than holding a posterior with no predictive groups attached.
+            idata = pm.sample(**self.sample_kwargs)
+            if idata is not None:
+                idata = _extend_datatree_left(
+                    idata, pm.sample_prior_predictive(random_seed=random_seed)
                 )
                 pm.sample_posterior_predictive(
-                    self.idata,
+                    idata,
                     progressbar=False,
                     random_seed=random_seed,
                     extend_inferencedata=True,
                 )
+            self.idata = idata
         return self.idata
 
     def fit_outcome_model(

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -1671,7 +1671,8 @@ class PropensityScore(PyMCModel):
         with self:
             # DECISION (#1127): the guarded block works on a local and assigns once at the end. Guarding ``self.idata`` in place left it Optional again after the branch rejoined, which is what made this return look nullable; the sibling fit methods that assign straight through already type-check. One consequence worth stating: if the predictive sampling below raises, ``self.idata`` keeps its previous value rather than holding a posterior with no predictive groups attached.
             idata = pm.sample(**self.sample_kwargs)
-            if idata is not None:
+            # pm.sample's return type excludes None, so the guard's False side never runs.
+            if idata is not None:  # pragma: no branch
                 idata = _extend_datatree_left(
                     idata, pm.sample_prior_predictive(random_seed=random_seed)
                 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -231,27 +231,11 @@ exclude_lines = [
 files = "causalpy"
 exclude = "build|dist|docs|notebooks|tests|setup.py"
 ignore_missing_imports = true
-# Report an override below that stops matching a real module, so a rename or a deletion does not leave a stale allowlist entry behind unnoticed. This warns rather than fails: mypy prints ``note: unused section(s)`` and still exits 0, so it surfaces the staleness in the log without turning the gate red on its own.
+# Report a per-module override that stops matching a real module, so a rename or a deletion does not leave a stale entry behind unnoticed. This warns rather than fails: mypy prints ``note: unused section(s)`` and still exits 0. There are no overrides left, and this keeps it that way if one is ever added and then outlives its module.
 warn_unused_configs = true
-
-# Allowlist of modules that still fail, so the gate stays green and ratchets down. It started at 49 errors in 16 files and is now 10 in 5. Each entry disables only the error codes that module actually produces, so everything else is still checked there.
+# The allowlist is empty: the package type-checks clean. What could not be expressed in the type system is a handful of line-level ``type: ignore`` comments, each with the reasoning next to it.
 #
-# What is left is one question rather than a backlog of small fixes: several attributes and parameters are declared wider than the values that reach them. ``PyMCModel.fit`` declares ``X`` and ``y`` as ``DataArray`` while two experiments pass numpy arrays; ``self.idata`` and ``self.causal_impact`` are None before fitting and never None at the points that read them; and ``Axes.get_figure`` is Optional for a detached artist that cannot occur here. Settling those means deciding what the model lifecycle promises, so they are left for a maintainer rather than papered over.
-[[tool.mypy.overrides]]
-module = [
-    "causalpy.experiments.diff_in_diff",
-    "causalpy.experiments.instrumental_variable",
-    "causalpy.experiments.inverse_propensity_weighting",
-]
-disable_error_code = ["arg-type"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.pymc_models"
-disable_error_code = ["return-value"]
-
-[[tool.mypy.overrides]]
-module = "causalpy.checks.operating_characteristics"
-disable_error_code = ["assignment"]
+# ``warn_unused_ignores`` would make those comments self-cleaning, and is worth turning on, but it currently reports 33 pre-existing unused ignores across 10 modules. Clearing those is its own change, not a rider on this one.
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"


### PR DESCRIPTION
Stacked on #1148. Draft on purpose: every one of these is a judgement call I made rather than one you asked for, and each is marked with a `DECISION (#1127)` comment at the line where it was made, so you can argue with any of them in place without reading the whole diff.

The package now type-checks clean with an empty allowlist.

## The one I got wrong before

I described the six `fit` errors in #1148 as "either the signature is too narrow, or those two experiments are misusing it". Neither is true. `PyMCModel.fit` rejects anything that is not a DataArray at runtime, and these call sites reach `PropensityScore.fit` and `InstrumentalVariableRegression.fit`, which take numpy arrays plus extra keywords. Both lines already carried `type: ignore[call-arg]` for exactly this reason; the ignores just did not list `arg-type`.

So the decision is: add `arg-type` to the ignores that were already there. The real fix is narrowing `self.model` on those two experiments from the base model union to the subclass they actually require, which would drop every one of these codes at once. That is a public type on the experiment classes, so I did not do it here.

## The others

`self.idata` is assigned `None` in `__init__` with no annotation, so mypy inferred it as exactly `None`, which is why returning it read as returning None. Declared `xr.DataTree | None`. One of the two fit methods then still failed because it guarded `self.idata` in place, leaving it Optional again where the branches rejoined; it now works on a local and assigns once, which is what the sibling methods that already type-checked do.

`causal_impact` was declared `| None` because the OLS branch could assign None when no coefficient matched the interaction term. That branch no longer exists on this base: the coefficient canonicalization from #1060 replaced the backend-identity branching with a single `coefficients().sel(...)`, and the `next(...)` there raises rather than yielding None. So the annotation drops `| None`, and the guard that had gone dead with it, `if self.causal_impact is not None else 0.0` in the plotting path, goes too. An earlier version of this PR added a `ValueError` in the OLS branch; rebasing onto the current base removed the code it lived in, so that is no longer part of the change.

One behaviour difference does remain, on an error path rather than the happy path. `PropensityScore.fit` now assigns `self.idata` once at the end instead of in stages, so if the predictive sampling raises, the attribute keeps its previous value rather than holding a posterior with no predictive groups attached. Same result whenever `fit` completes. It is noted in the code as well; say if you would rather keep the staged assignment.

`Axes.get_figure` is typed `Figure | SubFigure | None`. A caller-supplied Axes always belongs to a figure, and this function returns a Figure, so a SubFigure would be wrong here too. Narrowed with `assert isinstance`, the idiom already used in `checks/convex_hull.py`.

`Axes.annotate` wants `tuple[float, float]` and `np.mean` returns `np.floating`. Older numpy and matplotlib stubs report that as an `arg-type` error and newer ones do not, so the same commit under the same pinned mypy passed in one project environment and failed in the other. Wrapping the value in `float()` removes the version sensitivity, so the gate answers from the code rather than from whichever stubs the environment resolved.

## Not in this PR

`warn_unused_ignores` would make the inline ignores self-cleaning, and I wanted it on, since it is the thing that stops an ignore outliving its cause. It currently reports 33 pre-existing unused ignores across 10 modules, so it needs its own change rather than riding along here. There is a note to that effect next to the setting.

Tests remain outside the checked set, which would add 73 errors in 19 files.

## Verification

- `mypy` with an empty allowlist: `Success: no issues found in 54 source files`, against both project environments (numpy 2.3.5 with matplotlib 3.10.8, and numpy 2.4.6 with matplotlib 3.11.1).
- Full suite: `2294 passed, 18 skipped, 3 deselected`.
- `prek run --all-files` clean.

Stacked on a feature branch, so the test matrix only arrives once the stack merges down.

