### PR TITLE
fix: repair both Test Notebooks failures on the transition branch

### DIFF
--- a/causalpy/tests/test_notebook_runner.py
+++ b/causalpy/tests/test_notebook_runner.py
@@ -532,6 +532,17 @@ assert {{"chain", "draw"}}.issubset(result["log_likelihood"]["y"].dims)
 assert "prior" not in result
 assert "prior_predictive" not in result
 assert result["posterior"]["x"].sizes["draw"] == 100
+# arviz-stats refuses multi-chain diagnostics on a single-chain posterior
+# (`_mtc_c requires at least 2 chains`), which is what `az.plot_rank_dist` calls.
+assert namespace["MOCK_CHAINS"] >= 2
+assert result["posterior"]["x"].sizes["chain"] == namespace["MOCK_CHAINS"]
+# sample_stats describes the posterior, so its chain count must agree with it.
+assert result["sample_stats"]["diverging"].sizes["chain"] == namespace["MOCK_CHAINS"]
+assert result["sample_stats"]["diverging"].sizes["draw"] == 100
+# Chains must hold distinct draws, otherwise rank diagnostics compare a chain to itself.
+assert not result["posterior"]["x"].isel(chain=0).equals(
+    result["posterior"]["x"].isel(chain=1)
+)
 """
 
     result = subprocess.run(

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,8 @@
 # This VCS dependency is intentionally docs-only: PyPI rejects direct VCS references in published package metadata.
-# d710dc0 is the immutable PyMC-Marketing transition commit used by the documentation notebooks.
-pymc-marketing @ git+https://github.com/pymc-labs/pymc-marketing.git@d710dc035b654b96d6abab2087df4f577beb66f1
-# Match the pinned commit's declared pymc-extras interval, which permits compatible 0.11.x and 0.12.x releases.
-pymc-extras>=0.11,<0.13
+# f8b552c is the immutable PyMC-Marketing commit used by the documentation notebooks. The previously pinned
+# d710dc0 imports `extract_dims` from `pymc.model.fgraph`, which PyMC no longer exports, so it raises
+# ImportError on any supported PyMC. This commit drops that import.
+pymc-marketing @ git+https://github.com/pymc-labs/pymc-marketing.git@f8b552cb4fec02478cc9bffeaf976789d2e9585e
+# Match the pinned commit's declared pymc-extras interval. It also caps pymc to >=6.2,<6.3, which is what
+# the docs environment resolves; the runtime package keeps its wider pymc>=6.0.1,<7 range.
+pymc-extras>=0.14,<0.15

--- a/scripts/run_notebooks/injected.py
+++ b/scripts/run_notebooks/injected.py
@@ -7,6 +7,12 @@ import xarray as xr
 # Minimum draws needed to satisfy notebook code that iterates over posterior samples
 MIN_DRAWS = 100
 FALLBACK_COMPILE_MODE = "FAST_COMPILE"
+# `sample_prior_predictive` always returns a single chain, but multi-chain diagnostics
+# are not optional extras for notebooks: arviz-stats raises outright on a one-chain
+# posterior (`_mtc_c requires at least 2 chains`), which broke
+# `az.plot_rank_dist` in the instrumental-variable notebook. Split the prior draws
+# into this many chains so rank/uniformity plots have something real to compare.
+MOCK_CHAINS = 2
 
 
 def mock_sample(*args, **kwargs):
@@ -25,23 +31,34 @@ def mock_sample(*args, **kwargs):
     if requested_draws is None and len(args) > 1 and isinstance(args[1], int):
         requested_draws = args[1]
 
-    # Ensure enough draws for notebook code while keeping execution fast.
+    # Ensure enough draws for notebook code while keeping execution fast. Each mock
+    # chain must carry the draw count the notebook asked for, so draw the total.
     n_draws = max(MIN_DRAWS, requested_draws or MIN_DRAWS)
+    total_draws = n_draws * MOCK_CHAINS
 
     try:
         idata = pm.sample_prior_predictive(
             model=model,
             random_seed=random_seed,
-            draws=n_draws,
+            draws=total_draws,
         )
     except ZeroDivisionError:
         idata = pm.sample_prior_predictive(
             model=model,
             random_seed=random_seed,
-            draws=n_draws,
+            draws=total_draws,
             compile_kwargs={"mode": FALLBACK_COMPILE_MODE},
         )
-    idata["posterior"] = idata["prior"].to_dataset().copy()
+    prior = idata["prior"].to_dataset().isel(chain=0, drop=True)
+    idata["posterior"] = xr.concat(
+        [
+            prior.isel(draw=slice(i * n_draws, (i + 1) * n_draws)).assign_coords(
+                draw=np.arange(n_draws)
+            )
+            for i in range(MOCK_CHAINS)
+        ],
+        dim="chain",
+    ).assign_coords(chain=np.arange(MOCK_CHAINS))
 
     log_likelihood = idata_kwargs.get("log_likelihood")
     if log_likelihood:
@@ -56,7 +73,7 @@ def mock_sample(*args, **kwargs):
 
     # Create mock sample stats with diverging data
     if "sample_stats" not in idata:
-        n_chains = 1
+        n_chains = MOCK_CHAINS
         sample_stats = xr.Dataset(
             {
                 "diverging": xr.DataArray(


### PR DESCRIPTION
Fixes the two `gallery-other` shard failures on the transition branch. The notebook lane last ran green on 2026-08-08; both failures are dependency drift since then, not any CausalPy change — **neither traceback contains a CausalPy frame**.

## 1. `interrupted-time-series-lift-test.ipynb` — pymc-marketing pin is broken

```
ImportError: cannot import name 'extract_dims' from 'pymc.model.fgraph'
  ... in pymc_marketing/pytensor_utils.py:23
```

PyMC no longer exports `extract_dims` — absent from 6.3.1 *and* from PyMC `main`. The pinned PyMC-Marketing commit `d710dc0` still imports it, so that pin cannot work against any supported PyMC.

Re-pinned to `f8b552c`, where the import is gone (`extract_dims` occurrences: 0). Kept the file's existing convention of an immutable SHA rather than a moving branch. That commit declares `pymc>=6.2,<6.3` and `pymc-extras>=0.14,<0.15`, so the adjacent pymc-extras pin moves with it — the comment there explicitly promises to match the pinned commit's interval.

Resolution verified with `uv pip compile`: **pymc 6.2.0, pytensor 3.2.4, arviz 1.3.0, pymc-extras 0.14.0**, all inside CausalPy's own declared ranges. pymc-extras 0.14.0's `pymc<6.3,>=6.2.0` agrees with pymc-marketing's cap, so the set is coherent rather than merely lucky. Note PyPI now publishes pymc-marketing 1.0.0 — but the released 1.0.0 is the artifact carrying the broken import, so the VCS pin stays.

## 2. `instrumental-variables-variable-selection-priors.ipynb` — one-chain mock posterior

```
ValueError: _mtc_c requires at least 2 chains for a multi-chain test
  ... arviz_stats/base/density.py:953, from the notebook's own az.plot_rank_dist(...)
```

`scripts/run_notebooks/injected.py` mocks `pm.sample` with `sample_prior_predictive`, which **always returns one chain**, so every mocked posterior had `chain=1`. Newer arviz-stats refuses multi-chain diagnostics on one chain where it previously tolerated them.

Raising the existing `n_chains` local to 2 would *not* have fixed this, and I verified why before writing the fix: `n_chains` only shapes the mocked `sample_stats`, so the posterior would stay at one chain — `plot_rank_dist` reads the posterior — and the two groups would then disagree about how many chains exist.

The real fix draws `MOCK_CHAINS * n_draws` prior samples and splits them into real chains, keeping each chain's draw count at what the notebook requested, and derives `sample_stats` from the same constant. Cost is one extra prior-predictive draw batch (100 → 200 at the floor).

The existing mock contract test now pins the chain count, posterior/`sample_stats` agreement, and that chains hold *distinct* draws — otherwise rank diagnostics would compare a chain against itself and pass vacuously.

## Verification

Replayed the exact failing shard (`--collection gallery --exclude-pattern '*-pymc.ipynb' --exclude-pattern '*-sklearn.ipynb'`) in a **CI-faithful pip env** built the way `test_notebook.yml` does — `pip install -r docs/requirements.txt` then `pip install -e '.[test,docs]'`, giving causalpy 1.0.0 / pymc 6.2.0 / pymc-marketing 1.0.0@f8b552c:

**11/11 notebooks pass**, including both failures above.

Also:
- Reverting only the mock change reproduces the original `_mtc_c` failure locally — regression direction confirmed in both directions.
- 29/30 gallery notebooks pass in the conda dev env (the 1 skip is `pymc_marketing` being docs-only and absent there).
- `causalpy/tests/test_notebook_runner.py`: 27 passed.
- Full suite: `2294 passed, 18 skipped, 3 deselected`, total coverage 96.61%.
- `prek run --all-files`: every hook passes, including `Validate notebooks`.