### PR TITLE
Fix order-dependent interaction-term lookup in DiD effect_summary (port of #1063)

### DIFF
--- a/causalpy/reporting.py
+++ b/causalpy/reporting.py
@@ -1600,18 +1600,25 @@ def _compute_statistics_did_ols(
     # with the degrees of freedom used below for the t-distribution.
     mse = np.sum(residuals**2) / df
 
-    # Find the interaction term coefficient index
-    interaction_term = (
-        f"{result.group_variable_name}:{result.post_treatment_variable_name}"
+    # Find the interaction term coefficient index. patsy names interaction
+    # columns by formula order (e.g. "post_treatment[T.True]:group" for a
+    # formula written as "post_treatment*group"), so match structurally via
+    # the same helper algorithm() uses to locate the causal_impact
+    # coefficient, rather than a concatenated "group:post_treatment" string.
+    coeff_idx = next(
+        (
+            i
+            for i, label in enumerate(result.labels)
+            if result._is_treatment_interaction(label)
+        ),
+        None,
     )
-    coeff_idx = None
-    for i, label in enumerate(result.labels):
-        if interaction_term in label:
-            coeff_idx = i
-            break
 
     if coeff_idx is None:
-        raise ValueError(f"Could not find interaction term {interaction_term} in model")
+        raise ValueError(
+            f"Could not find interaction term between '{result.group_variable_name}' "
+            f"and '{result.post_treatment_variable_name}' in model"
+        )
 
     X = X_da
     try:

--- a/causalpy/tests/test_reporting.py
+++ b/causalpy/tests/test_reporting.py
@@ -414,6 +414,90 @@ def test_effect_summary_ols_did_residuals_are_per_observation(did_data):
 
 
 @pytest.mark.integration
+def test_effect_summary_ols_did_order_independent(did_data):
+    """``effect_summary()`` must not depend on which variable is written
+    first in the DiD interaction term.
+
+    ``_compute_statistics_did_ols`` looked up the interaction coefficient via
+    a single concatenated substring (``"group:post_treatment"``), which only
+    matches patsy's column naming when the formula writes the group variable
+    first. Writing the formula the other way round (``post_treatment*group``)
+    fits an identical model (``causal_impact`` was already order-independent,
+    fixed by #994 in ``DifferenceInDifferences.algorithm()``) but this
+    separate, still order-dependent lookup raised
+    ``ValueError: Could not find interaction term ...`` instead of returning
+    a result.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    df = did_data
+
+    result_group_first = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + group * post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    result_post_first = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + post_treatment * group",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    stats_group_first = result_group_first.effect_summary().table.loc[
+        "treatment_effect"
+    ]
+    stats_post_first = result_post_first.effect_summary().table.loc["treatment_effect"]
+
+    for col in ("mean", "ci_lower", "ci_upper", "p_value"):
+        assert stats_group_first[col] == pytest.approx(stats_post_first[col])
+
+
+@pytest.mark.integration
+def test_effect_summary_ols_did_categorical_group_spelling(did_data):
+    """``effect_summary()`` must accept the ``C(group)`` categorical spelling
+    of the DiD interaction.
+
+    patsy names the interaction column
+    ``"C(group)[T.1]:post_treatment[T.True]"`` for a formula written as
+    ``C(group) * post_treatment``; the concatenated substring lookup
+    (``"group:post_treatment"``) failed on it just as it did for reversed
+    formula order. The design matrix is numerically identical to the plain
+    ``group * post_treatment`` spelling (``group`` is already dummy coded),
+    so the reported statistics must match too.
+    """
+    from sklearn.linear_model import LinearRegression
+
+    df = did_data
+
+    result_plain = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + group * post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+    result_categorical = cp.DifferenceInDifferences(
+        df.copy(),
+        formula="y ~ 1 + C(group) * post_treatment",
+        time_variable_name="t",
+        group_variable_name="group",
+        model=LinearRegression(),
+    )
+
+    stats_plain = result_plain.effect_summary().table.loc["treatment_effect"]
+    stats_categorical = result_categorical.effect_summary().table.loc[
+        "treatment_effect"
+    ]
+
+    for col in ("mean", "ci_lower", "ci_upper", "p_value"):
+        assert stats_plain[col] == pytest.approx(stats_categorical[col])
+
+
+@pytest.mark.integration
 def test_effect_summary_ols_sc(mock_pymc_sample, sc_data):
     """Test effect_summary with OLS model for Synthetic Control."""
     from sklearn.linear_model import LinearRegression


### PR DESCRIPTION
## Summary

Port of #1063 by @Mari1988 to the migration branch.

`effect_summary()` on an OLS `DifferenceInDifferences` result crashed with `ValueError: Could not find interaction term group:post_treatment in model` when the formula was written as `y ~ 1 + post_treatment*group` instead of `y ~ 1 + group*post_treatment`. Both formulas fit the same model. The point estimate was already order-independent (#994 fixed that in `algorithm()`); only this reporting step crashed.

## Cause

`_compute_statistics_did_ols` needs the design-matrix column index of the interaction term to compute the SE, CI, and p-value. It found that column by checking whether the concatenated string `"group:post_treatment"` appears in each patsy column name. patsy names interaction columns in formula order, so the reversed formula produces the label `post_treatment[T.True]:group` and the check never matches. The categorical spelling `C(group)*post_treatment` fails the same way: its label is `C(group)[T.1]:post_treatment[T.True]`, which also does not contain the literal string.

## Fix

Use `_is_treatment_interaction()` for the lookup instead. That helper was introduced by #994 and `algorithm()` already uses it to locate the `causal_impact` coefficient. It parses each label into its factor set, strips `[T.…]` suffixes, accepts the `C(group)` spelling, and requires an exact match on `{group, post_treatment}`.

This deviates from the diff in #1063, which matched the two variable names as independent substrings. That fixes the crash, but a label like `subgroup:post_treatment` would also match, and since the loop takes the first hit the SE could silently come from the wrong column while the mean stays correct. The reviewer on #1063 suggested the helper for exactly this reason, and this PR adopts that suggestion. The improved error message is taken from #1063 unchanged.

Part of the "stop string-matching patsy display labels" family (#993 to #1000).

## Testing

- `test_effect_summary_ols_did_order_independent`, ported verbatim from #1063: both formula orders must produce identical `effect_summary` statistics.
- `test_effect_summary_ols_did_categorical_group_spelling`, new: the `C(group)` spelling must match the plain spelling. The old lookup failed on it too.
- Full `causalpy/tests/test_reporting.py`: 166 passed. Full suite: 2283 passed; the only 3 failures (`test_doctest_sampling.py`) also fail on the untouched branch head in my local environment, so they are pre-existing and unrelated.
- Local patch-coverage gate (`diff-cover` vs this base branch, 96% threshold): 100% on all 22 changed lines.
- Manual check on the `banks` dataset: all three spellings return identical output (effect 20.12, 95% CI [19.12, 21.12]). Two of the three raised `ValueError` before the fix.

## Notes

- The diagnosis, the error message, and the order-independence test are @Mari1988's work (co-authored on the commit). Maintainers may want to close #1063 once the migration branch lands, since this supersedes it there.
- Same bug family, out of scope here: `PrePostNEGD._get_treatment_effect_coeff` in `causalpy/experiments/prepostnegd.py` still substring-matches the group name and could misfire on a column like `subgroup`. Worth a follow-up issue.

## Checklist

- [x] Regression tests added
- [x] `prek run --all-files` passes
- [x] Local patch-coverage gate passes (`DIFF_COVER_COMPARE_BRANCH=origin/pymc6_and_pymcmarketing1_migration`)
- [x] No ARCHITECTURE.md change needed (internal lookup and error message only)
