### PR TITLE
fix: re-express main's #1060 and #1116 in the transition branch's idioms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,25 @@ PACKAGE_DIR = causalpy
 
 .PHONY: init setup lint check_lint check-exports check-architecture test test-correctness test-patch-cov uml gallery html cleandocs doctest run_notebooks_full help
 
-DIFF_COVER_COMPARE_BRANCH ?= $(shell if git show-ref --verify --quiet refs/remotes/upstream/main; then printf "upstream/main"; else printf "origin/main"; fi)
+# Patch coverage must be measured against the branch the PR actually targets.
+# While the 1.0 transition branch exists, work branched from it targets it, not
+# `main` -- and it is hundreds of commits ahead of `main`, so comparing against
+# `main` reports the whole migration as "the patch" and the gate stops meaning
+# anything. Prefer the transition branch when HEAD descends from it (a branch
+# cut from `main` never does), otherwise fall back to `main`. Override
+# DIFF_COVER_COMPARE_BRANCH when a PR deliberately targets something else.
+DIFF_COVER_COMPARE_BRANCH ?= $(shell \
+	for ref in upstream/pymc6_and_pymcmarketing1_migration origin/pymc6_and_pymcmarketing1_migration; do \
+		if git show-ref --verify --quiet "refs/remotes/$$ref" \
+			&& git merge-base --is-ancestor "$$ref" HEAD; then \
+			printf "%s" "$$ref"; exit 0; \
+		fi; \
+	done; \
+	if git show-ref --verify --quiet refs/remotes/upstream/main; then \
+		printf "upstream/main"; \
+	else \
+		printf "origin/main"; \
+	fi)
 DIFF_COVER_FAIL_UNDER ?= 96
 # diff-cover (10.3.0, 10.4.1) matches exclude patterns against the basename
 # and then the absolute path, never the repo-relative path. The pattern goes

--- a/causalpy/experiments/model_adapter.py
+++ b/causalpy/experiments/model_adapter.py
@@ -97,11 +97,12 @@ def _sklearn_y(y: Any) -> np.ndarray:
     return arr
 
 
-def _canonical_pymc_coefficients(posterior: xr.Dataset) -> xr.DataArray:
+def _canonical_pymc_coefficients(posterior: xr.DataTree) -> xr.DataArray:
     """Normalize supported PyMC coefficient variables to the canonical contract."""
+    variables = posterior.dataset
     coefficient_names = ("beta", "b", "beta_z")
     coefficient_name = next(
-        (name for name in coefficient_names if name in posterior), None
+        (name for name in coefficient_names if name in variables), None
     )
     if coefficient_name is None:
         raise ValueError(
@@ -109,7 +110,7 @@ def _canonical_pymc_coefficients(posterior: xr.Dataset) -> xr.DataArray:
             "as design-matrix coefficients."
         )
 
-    coefficients = posterior[coefficient_name]
+    coefficients = variables[coefficient_name]
     label_dims = ("coeffs", "covariates", "instruments", "outcome_coeffs")
     label_dim = next((dim for dim in label_dims if dim in coefficients.dims), None)
     if label_dim is None:

--- a/causalpy/tests/test_coefficient_contract.py
+++ b/causalpy/tests/test_coefficient_contract.py
@@ -181,6 +181,30 @@ def test_pymc_coefficients_reject_noncanonical_dimensions(dims, shape, match):
         PyMCModelAdapter(model).coefficients()
 
 
