### PR TITLE
fix: clear the stale type: ignore comments and gate warn_unused_ignores

### DIFF
--- a/causalpy/checks/mccrary.py
+++ b/causalpy/checks/mccrary.py
@@ -91,7 +91,7 @@ class McCraryDensityTest:
         rd = experiment
         threshold = rd.treatment_threshold  # type: ignore[attr-defined]
         running_var = rd.running_variable_name  # type: ignore[attr-defined]
-        data = rd.data  # type: ignore[attr-defined]
+        data = rd.data
 
         x = data[running_var].values
         below = x[x < threshold]

--- a/causalpy/checks/placebo_in_time.py
+++ b/causalpy/checks/placebo_in_time.py
@@ -528,7 +528,7 @@ class PlaceboInTime:
             return self.intervention_length
 
         treatment_time = experiment.treatment_time  # type: ignore[attr-defined]
-        data = experiment.data  # type: ignore[attr-defined]
+        data = experiment.data
 
         treatment_end = getattr(experiment, "treatment_end_time", None)
         if treatment_end is not None:
@@ -1042,13 +1042,9 @@ class PlaceboInTime:
             raise ValueError("expected_effect_prior is not set.")
         if hasattr(prior, "rvs"):
             if self.random_seed is None:
-                return np.asarray(prior.rvs(n))  # type: ignore[union-attr]
+                return np.asarray(prior.rvs(n))
             if self._rvs_accepts_random_state(prior):
-                return np.asarray(
-                    prior.rvs(  # type: ignore[union-attr]
-                        n, random_state=self._rng_for_stage(0)
-                    )
-                )
+                return np.asarray(prior.rvs(n, random_state=self._rng_for_stage(0)))
 
             prior_type = f"{type(prior).__module__}.{type(prior).__qualname__}"
             if unseeded_custom_priors is not None:
@@ -1065,7 +1061,7 @@ class PlaceboInTime:
                 "marks its type as unseeded.",
                 stacklevel=2,
             )
-            return np.asarray(prior.rvs(n))  # type: ignore[union-attr]
+            return np.asarray(prior.rvs(n))
         raise TypeError(
             f"expected_effect_prior must have an .rvs(n) method, got "
             f"{type(prior).__name__}."
@@ -1147,7 +1143,7 @@ class PlaceboInTime:
         unseeded_custom_priors: list[dict[str, str]] = []
         factory = self._get_factory(context)
         treatment_time = experiment.treatment_time  # type: ignore[attr-defined]
-        data = experiment.data  # type: ignore[attr-defined]
+        data = experiment.data
         intervention_length = self._compute_intervention_length(experiment)
         required_pre_period_rows = self._get_intervention_window_observation_count(
             data, treatment_time, intervention_length

--- a/causalpy/experiments/interrupted_time_series.py
+++ b/causalpy/experiments/interrupted_time_series.py
@@ -274,13 +274,13 @@ class InterruptedTimeSeries(BaseExperiment):
             # Validate treatment_end_time > treatment_time
             # Type check: we've already validated both match the index type, so they're compatible
             # NOTE: Both treatment_time and treatment_end_time are INCLUSIVE (>=) in their respective periods
-            if treatment_end_time <= treatment_time:  # type: ignore[operator]
+            if treatment_end_time <= treatment_time:
                 raise ValueError(
                     f"treatment_end_time ({treatment_end_time}) must be greater than treatment_time ({treatment_time})"
                 )
             # Validate treatment_end_time is within data range
             # NOTE: treatment_end_time is INCLUSIVE, so it can equal data.index.max()
-            if treatment_end_time > data.index.max():  # type: ignore[operator]
+            if treatment_end_time > data.index.max():
                 raise ValueError(
                     f"treatment_end_time ({treatment_end_time}) is beyond the data range (max: {data.index.max()})"
                 )

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -448,9 +448,9 @@ class InversePropensityWeighting(BaseExperiment):
             weighted_outcome_trt,
             n_ntrt,
             n_trt,
-        ) = self.make_overlap_adjustments(ps)  # type: ignore[assignment]
-        ntrt = np.sum(weighted_outcome_ntrt) / np.sum(n_ntrt)  # type: ignore[arg-type]
-        trt = np.sum(weighted_outcome_trt) / np.sum(n_trt)  # type: ignore[arg-type]
+        ) = self.make_overlap_adjustments(ps)
+        ntrt = np.sum(weighted_outcome_ntrt) / np.sum(n_ntrt)
+        trt = np.sum(weighted_outcome_trt) / np.sum(n_trt)
         ate = trt - ntrt
         return ate, trt, ntrt
 
@@ -478,7 +478,7 @@ class InversePropensityWeighting(BaseExperiment):
             weighted_outcome_trt,
             _n_ntrt,
             _n_trt,
