### PR TITLE
fix: narrow self.model on InstrumentalVariable and InversePropensityWeighting

### DIFF
--- a/causalpy/experiments/instrumental_variable.py
+++ b/causalpy/experiments/instrumental_variable.py
@@ -123,6 +123,7 @@ class InstrumentalVariable(BaseExperiment):
     supports_ols = False
     supports_bayes = True
     _default_model_class = InstrumentalVariableRegression
+    model: InstrumentalVariableRegression
 
     def __init__(
         self,
@@ -206,11 +207,10 @@ class InstrumentalVariable(BaseExperiment):
                     "eta": 2,
                     "lkj_sd": 1,
                 }
-        # DECISION (#1127): the ignores below have one cause. `self.model` is declared as the base model union, while this experiment requires `InstrumentalVariableRegression`, whose `fit` takes numpy arrays plus `Z`, `t` and `priors`. Narrowing the attribute is the real fix and would drop every one of these codes, but that is a public type on the experiment classes, so it is left as a separate decision. mypy reports argument mismatches against the argument's own line, hence the per-argument ignores.
-        self.model.fit(  # type: ignore[call-arg,union-attr]
-            X=self.X,  # type: ignore[arg-type]
+        self.model.fit(
+            X=self.X,
             Z=self.Z,
-            y=self.y,  # type: ignore[arg-type]
+            y=self.y,
             t=self.t,
             coords=COORDS,
             priors=self.priors,

--- a/causalpy/experiments/inverse_propensity_weighting.py
+++ b/causalpy/experiments/inverse_propensity_weighting.py
@@ -83,6 +83,7 @@ class InversePropensityWeighting(BaseExperiment):
     supports_ols = False
     supports_bayes = True
     _default_model_class = PropensityScore
+    model: PropensityScore
 
     def __init__(
         self,
@@ -135,8 +136,7 @@ class InversePropensityWeighting(BaseExperiment):
         Delegates to ``self.model.fit`` with the covariate matrix ``self.X``,
         treatment vector ``self.t``, and coordinate metadata ``self.coords``.
         """
-        # DECISION (#1127): `arg-type` joins the `call-arg` ignore that was already here. Both come from the same cause: `self.model` is declared as the base model union, while this experiment requires `PropensityScore`, whose `fit` takes numpy arrays and the extra `t` argument. Narrowing the attribute is the real fix and would drop both codes, but that is a public type on the experiment classes. `warn_unused_ignores` will flag this line if that lands.
-        self.model.fit(X=self.X, t=self.t, coords=self.coords)  # type: ignore[call-arg,arg-type]
+        self.model.fit(X=self.X, t=self.t, coords=self.coords)
 
     def input_validation(self) -> None:
         """Validate the input data and model formula for correctness.


### PR DESCRIPTION
Stacked on #1149. Settles the `self.model` narrowing that #1149 left as a separate decision, marked by the two `DECISION (#1127)` comments in `instrumental_variable.py` and `inverse_propensity_weighting.py`.

Both experiments require a specific `PyMCModel` subclass with a non-standard `fit()` signature: `InstrumentalVariableRegression` (extra `Z`, `t`, `priors`, ...) and `PropensityScore` (extra `t`). `self.model` is typed as `BaseExperiment`'s full model union (`PyMCModel | RegressorMixin | PyMCForecastModel`), so mypy checked the `fit()` calls against every member of that union instead of the concrete subclass, which is what produced the `call-arg`/`union-attr`/`arg-type` ignores.

Both subclasses already declare their constructor's `model` parameter and `_default_model_class` as that specific subclass, so nothing about the runtime contract changes. Adding `model: InstrumentalVariableRegression` / `model: PropensityScore` on the subclass states that in the type system too, so mypy resolves `fit()` against the concrete override and every ignore at that call site goes. `BaseExperiment.model` itself is untouched, so no other experiment's public type changes.

## What happens if the wrong model is passed

Nothing new. `make_model_adapter` only checks `isinstance(model, PyMCModel)` and `supports_bayes`, never the exact subclass. A caller who bypasses the type hints and passes the wrong `PyMCModel` still fails at the `fit()` call with the same runtime `TypeError` as before. No new validation added.

## Relationship to #1172

#1172 clears the 33 unused ignores and turns `warn_unused_ignores` on. It originally also narrowed the `instrumental_variable.py` ignore from `[call-arg,union-attr]` to `[call-arg]`, which is the same line this PR deletes outright. #1172 is now rebased on top of this branch and that hunk is gone from it, so the two no longer collide: this PR removes the ignores, #1172 assumes they are already gone. Merge order is this one first, then #1172.

## Verification

- `mypy`, full package, both project environments: `Success: no issues found in 54 source files` in each. The two resolve different stubs (numpy 2.3.5 / matplotlib 3.10.8, and numpy 2.4.6 / matplotlib 3.11.1), which is what makes checking both worthwhile.
- Full suite: `2294 passed, 18 skipped, 3 deselected`, plus the `InstrumentalVariable`/`InversePropensityWeighting` tests re-run clean in the second environment.
- `prek run --all-files` clean.

Being stacked on a feature branch, this gets the repo-wide workflows but not the test matrix. That arrives when the stack merges down.