+def test_pymc_coefficients_ignore_child_groups_named_like_coefficients():
+    """Coefficient lookup must read data variables, never sibling DataTree groups.
+
+    ``idata.posterior`` is an ``xarray.DataTree`` node on this stack, and ``in``
+    on a node also matches its child groups. A group named ``beta`` therefore
+    used to satisfy the lookup and hand back a ``DataTree`` instead of draws.
+    """
+    draws = xr.DataArray(
+        np.arange(6).reshape(1, 2, 3),
+        dims=("chain", "draw", "coeffs"),
+        coords={"chain": [0], "draw": [0, 1], "coeffs": ["a", "b", "c"]},
+    )
+    model = PyMCLinearRegression()
+    model.idata = xr.DataTree.from_dict(
+        {
+            "posterior": xr.Dataset({"gamma": draws}),
+            "posterior/beta": xr.Dataset({"gamma": draws}),
+        }
+    )
+
+    with pytest.raises(ValueError, match="must expose one of 'beta', 'b', or 'beta_z'"):
+        PyMCModelAdapter(model).coefficients()
+
+
 def test_shared_print_coefficients_dispatches_on_draw_count(capsys):
     X = xr.DataArray(
         np.arange(12).reshape(6, 2),


### PR DESCRIPTION
Stacked on #1167 (base `fix/1060-sync-test-fallout`). Merge #1166 → #1167 → this.

## Why

`origin/main` (`ea44a988`) is already a strict ancestor of `pymc6_and_pymcmarketing1_migration` — `0 323`, and `git merge origin/main` reports *Already up to date*. So nothing is missing topologically. What was missing is **idiom re-expression**: sync commit `ce6001c3` landed 5 minutes after #1060 merged and carried main's arviz-0.x/`main`-based assumptions in unchanged.

I audited all twelve of main's commits in the 2026-07-27 → 2026-08-08 window line by line. Ten are correctly re-expressed (#1025/#1027 unbiased SE present at `reporting.py:1598` and `:1738` and correctly superseded by #1129's threshold contrast; #909's 23 bibliography directives intact in 23 files; #1086's pinned ruff `select` present; #1095's `0.9.0` deliberately superseded by `1.0.0`; #1082/#1084/#1125/#1126/#1152 clean). Two were not, and both failed silently.

## Fix 1 — `_canonical_pymc_coefficients` still assumed an arviz-0.x `Dataset`

#1167 repairs the ten test failures the sync left. It explicitly declined one residual, which this fixes.

`model_adapter.py:100` annotated `posterior: xr.Dataset`, but every caller passes a `DataTree` node — production `PyMCModelAdapter.coefficients` (`model_adapter.py:428` → `idata.posterior`, built as `xr.DataTree.from_dict(...)` at `pymc_forecast_models.py:288`) and, after #1167, the tests. Runtime-confirmed: `type(idata.posterior)` is `xarray.core.datatree.DataTree` and `isinstance(..., xr.Dataset)` is `False`.

Not cosmetic. `name in node` on a `DataTree` **also matches child groups**, so a sibling group named `beta`/`b`/`beta_z` satisfied the coefficient lookup and `node[name]` returned a `DataTree` instead of draws — crashing with `AttributeError: 'DataTree' object has no attribute 'transpose'` instead of raising the informative `ValueError`. Reading `posterior.dataset` restricts the lookup to data variables, which is what the contract means, and makes the annotation true. mypy could not see any of this because attribute access on `DataTree` is untyped.

New regression test `test_pymc_coefficients_ignore_child_groups_named_like_coefficients` fails without the fix (`AttributeError`) and passes with it.

## Fix 2 — #1116's coverage base is wrong by construction on this branch

The sync imported `DIFF_COVER_COMPARE_BRANCH ?= upstream/main | origin/main` unchanged. Correct on `main`; wrong here, because every PR targets `pymc6_and_pymcmarketing1_migration`, which is 323 commits ahead of `main` — so diff-cover attributes the entire migration to the patch. Measured on this branch: **17,633 added lines across 81 files** treated as "the patch" versus the **33 lines across 4 files** actually changed. A 534× inflation that silently voids the gate AGENTS.md requires before handoff.

Now prefers the transition branch when HEAD descends from it, keeping the `main` fallback otherwise. A branch cut from `main` never descends from the transition branch, so it still resolves to `main` — verified both ways. Falls back cleanly once the transition ref goes away at the release switch.

## Verification

Python 3.13.15, prefix-local mamba env, pymc 6.3.1 / pytensor 3.3.0 / arviz 1.3.0 / pandas 3.0.5 / numpy 2.4.6.

- Full suite: **`2294 passed, 18 skipped, 3 deselected`**, total coverage 96.61% (branch before #1167: `10 failed, 2283 passed`). The +1 over #1167's reported 2293 is the new regression test.
- `make test-patch-cov`: resolves to `origin/pymc6_and_pymcmarketing1_migration` and reports `model_adapter.py (100%)`, 3 lines, 100% — i.e. the real patch, demonstrating Fix 2.
- `prek run` on every changed file: all hooks pass, including mypy and numpydoc.

Note this env resolves *newer* than #1048's recorded baseline (pymc 6.2.0 / pytensor 3.2.4 / arviz 1.2.0) and is green on it, so a baseline re-run will need a re-pin. CI covers only 3.12 and 3.14.

## Not attempted here

Derick Wells' sweep still has six `migration:needs-port` PRs open against `main` (#733, #821, #846, #871, #872, #932), and #1163/#1165/#1168/#1169 are open against `main` now — retarget or hold, or the next 5-minute sync accrues the same class of debt. Separately, `main` still ships `effect_summary(**kwargs)`, so the signature question recurs the next time the branches meet.