-        ) = self.make_doubly_robust_adjustment(ps)  # type: ignore[assignment]
+        ) = self.make_doubly_robust_adjustment(ps)
         trt = np.mean(weighted_outcome_trt)
         ntrt = np.mean(weighted_outcome_ntrt)
         ate = trt - ntrt

--- a/causalpy/experiments/panel_regression.py
+++ b/causalpy/experiments/panel_regression.py
@@ -854,11 +854,11 @@ class PanelRegression(BaseExperiment):
         if units is not None:
             selected_units = units
         elif self.n_units <= n_sample:
-            selected_units = all_units  # type: ignore[assignment]
+            selected_units = all_units
         else:
             if select == "random":
                 rng = np.random.default_rng(42)
-                selected_units = rng.choice(all_units, size=n_sample, replace=False)  # type: ignore[assignment]
+                selected_units = rng.choice(all_units, size=n_sample, replace=False)
             elif select == "extreme":
                 # Select units with the largest and smallest mean outcomes
                 unit_means = self.data.groupby(self.unit_fe_variable, observed=True)[
@@ -953,7 +953,7 @@ class PanelRegression(BaseExperiment):
                 # OLS: get fitted values for this unit
                 y_fitted = np.squeeze(self.model.predict(self.design["X"]))[
                     sorted_obs_indices
-                ]  # type: ignore[union-attr]
+                ]
                 ax.plot(
                     sorted_time_vals,
                     y_fitted,

--- a/causalpy/experiments/staggered_did.py
+++ b/causalpy/experiments/staggered_did.py
@@ -589,8 +589,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
         ).groups
         att_gt_rows: list[dict] = []
         for key, idx in gt_groups.items():
-            g_val = key[0]  # type: ignore[index]
-            t_val = key[1]  # type: ignore[index]
+            g_val = key[0]
+            t_val = key[1]
             # Find positions in treated_indices
             positions = [np.where(treated_indices == i)[0][0] for i in idx]
             tau_gt = tau_draws_treated[:, :, positions].mean(axis=2)
@@ -1196,8 +1196,8 @@ class StaggeredDifferenceInDifferences(BaseExperiment):
             ["G", self.time_variable_name], observed=True
         ).groups
         for key, idx in gt_groups.items():
