### PR TITLE
fix: parse micromamba list --json output from micromamba 2.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,9 @@ jobs:
       - name: Setup micromamba environment
         uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
         with:
+          # Pinned: the micromamba binary is resolved at run time, so an
+          # unpinned version changes CI behaviour on an untouched branch.
+          micromamba-version: 2.9.0-0
           environment-file: environment.yml
           environment-name: CausalPy
           # Pin python to the matrix version. All other deps (including
@@ -154,7 +157,7 @@ jobs:
           ).stdout
           with compiler.open("rb") as source:
               compiler_sha256 = hashlib.file_digest(source, "sha256").hexdigest()
-          packages = json.loads(
+          listing = json.loads(
               subprocess.run(
                   ["micromamba", "list", "--json"],
                   check=True,
@@ -162,6 +165,9 @@ jobs:
                   text=True,
               ).stdout
           )
+          # micromamba >= 2.9 wraps the packages in an object; older versions
+          # print the bare list.
+          packages = listing["packages"] if isinstance(listing, dict) else listing
           runtime = {
               "compiler": {
                   "path": str(compiler),


### PR DESCRIPTION
The `test` job on `pymc6_and_pymcmarketing1_migration` has been red since 2026-08-08. All three matrix legs fail at `Fingerprint the resolved PyTensor C-cache runtime` with `AttributeError: 'str' object has no attribute 'get'`, before any test runs. The last green run on the branch is 194343ca (2026-08-04).

Cause: the step parses `micromamba list --json` and iterates the result as a list of package dicts. micromamba 2.9.0 wraps that list in an object (`{"log_history": [...], "packages": [...]}`), so iteration yields the two key strings instead. `setup-micromamba` is SHA-pinned but the micromamba binary it downloads is not, so CI moved to 2.9.0 on its own.

Fix: take `packages` from the object when the parsed JSON is a dict, keep the bare list otherwise, and pin `micromamba-version: 2.9.0-0` so the binary stops floating.

Verified by extracting the step's script and running its parsing block against both binaries in the local `CausalPy` env: 437 packages parsed under 2.9.0 and under 2.5.0, while the pre-fix code returns a `dict` under 2.9.0. Downloaded 2.6.0 and 2.8.0 as well, both print a bare list, so 2.9 is where the shape changed. `prek run --all-files` passes.

CI on this PR confirms the fix: `Fingerprint the resolved PyTensor C-cache runtime` is green on all three legs. The matrix is still red one step further along, at `Run tests`, and those ten failures are pre-existing rather than anything this change introduced. They reproduce locally on the base branch source (10 failed, 2283 passed) and were hidden behind the fingerprint break; #1167 fixes them.