-            g_val = key[0]  # type: ignore[index]
-            t_val = key[1]  # type: ignore[index]
+            g_val = key[0]
+            t_val = key[1]
             positions = [np.where(self.data.index == i)[0][0] for i in idx]
             tau_gt = tau_draws_all[:, :, positions].mean(axis=2)
             att_gt_rows.append(

--- a/causalpy/formula_utils.py
+++ b/causalpy/formula_utils.py
@@ -96,7 +96,7 @@ def _normalize_patsy_data(data: pd.DataFrame) -> pd.DataFrame:
         # ``isetitem`` accepts a Series at runtime; pandas-stubs omits it.
         normalized_data.isetitem(
             position,
-            pd.Series(values, index=data.index, dtype=object),  # type: ignore[arg-type]
+            pd.Series(values, index=data.index, dtype=object),
         )
     return normalized_data
 

--- a/causalpy/pymc_models.py
+++ b/causalpy/pymc_models.py
@@ -2120,7 +2120,7 @@ class BayesianBasisExpansionTimeSeries(PyMCModel):
 
         # Add coeffs coordinate if we have exogenous variables
         if self._exog_var_names:
-            model_coords["coeffs"] = self._exog_var_names  # type: ignore[assignment]
+            model_coords["coeffs"] = self._exog_var_names
 
         with self:
             self.add_coords(model_coords)

--- a/causalpy/transforms.py
+++ b/causalpy/transforms.py
@@ -102,12 +102,12 @@ class StepTransform:
         if self._is_datetime_like(x):
             self._is_datetime = True
             x_dt = pd.to_datetime(x)
-            x_min: pd.Timestamp = pd.Timestamp(x_dt.min())  # type: ignore[assignment]
+            x_min: pd.Timestamp = pd.Timestamp(x_dt.min())
             if self._origin is None:
                 self._origin = x_min
             else:
                 # Handle chunked data - keep the overall minimum
-                self._origin = min(self._origin, x_min)  # type: ignore[assignment]
+                self._origin = min(self._origin, x_min)
 
     def memorize_finish(self) -> None:
         """Called after all chunks processed - finalize state."""
@@ -149,7 +149,7 @@ class StepTransform:
             t_numeric = (threshold_dt - self._origin).total_seconds() / (24 * 3600)
         else:
             x_numeric = np.asarray(x, dtype=float)
-            t_numeric = float(threshold)  # type: ignore[arg-type]
+            t_numeric = float(threshold)
 
         return (x_numeric >= t_numeric).astype(float)
 
@@ -161,7 +161,7 @@ class StepTransform:
             return threshold
         else:
             # Assume it's something pandas can convert (str or numeric)
-            return pd.Timestamp(threshold)  # type: ignore[arg-type, return-value]
+            return pd.Timestamp(threshold)
 
 
 class RampTransform:
@@ -222,11 +222,11 @@ class RampTransform:
         if self._is_datetime_like(x):
             self._is_datetime = True
             x_dt = pd.to_datetime(x)
-            x_min: pd.Timestamp = pd.Timestamp(x_dt.min())  # type: ignore[assignment]
+            x_min: pd.Timestamp = pd.Timestamp(x_dt.min())
             if self._origin is None:
                 self._origin = x_min
             else:
-                self._origin = min(self._origin, x_min)  # type: ignore[assignment]
+                self._origin = min(self._origin, x_min)
 
     def memorize_finish(self) -> None:
         """Called after all chunks processed."""
@@ -269,7 +269,7 @@ class RampTransform:
             t_numeric = (threshold_dt - self._origin).total_seconds() / (24 * 3600)
         else:
             x_numeric = np.asarray(x, dtype=float)
-            t_numeric = float(threshold)  # type: ignore[arg-type]
+            t_numeric = float(threshold)
 
         return np.maximum(0.0, x_numeric - t_numeric)
 
@@ -281,7 +281,7 @@ class RampTransform:
             return threshold
         else:
             # Assume it's something pandas can convert (str or numeric)
-            return pd.Timestamp(threshold)  # type: ignore[arg-type, return-value]
+            return pd.Timestamp(threshold)
 
 
 class ElapsedDaysTransform:
@@ -326,9 +326,9 @@ class ElapsedDaysTransform:
 
 
 # Create callable stateful transforms for use in formulas
-step = patsy.stateful_transform(StepTransform)  # type: ignore[attr-defined]
-ramp = patsy.stateful_transform(RampTransform)  # type: ignore[attr-defined]
-elapsed = patsy.stateful_transform(ElapsedDaysTransform)  # type: ignore[attr-defined]
+step = patsy.stateful_transform(StepTransform)
+ramp = patsy.stateful_transform(RampTransform)
+elapsed = patsy.stateful_transform(ElapsedDaysTransform)
 
 __all__ = [
     "step",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -235,7 +235,8 @@ ignore_missing_imports = true
 warn_unused_configs = true
 # The allowlist is empty: the package type-checks clean. What could not be expressed in the type system is a handful of line-level ``type: ignore`` comments, each with the reasoning next to it.
 #
-# ``warn_unused_ignores`` would make those comments self-cleaning, and is worth turning on, but it currently reports 33 pre-existing unused ignores across 10 modules. Clearing those is its own change, not a rider on this one.
+# ``warn_unused_ignores`` keeps those comments self-cleaning: a fix that removes the underlying error now fails the check unless the now-unneeded ignore is deleted with it.
+warn_unused_ignores = true
 
 [tool.marimo.runtime]
 watcher_on_save = "autorun"


### PR DESCRIPTION
Branched on top of #1173, which is itself stacked on #1149. Clears the 33 unused `type: ignore` comments that #1149 left as a follow-up, and turns `warn_unused_ignores` on.

The base field still reads `chore/mypy-zero` because GitHub refuses to retarget a PR that is part of a stack, so the diff currently shows #1173's commit as well. That resolves itself: once #1173 merges into `chore/mypy-zero`, this PR narrows to its own single commit. **Merge #1173 first.**

All 33 carried explicit error codes, none bare, so removing them can't unmask a hidden error class.

CausalPy and CausalPy-pymc6 resolve different numpy and matplotlib stubs, so I checked both before deleting anything: same 33 lines, same 10 files, in both. Nothing needed to stay for one env only.

No source behaviour changes. Every deletion is a clean unused-ignore removal.

## Why it sits on #1173 rather than #1149

One of the 33 was only partly unused: `instrumental_variable.py` carried `type: ignore[call-arg,union-attr]` and mypy flagged only `union-attr`, so this PR originally narrowed it to `[call-arg]`. #1173 narrows `self.model` to the concrete subclass, which removes that ignore and its neighbours entirely, so the two PRs were editing the same line in incompatible ways. Rebasing onto #1173 drops that hunk from this PR: it now touches 10 files instead of 11, and the remaining 32 deletions are independent of it.

The dependency runs the other way too, which is why these cannot be siblings. Turning `warn_unused_ignores` on requires that line to already be clean, and only #1173 makes it clean.

## Verification

- `mypy==2.3.0 --warn-unused-ignores`: `Success: no issues found in 54 source files`, in both envs, after the rebase.
- Full suite: `2294 passed, 18 skipped, 3 deselected`.
- `prek run --all-files` clean.

Stacked on a feature branch, so the test matrix only arrives once the stack merges down.
